### PR TITLE
Clamp cursors to the maximum int32 range to ensure validity

### DIFF
--- a/cmd/soroban-rpc/internal/db/cursor.go
+++ b/cmd/soroban-rpc/internal/db/cursor.go
@@ -7,7 +7,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/stellar/go/support/ordered"
 	"github.com/stellar/go/toid"
+	"golang.org/x/exp/constraints"
 )
 
 const (
@@ -40,9 +42,15 @@ type CursorRange struct {
 
 // String returns a string representation of this cursor
 func (c Cursor) String() string {
+	// TOID maxes out at int32, so we need to clamp accordingly to avoid
+	// generating invalid cursors
+	ledger := int32(clamp(c.Ledger, 0, math.MaxInt32))
+	tx := int32(clamp(c.Tx, 0, math.MaxInt32))
+	op := int32(clamp(c.Op, 0, math.MaxInt32))
+
 	return fmt.Sprintf(
 		"%019d-%010d",
-		toid.New(int32(c.Ledger), int32(c.Tx), int32(c.Op)).ToInt64(),
+		toid.New(ledger, tx, op).ToInt64(),
 		c.Event,
 	)
 }
@@ -95,16 +103,6 @@ func ParseCursor(input string) (Cursor, error) {
 	}, nil
 }
 
-func cmp(a, b uint32) int {
-	if a < b {
-		return -1
-	}
-	if a > b {
-		return 1
-	}
-	return 0
-}
-
 // Cmp compares two cursors.
 // 0 is returned if the c is equal to other.
 // 1 is returned if c is greater than other.
@@ -120,6 +118,20 @@ func (c Cursor) Cmp(other Cursor) int {
 		return cmp(c.Tx, other.Tx)
 	}
 	return cmp(c.Ledger, other.Ledger)
+}
+
+func cmp(a, b uint32) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+func clamp[T constraints.Ordered](val, floor, ceil T) T {
+	return ordered.Min(ceil, ordered.Max(floor, val))
 }
 
 var (

--- a/cmd/soroban-rpc/internal/db/cursor.go
+++ b/cmd/soroban-rpc/internal/db/cursor.go
@@ -131,6 +131,7 @@ func cmp(a, b uint32) int {
 	return 0
 }
 
+// Clamp returns a `val` in the range `[floor, ceil]`.
 func clamp[T constraints.Ordered](val, floor, ceil T) T {
 	return ordered.Min(ceil, ordered.Max(floor, val))
 }

--- a/cmd/soroban-rpc/internal/db/cursor.go
+++ b/cmd/soroban-rpc/internal/db/cursor.go
@@ -7,9 +7,10 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/exp/constraints"
+
 	"github.com/stellar/go/support/ordered"
 	"github.com/stellar/go/toid"
-	"golang.org/x/exp/constraints"
 )
 
 const (


### PR DESCRIPTION
### What
Clamp cursors on `[0, MaxInt32]`.

### Why
We never want to generate invalid cursors since we use them in DB queries. Related: https://github.com/stellar/soroban-rpc/pull/325.

### Known limitations
n/a

I'd like to move `clamp` to our [`support/ordered`](https://github.com/stellar/go/blob/master/support/ordered/math.go) later, too.