### PR TITLE
Use single DB transaction for fetching ledger range and ledgers in `getTransactions`

### DIFF
--- a/cmd/stellar-rpc/internal/methods/get_transactions_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_transactions_test.go
@@ -71,7 +71,7 @@ func setupDB(t *testing.T, numLedgers int, skipLedger int) *db.DB {
 	return testDB
 }
 
-func TestGetTransactions_DefaultLimit(t *testing.T) {
+func TestGetTransactions_DefaultLimit(t *testing.T) { //nolint:dupl
 	testDB := setupDB(t, 10, 0)
 	handler := transactionsRPCHandler{
 		ledgerReader:      db.NewLedgerReader(testDB),
@@ -101,7 +101,7 @@ func TestGetTransactions_DefaultLimit(t *testing.T) {
 	assert.Equal(t, expectedTransactionInfo, response.Transactions[0])
 }
 
-func TestGetTransactions_DefaultLimitExceedsLatestLedger(t *testing.T) {
+func TestGetTransactions_DefaultLimitExceedsLatestLedger(t *testing.T) { //nolint:dupl
 	testDB := setupDB(t, 3, 0)
 	handler := transactionsRPCHandler{
 		ledgerReader:      db.NewLedgerReader(testDB),

--- a/cmd/stellar-rpc/internal/methods/get_transactions_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_transactions_test.go
@@ -116,18 +116,10 @@ func TestGetTransactions_DefaultLimitExceedsLatestLedger(t *testing.T) {
 
 	response, err := handler.getTransactionsByLedgerSequence(context.TODO(), request)
 	require.NoError(t, err)
-
-	// assert latest ledger details
 	assert.Equal(t, uint32(3), response.LatestLedger)
 	assert.Equal(t, int64(175), response.LatestLedgerCloseTime)
-
-	// assert pagination
 	assert.Equal(t, toid.New(3, 2, 1).String(), response.Cursor)
-
-	// assert transactions result
 	assert.Len(t, response.Transactions, 6)
-
-	// assert the transaction structure. We will match only 1 tx for sanity purposes.
 	assert.Equal(t, expectedTransactionInfo, response.Transactions[0])
 }
 
@@ -149,20 +141,12 @@ func TestGetTransactions_CustomLimit(t *testing.T) {
 
 	response, err := handler.getTransactionsByLedgerSequence(context.TODO(), request)
 	require.NoError(t, err)
-
-	// assert latest ledger details
 	assert.Equal(t, uint32(10), response.LatestLedger)
 	assert.Equal(t, int64(350), response.LatestLedgerCloseTime)
-
-	// assert pagination
 	assert.Equal(t, toid.New(1, 2, 1).String(), response.Cursor)
-
-	// assert transactions result
 	assert.Len(t, response.Transactions, 2)
 	assert.Equal(t, uint32(1), response.Transactions[0].Ledger)
 	assert.Equal(t, uint32(1), response.Transactions[1].Ledger)
-
-	// assert the transaction structure. We will match only 1 tx for sanity purposes.
 	assert.Equal(t, expectedTransactionInfo, response.Transactions[0])
 }
 
@@ -184,15 +168,9 @@ func TestGetTransactions_CustomLimitAndCursor(t *testing.T) {
 
 	response, err := handler.getTransactionsByLedgerSequence(context.TODO(), request)
 	require.NoError(t, err)
-
-	// assert latest ledger details
 	assert.Equal(t, uint32(10), response.LatestLedger)
 	assert.Equal(t, int64(350), response.LatestLedgerCloseTime)
-
-	// assert pagination
 	assert.Equal(t, toid.New(3, 1, 1).String(), response.Cursor)
-
-	// assert transactions result
 	assert.Len(t, response.Transactions, 3)
 	assert.Equal(t, uint32(2), response.Transactions[0].Ledger)
 	assert.Equal(t, uint32(2), response.Transactions[1].Ledger)

--- a/cmd/stellar-rpc/internal/methods/get_transactions_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_transactions_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 
 	"github.com/creachadair/jrpc2"
-	"github.com/stellar/go/support/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/toid"
 	"github.com/stellar/go/xdr"
 


### PR DESCRIPTION
### What

Closes #334 

### Why

We want to get the same view of the db and avoid any race conditions when accessing without a db txn.

### Known limitations

NA
