### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/protocol/get_events.go
+++ b/protocol/get_events.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/stellar/go/strkey"
@@ -212,12 +213,7 @@ func (e *EventFilter) matchesContractIDs(event xdr.ContractEvent) bool {
 		return false
 	}
 	needle := strkey.MustEncode(strkey.VersionByteContract, (*event.ContractId)[:])
-	for _, id := range e.ContractIDs {
-		if id == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(e.ContractIDs, needle)
 }
 
 func (e *EventFilter) matchesTopics(event xdr.ContractEvent) bool {


### PR DESCRIPTION
### What



using slices.Contains to simplify the code

### Why

This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

### Known limitations

N
