### PR TITLE
Remove duplicate build-stellar-rpc target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,13 +81,6 @@ clean:
 	cargo clean
 	go clean ./...
 
-# DEPRECATED - please use build-stellar-rpc instead
-# the build-stellar-rpc build target is an optimized build target used by
-# https://github.com/stellar/pipelines/blob/master/stellar-rpc/Jenkinsfile-stellar-rpc-package-builder
-# as part of the package building.
-build-stellar-rpc: build-libs
-	go build -ldflags="${GOLDFLAGS}" ${MACOS_MIN_VER} -o ${STELLAR_RPC_BINARY} -trimpath -v ./cmd/stellar-rpc
-
 # the build-stellar-rpc build target is an optimized build target used by
 # https://github.com/stellar/pipelines/blob/master/stellar-rpc/Jenkinsfile-stellar-rpc-package-builder
 # as part of the package building.

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ endif
 CARGO_BUILD_TARGET ?= $(shell rustc -vV | sed -n 's|host: ||p')
 
 STELLAR_RPC_BINARY := stellar-rpc
-STELLAR_RPC_BINARY := stellar-rpc
 
 
 # update the Cargo.lock every time the Cargo.toml changes.


### PR DESCRIPTION
### What

Remove duplicate Makefile `build-stellar-rpc` target

### Why

Shouldn't have two of the same target. This was probably accidental from `soroban-rpc` --> `stellar-rpc` rename

### Known limitations

N/A
