### PR TITLE
Filter non-temporary entries from eviction

### DIFF
--- a/cmd/stellar-rpc/internal/ingest/service.go
+++ b/cmd/stellar-rpc/internal/ingest/service.go
@@ -295,12 +295,30 @@ func (s *Service) ingest(ctx context.Context, sequence uint32) error {
 		return err
 	}
 
-	// EvictedTemporaryLedgerKeys will include both temporary ledger keys which
-	// have been evicted and their corresponding ttl ledger entries
-	evictedTempLedgerKeys, err := ledgerCloseMeta.EvictedTemporaryLedgerKeys()
+	// EvictedTemporaryLedgerKeys will, in this completely borked up version of
+	// XDR, actually include ALL evicted ledger keys (including persistent and
+	// code entries).
+	//
+	// In order to maintain the facade for simulation that eviction isn't
+	// happening yet (simulation isn't ready for state archival yet), we will
+	// continue to only evict temporary entries from our state.
+	//
+	// Tomorrow, when ledger state isn't managed by RPC at all, this code can be
+	// removed entirely and we can rely on Core to maintain ledger entries for
+	// simulation.
+	evictedLedgerKeys, err := ledgerCloseMeta.EvictedTemporaryLedgerKeys()
 	if err != nil {
 		return err
 	}
+
+	evictedTempLedgerKeys := make([]xdr.LedgerKey, 0, len(evictedLedgerKeys))
+	for _, key := range evictedLedgerKeys {
+		if key.Type == xdr.LedgerEntryTypeContractData &&
+			key.MustContractData().Durability == xdr.ContractDataDurabilityTemporary {
+			evictedTempLedgerKeys = append(evictedTempLedgerKeys, key)
+		}
+	}
+
 	if err := s.ingestTempLedgerEntryEvictions(ctx, evictedTempLedgerKeys, tx); err != nil {
 		return err
 	}


### PR DESCRIPTION
### What
Filter non-temporary entries from ledger entry eviction routine.

### Why
The name was not updated, but the semantic meaning of the field has changed. See 

https://github.com/stellar/stellar-xdr/blob/5d7aebdd9f550707b482037e75c692e3e70aac27/Stellar-ledger.x#L561-L564

This means we need to filter out all persistent entries that are being evicted, only evicting temporary ones from our ledger entry store. This effectively means that RPC's ledger entry store will contain all valid entries (as if state archival didn't exist), which is exactly what we need during the transition period before Core's `/getledgerentry` fuels simulation.

### Known limitations
This will need to change later, but allows behavior to be correct for now.