### PR TITLE
Add benchmark for getLedgerentries method

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -33,8 +33,8 @@ jobs:
           make build-libs
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@58eda26a511c265ee35b3ee4b101fb8adfd76480 # version v6.1.1
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.63.4 # this is the golangci-lint version
+          version: v2.0.2 # this is the golangci-lint version
           github-token: ${{ secrets.GITHUB_TOKEN }}
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,125 +1,100 @@
-linters-settings:
-  dupl:
-    threshold: 100
-
-  funlen:
-    lines: 100
-    statements: 50
-
-  misspell:
-    locale: US
-
-  gci:
-    # Section configuration to compare against.
-    # Section names are case-insensitive and may contain parameters in ().
-    # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`,
-    # If `custom-order` is `true`, it follows the order of `sections` option.
-    # Default: ["standard", "default"]
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/stellar/) # Custom section: groups all imports with the specified Prefix.
-      - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
-    skip-generated: false
-    # Enable custom order of sections.
-    # If `true`, make the section order the same as the order of `sections`.
-    # Default: false
-    custom-order: true
-
-  dogsled:
-    # Checks assignments with too many blank identifiers.
-    # Default: 2
-    max-blank-identifiers: 3
-
-  cyclop:
-    # The maximal code complexity to report.
-    # Default: 10
-    max-complexity: 15
-
-  wrapcheck:
-    # An array of strings that specify substrings of signatures to ignore.
-    # If this set, it will override the default set of ignored signatures.
-    # See https://github.com/tomarrell/wrapcheck#configuration for more information.
-    # Default: [".Errorf(", "errors.New(", "errors.Unwrap(", "errors.Join(", ".Wrap(", ".Wrapf(", ".WithMessage(", ".WithMessagef(", ".WithStack("]
-    ignoreSigs:
-      - .Errorf(
-      - errors.New(
-      - errors.Unwrap(
-      - errors.Join(
-      - .Wrap(
-      - .Wrapf(
-      - .WithMessage(
-      - .WithMessagef(
-      - .WithStack(
-    # An array of strings that specify regular expressions of signatures to ignore.
-    # Default: []
-    ignoreSigRegexps:
-      - \.New.*Error\(
-    # An array of strings that specify globs of packages to ignore.
-    # Default: []
-    ignorePackageGlobs:
-      - encoding/*
-      - github.com/pkg/*
-      - github.com/stellar/*
-    # An array of strings that specify regular expressions of interfaces to ignore.
-    # Default: []
-    ignoreInterfaceRegexps:
-      - ^(?i)c(?-i)ach(ing|e)
-
-  testifylint:
-    enable-all: true
-    disable:
-      # TODO: try to enable it
-      - go-require
-
-  forbidigo:
-    # Forbid the following identifiers (list of regexp).
-    # Default: ["^(fmt\\.Print(|f|ln)|print|println)$"]
-    forbid:
-      - p: "^(fmt\\.Print(|f|ln)|print|println)$"
-        msg: Do not commit debug print statements (in tests use t.Log()).
-      - p: "^.*$"
-        pkg: "^github.com/stellar/go/support/errors$"
-        msg: Do not use stellar/go/support/errors, use the standard 'errors' package and fmt.Errorf().
-    exclude-godoc-examples: false
-    analyze-types: true
-
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
-    # deprecated:
-    - gomnd
-    - execinquery
-
     - depguard
-    - nlreturn
-    - godox
-    # exhaustruct: enforcing exhaustive fields is useful in some cases, but there are
-    #              too many legitimate default field values in Go
-    - exhaustruct
-    # err113: Enforcing errors.Is() is useful but cannot be enabled in isolation
     - err113
-    - thelper
-    - wsl
-    - wrapcheck
-    - testpackage
-    # TODO: varnamelen: I didn't manage to make it accept short parameter names
-    - varnamelen
-    # TODO: ireturn: consider enabling it later on
-    - ireturn
+    - exhaustruct
     - godot
+    - godox
+    - ireturn
+    - mnd
+    - nlreturn
     - paralleltest
-  presets: [ ]
-  fast: false
-
-issues:
-  # Exclude certain checks in test files
-  exclude-rules:
-    - path: '^(.*_test\.go|cmd/stellar-rpc/internal/integrationtest/infrastructure/.*)$'
-      linters:
-        - mnd
-        - gosec
-        - gochecknoglobals
-        - nosprintfhostport
-run:
-  timeout: 10m
+    - testpackage
+    - thelper
+    - varnamelen
+    - wrapcheck
+    - wsl
+  settings:
+    cyclop:
+      max-complexity: 15
+    dogsled:
+      max-blank-identifiers: 3
+    dupl:
+      threshold: 100
+    forbidigo:
+      forbid:
+        - pattern: ^(fmt\.Print(|f|ln)|print|println)$
+          msg: Do not commit debug print statements (in tests use t.Log()).
+        - pattern: ^.*$
+          pkg: ^github.com/stellar/go/support/errors$
+          msg: Do not use stellar/go/support/errors, use the standard 'errors' package and fmt.Errorf().
+      exclude-godoc-examples: false
+      analyze-types: true
+    funlen:
+      lines: 100
+      statements: 50
+    misspell:
+      locale: US
+    testifylint:
+      enable-all: true
+      disable:
+        - go-require
+    wrapcheck:
+      ignore-sigs:
+        - .Errorf(
+        - errors.New(
+        - errors.Unwrap(
+        - errors.Join(
+        - .Wrap(
+        - .Wrapf(
+        - .WithMessage(
+        - .WithMessagef(
+        - .WithStack(
+      ignore-sig-regexps:
+        - \.New.*Error\(
+      ignore-package-globs:
+        - encoding/*
+        - github.com/pkg/*
+        - github.com/stellar/*
+      ignore-interface-regexps:
+        - ^(?i)c(?-i)ach(ing|e)
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gochecknoglobals
+          - gosec
+          - mnd
+          - nosprintfhostport
+        path: ^(.*_test\.go|cmd/stellar-rpc/internal/integrationtest/infrastructure/.*)$
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/stellar/)
+        - localmodule
+      custom-order: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/stellar-rpc/internal/integrationtest/archive_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/archive_test.go
@@ -1,9 +1,9 @@
 package integrationtest
 
 import (
-	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -33,12 +33,14 @@ func TestArchiveUserAgent(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer historyArchive.Close()
-	historyPort := historyArchive.Listener.Addr().(*net.TCPAddr).Port
+	url, err := url.Parse(historyArchive.URL)
+	require.NoError(t, err)
+	historyHostPort := url.Host
 
 	cfg := &infrastructure.TestConfig{
 		OnlyRPC: &infrastructure.TestOnlyRPCConfig{
 			CorePorts: infrastructure.TestCorePorts{
-				CoreArchivePort: uint16(historyPort),
+				CoreArchiveHostPort: historyHostPort,
 			},
 			DontWait: true,
 		},

--- a/cmd/stellar-rpc/internal/integrationtest/get_ledger_entries_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/get_ledger_entries_test.go
@@ -192,7 +192,6 @@ func benchmarkGetLedgerEntries(b *testing.B, useCore bool) {
 			},
 			DontWait: false,
 		}
-
 	}
 	test := infrastructure.NewTest(b, &infrastructure.TestConfig{
 		EnableCoreHTTPQueryServer: useCore,

--- a/cmd/stellar-rpc/internal/integrationtest/get_ledger_entries_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/get_ledger_entries_test.go
@@ -2,6 +2,8 @@ package integrationtest
 
 import (
 	"context"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/creachadair/jrpc2"
@@ -164,8 +166,21 @@ func testGetLedgerEntriesSucceeds(t testing.TB, useCore bool) {
 }
 
 func benchmarkGetLedgerEntries(b *testing.B, useCore bool) {
+	sqlitePath := ""
+	captivecoreStoragePath := ""
+	dir := os.Getenv("STELLAR_RPC_BENCH_BASE_STORAGE_DIR")
+	if dir != "" {
+		tmp, err := os.MkdirTemp(dir, "rpcbench") //nolint:usetesting
+		require.NoError(b, err)
+		b.Cleanup(func() { _ = os.RemoveAll(tmp) })
+		sqlitePath = path.Join(tmp, "stellar_rpc.sqlite")
+		captivecoreStoragePath = tmp
+	}
+
 	test := infrastructure.NewTest(b, &infrastructure.TestConfig{
 		EnableCoreHTTPQueryServer: useCore,
+		SQLitePath:                sqlitePath,
+		CaptiveCoreStoragePath:    captivecoreStoragePath,
 	})
 	_, contractID, contractHash := test.CreateHelloWorldContract()
 

--- a/cmd/stellar-rpc/internal/integrationtest/get_ledger_entries_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/get_ledger_entries_test.go
@@ -237,9 +237,7 @@ func benchmarkGetLedgerEntries(b *testing.B, useCore bool) {
 
 	client := test.GetRPCLient()
 
-	b.ResetTimer()
-
-	for range b.N {
+	for b.Loop() {
 		result, err := client.GetLedgerEntries(context.Background(), request)
 		b.StopTimer()
 		require.NoError(b, err)

--- a/cmd/stellar-rpc/internal/integrationtest/get_ledger_entries_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/get_ledger_entries_test.go
@@ -238,10 +238,12 @@ func benchmarkGetLedgerEntries(b *testing.B, useCore bool) {
 	client := test.GetRPCLient()
 
 	for b.Loop() {
-		result, err := client.GetLedgerEntries(context.Background(), request)
+		result, err := client.GetLedgerEntries(b.Context(), request)
 		b.StopTimer()
 		require.NoError(b, err)
 		require.Len(b, result.Entries, 2)
+		// False positive lint error: see https://github.com/Antonboom/testifylint/pull/236
+		//nolint:testifylint
 		require.Positive(b, result.LatestLedger)
 		b.StartTimer()
 	}

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/client.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/client.go
@@ -17,9 +17,9 @@ import (
 	"github.com/stellar/stellar-rpc/protocol"
 )
 
-func getTransaction(t *testing.T, client *client.Client, hash string) protocol.GetTransactionResponse {
+func getTransaction(t testing.TB, client *client.Client, hash string) protocol.GetTransactionResponse {
 	var result protocol.GetTransactionResponse
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		var err error
 		request := protocol.GetTransactionRequest{Hash: hash}
 		result, err = client.GetTransaction(context.Background(), request)
@@ -36,7 +36,7 @@ func getTransaction(t *testing.T, client *client.Client, hash string) protocol.G
 	return result
 }
 
-func logTransactionResult(t *testing.T, response protocol.GetTransactionResponse) {
+func logTransactionResult(t testing.TB, response protocol.GetTransactionResponse) {
 	var txResult xdr.TransactionResult
 	require.NoError(t, xdr.SafeUnmarshalBase64(response.ResultXDR, &txResult))
 	t.Logf("error: %#v\n", txResult)
@@ -61,7 +61,7 @@ func logTransactionResult(t *testing.T, response protocol.GetTransactionResponse
 	}
 }
 
-func SendSuccessfulTransaction(t *testing.T, client *client.Client, kp *keypair.Full,
+func SendSuccessfulTransaction(t testing.TB, client *client.Client, kp *keypair.Full,
 	transaction *txnbuild.Transaction,
 ) protocol.GetTransactionResponse {
 	tx, err := transaction.Sign(StandaloneNetworkPassphrase, kp)
@@ -99,7 +99,7 @@ func SendSuccessfulTransaction(t *testing.T, client *client.Client, kp *keypair.
 	return response
 }
 
-func SimulateTransactionFromTxParams(t *testing.T, client *client.Client,
+func SimulateTransactionFromTxParams(t testing.TB, client *client.Client,
 	params txnbuild.TransactionParams,
 ) protocol.SimulateTransactionResponse {
 	savedAutoIncrement := params.IncrementSequenceNum
@@ -115,7 +115,7 @@ func SimulateTransactionFromTxParams(t *testing.T, client *client.Client,
 	return response
 }
 
-func PreflightTransactionParamsLocally(t *testing.T, params txnbuild.TransactionParams,
+func PreflightTransactionParamsLocally(t testing.TB, params txnbuild.TransactionParams,
 	response protocol.SimulateTransactionResponse,
 ) txnbuild.TransactionParams {
 	if !assert.Empty(t, response.Error) {
@@ -144,13 +144,13 @@ func PreflightTransactionParamsLocally(t *testing.T, params txnbuild.Transaction
 		}
 		v.Auth = auth
 	case *txnbuild.ExtendFootprintTtl:
-		require.Len(t, response.Results, 0)
+		require.Empty(t, response.Results)
 		v.Ext = xdr.TransactionExt{
 			V:           1,
 			SorobanData: &transactionData,
 		}
 	case *txnbuild.RestoreFootprint:
-		require.Len(t, response.Results, 0)
+		require.Empty(t, response.Results)
 		v.Ext = xdr.TransactionExt{
 			V:           1,
 			SorobanData: &transactionData,
@@ -165,7 +165,7 @@ func PreflightTransactionParamsLocally(t *testing.T, params txnbuild.Transaction
 	return params
 }
 
-func PreflightTransactionParams(t *testing.T, client *client.Client, params txnbuild.TransactionParams,
+func PreflightTransactionParams(t testing.TB, client *client.Client, params txnbuild.TransactionParams,
 ) txnbuild.TransactionParams {
 	response := SimulateTransactionFromTxParams(t, client, params)
 	// The preamble should be zero except for the special restore case

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/contract.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/contract.go
@@ -55,7 +55,7 @@ func CreateInvokeHostOperation(sourceAccount string, contractID xdr.Hash, method
 	}
 }
 
-func getContractID(t *testing.T, sourceAccount string, salt [32]byte, networkPassphrase string) [32]byte {
+func getContractID(t testing.TB, sourceAccount string, salt [32]byte, networkPassphrase string) [32]byte {
 	sourceAccountID := xdr.MustAddress(sourceAccount)
 	preImage := xdr.HashIdPreimage{
 		Type: xdr.EnvelopeTypeEnvelopeTypeContractId,

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
@@ -93,7 +93,7 @@ type TestPorts struct {
 }
 
 type Test struct {
-	t *testing.T
+	t testing.TB
 
 	testPorts TestPorts
 
@@ -119,7 +119,7 @@ type Test struct {
 	enableCoreHTTPQueryServer bool
 }
 
-func NewTest(t *testing.T, cfg *TestConfig) *Test {
+func NewTest(t testing.TB, cfg *TestConfig) *Test {
 	if os.Getenv("STELLAR_RPC_INTEGRATION_TESTS_ENABLED") == "" {
 		t.Skip("skipping integration test: STELLAR_RPC_INTEGRATION_TESTS_ENABLED not set")
 	}
@@ -153,8 +153,8 @@ func NewTest(t *testing.T, cfg *TestConfig) *Test {
 		i.sqlitePath = path.Join(i.t.TempDir(), "stellar_rpc.sqlite")
 	}
 
-	if parallel {
-		t.Parallel()
+	if tt, ok := t.(*testing.T); ok && parallel {
+		tt.Parallel()
 	}
 
 	if i.protocolVersion == 0 {
@@ -424,13 +424,13 @@ func (i *Test) generateRPCConfigFile(rpcConfig rpcConfig) {
 	require.NoError(i.t, err)
 }
 
-func newTestLogWriter(t *testing.T, prefix string) *testLogWriter {
+func newTestLogWriter(t testing.TB, prefix string) *testLogWriter {
 	tw := &testLogWriter{t: t, prefix: prefix}
 	return tw
 }
 
 type testLogWriter struct {
-	t      *testing.T
+	t      testing.TB
 	prefix string
 }
 

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
@@ -70,7 +70,9 @@ type TestConfig struct {
 	UseReleasedRPCVersion string
 	// Use/Reuse a SQLite file path
 	SQLitePath string
-	OnlyRPC    *TestOnlyRPCConfig
+	// Use/Reuse a Captive core file path
+	CaptiveCoreStoragePath string
+	OnlyRPC                *TestOnlyRPCConfig
 	// Do not mark the test as running in parallel
 	NoParallel                bool
 	EnableCoreHTTPQueryServer bool
@@ -101,7 +103,8 @@ type Test struct {
 
 	rpcConfigFilesDir string
 
-	sqlitePath string
+	sqlitePath             string
+	captiveCoreStoragePath string
 
 	rpcContainerVersion        string
 	rpcContainerSQLiteMountDir string
@@ -136,6 +139,7 @@ func NewTest(t testing.TB, cfg *TestConfig) *Test {
 		i.rpcContainerVersion = cfg.UseReleasedRPCVersion
 		i.protocolVersion = cfg.ProtocolVersion
 		i.sqlitePath = cfg.SQLitePath
+		i.captiveCoreStoragePath = cfg.CaptiveCoreStoragePath
 		if cfg.OnlyRPC != nil {
 			i.onlyRPC = true
 			i.testPorts.TestCorePorts = cfg.OnlyRPC.CorePorts
@@ -151,6 +155,9 @@ func NewTest(t testing.TB, cfg *TestConfig) *Test {
 
 	if i.sqlitePath == "" {
 		i.sqlitePath = path.Join(i.t.TempDir(), "stellar_rpc.sqlite")
+	}
+	if i.captiveCoreStoragePath == "" {
+		i.captiveCoreStoragePath = path.Join(i.t.TempDir(), "stellar_rpc.sqlite")
 	}
 
 	if tt, ok := t.(*testing.T); ok && parallel {
@@ -304,7 +311,7 @@ func (i *Test) getRPConfigForDaemon() rpcConfig {
 		stellarCoreURL:           fmt.Sprintf("http://localhost:%d", i.testPorts.CoreHTTPPort),
 		coreBinaryPath:           coreBinaryPath,
 		captiveCoreConfigPath:    path.Join(i.rpcConfigFilesDir, captiveCoreConfigFilename),
-		captiveCoreStoragePath:   i.t.TempDir(),
+		captiveCoreStoragePath:   i.captiveCoreStoragePath,
 		archiveURL:               fmt.Sprintf("http://localhost:%d", i.testPorts.CoreArchivePort),
 		sqlitePath:               i.sqlitePath,
 		captiveCoreHTTPQueryPort: i.testPorts.captiveCoreHTTPQueryPort,

--- a/cmd/stellar-rpc/internal/methods/util.go
+++ b/cmd/stellar-rpc/internal/methods/util.go
@@ -26,7 +26,7 @@ func getProtocolVersion(
 		return 0, fmt.Errorf("missing meta for latest ledger (%d)", latestLedger)
 	}
 	if closeMeta.V != 1 {
-		return 0, fmt.Errorf("latest ledger (%d) meta has unexpected verion (%d)", latestLedger, closeMeta.V)
+		return 0, fmt.Errorf("latest ledger (%d) meta has unexpected version (%d)", latestLedger, closeMeta.V)
 	}
 	return uint32(closeMeta.V1.LedgerHeader.Header.LedgerVersion), nil
 }

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -82,7 +82,7 @@ fn new_cpreflight_result_from_invoke_host_function(
     if let Some(p) = restore_preamble {
         result.pre_restore_min_fee = p.transaction_data.resource_fee;
         result.pre_restore_transaction_data = xdr_to_c(&p.transaction_data);
-    };
+    }
     result
 }
 
@@ -104,7 +104,7 @@ fn new_cpreflight_result_from_transaction_data(
     if let Some(p) = restore_preamble {
         result.pre_restore_min_fee = p.transaction_data.resource_fee;
         result.pre_restore_transaction_data = xdr_to_c(&p.transaction_data);
-    };
+    }
     result
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/stellar/stellar-rpc
 
-go 1.23
+go 1.24
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/Masterminds/squirrel v1.5.4


### PR DESCRIPTION
Part of https://github.com/stellar/stellar-rpc/issues/367

The benchmark tests the two backends for the implementation:

* Using the new Captive Core HTTP endpoint
* Using the DB-based internal soroban-rpc implementation
