### PR TITLE
Add extension field to `getLedgerEntries` response

### DIFF
--- a/cmd/stellar-rpc/internal/methods/get_ledger_entries.go
+++ b/cmd/stellar-rpc/internal/methods/get_ledger_entries.go
@@ -259,8 +259,15 @@ func ledgerKeyEntryToResult(keyEntry db.LedgerKeyAndEntry, format string) (proto
 		if err != nil {
 			return protocol.LedgerEntryResult{}, err
 		}
+		extJs, err := xdr2json.ConvertInterface(keyEntry.Entry.Ext)
+		if err != nil {
+			return protocol.LedgerEntryResult{}, err
+		}
+
 		result.KeyJSON = keyJs
 		result.DataJSON = entryJs
+		result.ExtensionJSON = extJs
+
 	default:
 		keyXDR, err := xdr.MarshalBase64(keyEntry.Key)
 		if err != nil {
@@ -273,9 +280,17 @@ func ledgerKeyEntryToResult(keyEntry db.LedgerKeyAndEntry, format string) (proto
 			return protocol.LedgerEntryResult{}, err
 		}
 
+		extXDR, err := xdr.MarshalBase64(keyEntry.Entry.Ext)
+		if err != nil {
+			err = fmt.Errorf("could not serialize ledger entry extension %v: %w", keyEntry.Entry.Ext, err)
+			return protocol.LedgerEntryResult{}, err
+		}
+
 		result.KeyXDR = keyXDR
 		result.DataXDR = entryXDR
+		result.ExtensionXDR = extXDR
 	}
+
 	result.LastModifiedLedger = uint32(keyEntry.Entry.LastModifiedLedgerSeq)
 	result.LiveUntilLedgerSeq = keyEntry.LiveUntilLedgerSeq
 	return result, nil

--- a/protocol/get_ledger_entries.go
+++ b/protocol/get_ledger_entries.go
@@ -20,6 +20,9 @@ type LedgerEntryResult struct {
 	LastModifiedLedger uint32 `json:"lastModifiedLedgerSeq"`
 	// The ledger sequence until the entry is live, available for entries that have associated ttl ledger entries.
 	LiveUntilLedgerSeq *uint32 `json:"liveUntilLedgerSeq,omitempty"`
+	// Extension field for this entry, if any
+	ExtensionXDR  string          `json:"extXdr,omitempty"`
+	ExtensionJSON json.RawMessage `json:"extJson,omitempty"`
 }
 
 type GetLedgerEntriesResponse struct {


### PR DESCRIPTION
### What
Adds the entry's `Ext` field to the response in both base64-encoded XDR and as JSON.

### Why
Closes #379.