### PR TITLE
Fix CLI refresh race conditions

### DIFF
--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -82,7 +82,7 @@ fn new_cpreflight_result_from_invoke_host_function(
     if let Some(p) = restore_preamble {
         result.pre_restore_min_fee = p.transaction_data.resource_fee;
         result.pre_restore_transaction_data = xdr_to_c(&p.transaction_data);
-    };
+    }
     result
 }
 
@@ -104,7 +104,7 @@ fn new_cpreflight_result_from_transaction_data(
     if let Some(p) = restore_preamble {
         result.pre_restore_min_fee = p.transaction_data.resource_fee;
         result.pre_restore_transaction_data = xdr_to_c(&p.transaction_data);
-    };
+    }
     result
 }
 


### PR DESCRIPTION
### What

Fix https://github.com/stellar/stellar-rpc/issues/394 with a mutex on the client.

### Why

We don't like races.

### Known limitations

It can cause contention if the client needs to be refreshed often due to errors. But this is better than a race, at least until a better solution is offered by the maintainer at https://github.com/stellar/stellar-rpc/issues/394
