### PR TITLE
Ignore state change entries which don't incur an actual diff

### DIFF
--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -82,7 +82,7 @@ fn new_cpreflight_result_from_invoke_host_function(
     if let Some(p) = restore_preamble {
         result.pre_restore_min_fee = p.transaction_data.resource_fee;
         result.pre_restore_transaction_data = xdr_to_c(&p.transaction_data);
-    };
+    }
     result
 }
 
@@ -104,7 +104,7 @@ fn new_cpreflight_result_from_transaction_data(
     if let Some(p) = restore_preamble {
         result.pre_restore_min_fee = p.transaction_data.resource_fee;
         result.pre_restore_transaction_data = xdr_to_c(&p.transaction_data);
-    };
+    }
     result
 }
 


### PR DESCRIPTION
### What
Even though the key was touched (but left unchanged), it won't appear in the list of state changes. This is semantically fine, since no state changed.

### Why
Closes https://github.com/stellar/stellar-rpc/issues/390 until https://github.com/stellar/rs-soroban-env/issues/1448 is done. Simulation should still be able to succeed in these cases.

### Known limitations
A bit hacky, but it's a temporary fix until the "proper" one is done in P23, where we'll include the key itself and allow `null`/`null` for before/after.