### PR TITLE
Always return a transactions array in getTransactions

### DIFF
--- a/cmd/stellar-rpc/internal/methods/get_transactions.go
+++ b/cmd/stellar-rpc/internal/methods/get_transactions.go
@@ -216,7 +216,8 @@ func (h transactionsRPCHandler) getTransactionsByLedgerSequence(ctx context.Cont
 
 	// Iterate through each ledger and its transactions until limit or end range is reached.
 	// The latest ledger acts as the end ledger range for the request.
-	var txns []protocol.TransactionInfo
+	// Initialize txns as an empty array so it's never null in the response.
+	txns := []protocol.TransactionInfo{}
 	var done bool
 	cursor := toid.New(0, 0, 0)
 	for ledgerSeq := start.LedgerSequence; ledgerSeq <= int32(ledgerRange.LastLedger.Sequence); ledgerSeq++ {

--- a/cmd/stellar-rpc/internal/methods/get_transactions_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_transactions_test.go
@@ -339,7 +339,7 @@ func TestGetTransactions_EmptyArray(t *testing.T) {
 
 	// Verify that transactions is an empty array, not null
 	assert.NotNil(t, response.Transactions)
-	assert.Equal(t, 0, len(response.Transactions))
+	assert.Empty(t, len(response.Transactions))
 
 	// Marshal to JSON to verify the field is [] and not null
 	jsonBytes, err := json.Marshal(response)

--- a/cmd/stellar-rpc/internal/methods/get_transactions_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_transactions_test.go
@@ -339,7 +339,7 @@ func TestGetTransactions_EmptyArray(t *testing.T) {
 
 	// Verify that transactions is an empty array, not null
 	assert.NotNil(t, response.Transactions)
-	assert.Empty(t, len(response.Transactions))
+	assert.Empty(t, response.Transactions)
 
 	// Marshal to JSON to verify the field is [] and not null
 	jsonBytes, err := json.Marshal(response)


### PR DESCRIPTION
### What
Initialize transactions in the getTransactions response as an empty array.

### Why
To ensure the field is not null in the getTransactions JSON response when there are no transactions.

Close #398