### PR TITLE
Bump go version to 1.24 in Dockerfile

### DIFF
--- a/cmd/stellar-rpc/docker/Dockerfile
+++ b/cmd/stellar-rpc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye as build
+FROM golang:1.24-bullseye as build
 ARG RUST_TOOLCHAIN_VERSION=stable
 ARG REPOSITORY_VERSION
 ARG BINARY_NAME=stellar-rpc


### PR DESCRIPTION
### What

Update the go version to 1.24 in Dockerfile.
 
### Why
We upgraded to go 1.24 in https://github.com/stellar/stellar-rpc/pull/380

### Known limitations
N/A