### PR TITLE
Drop soroban-rpc build support

### DIFF
--- a/cmd/stellar-rpc/docker/Dockerfile
+++ b/cmd/stellar-rpc/docker/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:1.23-bullseye as build
 ARG RUST_TOOLCHAIN_VERSION=stable
 ARG REPOSITORY_VERSION
-ARG BINARY_NAME=stellar-rpc
 
 WORKDIR /go/src/github.com/stellar/stellar-rpc
 
@@ -19,14 +18,13 @@ RUN apt-get clean
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_TOOLCHAIN_VERSION
 
-RUN make REPOSITORY_VERSION=${REPOSITORY_VERSION} build-${BINARY_NAME}
+RUN make REPOSITORY_VERSION=${REPOSITORY_VERSION} build-stellar-rpc
 
 # Move the binary to a common location
-RUN mv ${BINARY_NAME} /bin/${BINARY_NAME}
+RUN mv stellar-rpc /bin/stellar-rpc
 
 FROM ubuntu:22.04
 ARG STELLAR_CORE_VERSION
-ARG BINARY_NAME=stellar-rpc
 ENV STELLAR_CORE_VERSION=${STELLAR_CORE_VERSION:-*}
 ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
 ENV DEBIAN_FRONTEND=noninteractive
@@ -40,7 +38,7 @@ RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 RUN apt-get clean
 
 # Copy the binary from the build stage
-COPY --from=build /bin/${BINARY_NAME} /app/${BINARY_NAME}
+COPY --from=build /bin/stellar-rpc /app/stellar-rpc
 
 # Set the entrypoint to the specific binary
-ENTRYPOINT ["/app/${BINARY_NAME}"]
+ENTRYPOINT ["/app/stellar-rpc"]

--- a/cmd/stellar-rpc/docker/Makefile
+++ b/cmd/stellar-rpc/docker/Makefile
@@ -22,24 +22,10 @@ ifndef STELLAR_CORE_VERSION
         $(error STELLAR_CORE_VERSION environment variable must be set. For example 19.10.1-1310.6649f5173.focal~soroban)
 endif
 
-# Set default value for BINARY_NAME if not provided
-BINARY_NAME ?= stellar-rpc
-
-ifndef TAG
-    # Set the TAG based on the value of BINARY_NAME
-    ifeq ($(BINARY_NAME),stellar-rpc)
-        TAG := stellar/stellar-rpc:$(STELLAR_RPC_VERSION_PACKAGE_VERSION)
-    else
-        TAG := stellar/stellar-stellar-rpc:$(STELLAR_RPC_VERSION_PACKAGE_VERSION)
-    endif
-endif # TAG
-
-
 docker-build:
 	$(SUDO) docker build --pull --platform linux/amd64 $(DOCKER_OPTS) \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) --build-arg STELLAR_RPC_VERSION=$(STELLAR_RPC_VERSION_PACKAGE_VERSION) \
-	--build-arg BINARY_NAME=$(BINARY_NAME) \
 	-t $(TAG) -f Dockerfile.release .
 
 docker-push:


### PR DESCRIPTION
### What

Remove `BINARY_NAME` build argument as we are discontinuing support for building `soroban-rpc` image. Only `stellar-rpc` will be built going forward.

### Why
We renamed `soroban-rpc` to `stellar-rpc` before protocol 22 and kept both builds to give users time to switch. Now that sufficient time has passed, we’re discontinuing the `soroban-rpc` build

### Known limitations
Users relying on the `soroban-rpc` image will need to migrate to `stellar-rpc`.