### PR TITLE
Remove Ubuntu 20 from CI as it's no longer supported

### DIFF
--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -18,7 +18,7 @@ jobs:
     name: Unit tests
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-22.04 ]
         protocol-version: [ 21, 22 ]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
### What

Remove Ubuntu 20 from CI. 

### Why

RPC CI failing because Ubuntu 20 is now fully unsupported (see: https://github.com/actions/runner-images/issues/11101).

### Known limitations
