### PR TITLE
Return `[]` rather than `null` when `getTransactions` is empty

### DIFF
--- a/cmd/stellar-rpc/internal/methods/get_transaction_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_transaction_test.go
@@ -337,6 +337,45 @@ func txMetaWithEvents(acctSeq uint32, successful bool) xdr.LedgerCloseMeta {
 	return meta
 }
 
+func emptyTxMeta(acctSeq uint32) xdr.LedgerCloseMeta {
+	txProcessing := []xdr.TransactionResultMeta{}
+	components := []xdr.TxSetComponent{
+		{
+			Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+			TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+				BaseFee: nil,
+				Txs:     []xdr.TransactionEnvelope{},
+			},
+		},
+	}
+	return xdr.LedgerCloseMeta{
+		V: 1,
+		V1: &xdr.LedgerCloseMetaV1{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue: xdr.StellarValue{
+						CloseTime: xdr.TimePoint(ledgerCloseTime(acctSeq + 100)),
+					},
+					LedgerSeq: xdr.Uint32(acctSeq + 100),
+				},
+			},
+			TxProcessing: txProcessing,
+			TxSet: xdr.GeneralizedTransactionSet{
+				V: 1,
+				V1TxSet: &xdr.TransactionSetV1{
+					PreviousLedgerHash: xdr.Hash{1},
+					Phases: []xdr.TransactionPhase{
+						{
+							V:            0,
+							V0Components: &components,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func TestGetTransaction_JSONFormat(t *testing.T) {
 	mockDBReader := db.NewMockTransactionStore(NetworkPassphrase)
 	mockLedgerReader := db.NewMockLedgerReader(mockDBReader)

--- a/cmd/stellar-rpc/internal/methods/get_transactions.go
+++ b/cmd/stellar-rpc/internal/methods/get_transactions.go
@@ -216,7 +216,7 @@ func (h transactionsRPCHandler) getTransactionsByLedgerSequence(ctx context.Cont
 
 	// Iterate through each ledger and its transactions until limit or end range is reached.
 	// The latest ledger acts as the end ledger range for the request.
-	var txns []protocol.TransactionInfo
+	txns := make([]protocol.TransactionInfo, 0, limit)
 	var done bool
 	cursor := toid.New(0, 0, 0)
 	for ledgerSeq := start.LedgerSequence; ledgerSeq <= int32(ledgerRange.LastLedger.Sequence); ledgerSeq++ {


### PR DESCRIPTION
### What
Using an uninitialized array causes the result to be `null` if it's never `append`ed to.

### Why
This is way more intuitive, closes #398.

### Known limitations
n/a