### PR TITLE
Add ledger close times and oldest ledger in DB to getEvents response

### DIFF
--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        protocol-version: [ 21, 22 ]
+        protocol-version: [ 22 ]
     runs-on: ${{ matrix.os }}
     env:
       STELLAR_RPC_INTEGRATION_TESTS_ENABLED: true

--- a/cmd/stellar-rpc/internal/methods/get_events.go
+++ b/cmd/stellar-rpc/internal/methods/get_events.go
@@ -214,9 +214,13 @@ func (h eventsRPCHandler) getEvents(ctx context.Context, request protocol.GetEve
 	}
 
 	return protocol.GetEventsResponse{
-		LatestLedger: ledgerRange.LastLedger.Sequence,
-		Events:       results,
-		Cursor:       cursor,
+		Events: results,
+		Cursor: cursor,
+
+		LatestLedger:          ledgerRange.LastLedger.Sequence,
+		OldestLedger:          ledgerRange.FirstLedger.Sequence,
+		LatestLedgerCloseTime: ledgerRange.LastLedger.CloseTime,
+		OldestLedgerCloseTime: ledgerRange.FirstLedger.CloseTime,
 	}, nil
 }
 

--- a/cmd/stellar-rpc/internal/methods/get_events_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_events_test.go
@@ -160,7 +160,12 @@ func TestGetEvents(t *testing.T) {
 		cursorStr := cursor.String()
 		assert.Equal(t,
 			protocol.GetEventsResponse{
-				Events: expected, LatestLedger: 1, Cursor: cursorStr,
+				Events:                expected,
+				Cursor:                cursorStr,
+				LatestLedger:          1,
+				OldestLedger:          1,
+				LatestLedgerCloseTime: now.Unix(),
+				OldestLedgerCloseTime: now.Unix(),
 			},
 			results,
 		)
@@ -314,7 +319,12 @@ func TestGetEvents(t *testing.T) {
 		cursorStr := cursor.String()
 		assert.Equal(t,
 			protocol.GetEventsResponse{
-				Events: expected, LatestLedger: 1, Cursor: cursorStr,
+				Events:                expected,
+				Cursor:                cursorStr,
+				LatestLedger:          1,
+				OldestLedger:          1,
+				LatestLedgerCloseTime: now.Unix(),
+				OldestLedgerCloseTime: now.Unix(),
 			},
 			results,
 		)
@@ -353,7 +363,12 @@ func TestGetEvents(t *testing.T) {
 		expected[0].TopicJSON = topicsJs
 		require.Equal(t,
 			protocol.GetEventsResponse{
-				Events: expected, LatestLedger: 1, Cursor: cursorStr,
+				Events:                expected,
+				Cursor:                cursorStr,
+				LatestLedger:          1,
+				OldestLedger:          1,
+				LatestLedgerCloseTime: now.Unix(),
+				OldestLedgerCloseTime: now.Unix(),
 			},
 			results,
 		)
@@ -471,7 +486,12 @@ func TestGetEvents(t *testing.T) {
 		cursorStr := cursor.String()
 		assert.Equal(t,
 			protocol.GetEventsResponse{
-				Events: expected, LatestLedger: 1, Cursor: cursorStr,
+				Events:                expected,
+				Cursor:                cursorStr,
+				LatestLedger:          1,
+				OldestLedger:          1,
+				LatestLedgerCloseTime: now.Unix(),
+				OldestLedgerCloseTime: now.Unix(),
 			},
 			results,
 		)
@@ -553,7 +573,12 @@ func TestGetEvents(t *testing.T) {
 		cursorStr := cursor.String()
 		assert.Equal(t,
 			protocol.GetEventsResponse{
-				Events: expected, LatestLedger: 1, Cursor: cursorStr,
+				Events:                expected,
+				Cursor:                cursorStr,
+				LatestLedger:          1,
+				OldestLedger:          1,
+				LatestLedgerCloseTime: now.Unix(),
+				OldestLedgerCloseTime: now.Unix(),
 			},
 			results,
 		)
@@ -630,7 +655,12 @@ func TestGetEvents(t *testing.T) {
 
 		assert.Equal(t,
 			protocol.GetEventsResponse{
-				Events: expected, LatestLedger: 1, Cursor: cursor,
+				Events:                expected,
+				Cursor:                cursor,
+				LatestLedger:          1,
+				OldestLedger:          1,
+				LatestLedgerCloseTime: now.Unix(),
+				OldestLedgerCloseTime: now.Unix(),
 			},
 			results,
 		)
@@ -735,8 +765,12 @@ func TestGetEvents(t *testing.T) {
 		cursor := expected[len(expected)-1].ID
 		assert.Equal(t,
 			protocol.GetEventsResponse{
-				Events: expected, LatestLedger: 5,
-				Cursor: cursor,
+				Events:                expected,
+				Cursor:                cursor,
+				LatestLedger:          5,
+				OldestLedger:          5,
+				LatestLedgerCloseTime: now.Unix(),
+				OldestLedgerCloseTime: now.Unix(),
 			},
 			results,
 		)
@@ -759,7 +793,12 @@ func TestGetEvents(t *testing.T) {
 		cursor = rawCursor.String()
 		assert.Equal(t,
 			protocol.GetEventsResponse{
-				Events: []protocol.EventInfo{}, LatestLedger: 5, Cursor: cursor,
+				Events:                []protocol.EventInfo{},
+				Cursor:                cursor,
+				LatestLedger:          5,
+				OldestLedger:          5,
+				LatestLedgerCloseTime: now.Unix(),
+				OldestLedgerCloseTime: now.Unix(),
 			},
 			results,
 		)

--- a/protocol/get_events.go
+++ b/protocol/get_events.go
@@ -327,9 +327,13 @@ type PaginationOptions struct {
 }
 
 type GetEventsResponse struct {
-	Events       []EventInfo `json:"events"`
-	LatestLedger uint32      `json:"latestLedger"`
+	Events []EventInfo `json:"events"`
 	// Cursor represents last populated event ID if total events reach the limit
 	// or end of the search window
 	Cursor string `json:"cursor"`
+
+	LatestLedger          uint32 `json:"latestLedger"`
+	OldestLedger          uint32 `json:"oldestLedger"`
+	LatestLedgerCloseTime int64  `json:"latestLedgerCloseTime,string"`
+	OldestLedgerCloseTime int64  `json:"oldestLedgerCloseTime,string"`
 }


### PR DESCRIPTION
### What
Adds the following to the base-level getEvents response schema to match other endpoints:

```go
	OldestLedger          uint32 `json:"oldestLedger"`
	LatestLedgerCloseTime int64  `json:"latestLedgerCloseTime,string"`
	OldestLedgerCloseTime int64  `json:"oldestLedgerCloseTime,string"`
```

### Why
Closes #231.

### Known limitations
n/a