### PR TITLE
p23: provide simulateTransaction ledger entries through core

### DIFF
--- a/cmd/stellar-rpc/internal/config/options.go
+++ b/cmd/stellar-rpc/internal/config/options.go
@@ -20,8 +20,9 @@ const (
 	OneDayOfLedgers   = 17280
 	SevenDayOfLedgers = OneDayOfLedgers * 7
 
-	defaultHTTPEndpoint        = "localhost:8000"
-	defaultCaptiveCoreHTTPPort = 11626 // regular queries like /info
+	defaultHTTPEndpoint             = "localhost:8000"
+	defaultCaptiveCoreHTTPPort      = 11626 // regular queries like /info
+	defaultCaptiveCoreHTTPQueryPort = 11628
 )
 
 // TODO: refactor and remove the linter exceptions
@@ -89,9 +90,10 @@ func (cfg *Config) options() Options {
 		},
 		{
 			Name:         "stellar-captive-core-http-query-port",
-			Usage:        "HTTP port for Captive Core to listen on for high-performance queries like /getledgerentry (0 disables the HTTP server, must not conflict with CAPTIVE_CORE_HTTP_PORT)",
+			Usage:        "HTTP port for Captive Core to listen on for high-performance queries like /getledgerentry (must not conflict with CAPTIVE_CORE_HTTP_PORT)",
 			ConfigKey:    &cfg.CaptiveCoreHTTPQueryPort,
-			DefaultValue: uint16(11628),
+			DefaultValue: uint16(defaultCaptiveCoreHTTPQueryPort),
+			Validate:     positive,
 		},
 		{
 			Name:         "stellar-captive-core-http-query-thread-pool-size",

--- a/cmd/stellar-rpc/internal/config/options.go
+++ b/cmd/stellar-rpc/internal/config/options.go
@@ -91,7 +91,7 @@ func (cfg *Config) options() Options {
 			Name:         "stellar-captive-core-http-query-port",
 			Usage:        "HTTP port for Captive Core to listen on for high-performance queries like /getledgerentry (0 disables the HTTP server, must not conflict with CAPTIVE_CORE_HTTP_PORT)",
 			ConfigKey:    &cfg.CaptiveCoreHTTPQueryPort,
-			DefaultValue: uint16(0), // Disabled by default, although it normally uses 11628
+			DefaultValue: uint16(11628),
 		},
 		{
 			Name:         "stellar-captive-core-http-query-thread-pool-size",

--- a/cmd/stellar-rpc/internal/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/daemon/daemon.go
@@ -123,13 +123,10 @@ func (d *Daemon) Close() error {
 // newCaptiveCore creates a new captive core backend instance and returns it.
 func newCaptiveCore(cfg *config.Config, logger *supportlog.Entry) (*ledgerbackend.CaptiveStellarCore, error) {
 	var queryServerParams *ledgerbackend.HTTPQueryServerParams
-	if cfg.CaptiveCoreHTTPQueryPort != 0 {
-		// Only try to enable the server if the port passed is non-zero
-		queryServerParams = &ledgerbackend.HTTPQueryServerParams{
-			Port:            cfg.CaptiveCoreHTTPQueryPort,
-			ThreadPoolSize:  cfg.CaptiveCoreHTTPQueryThreadPoolSize,
-			SnapshotLedgers: cfg.CaptiveCoreHTTPQuerySnapshotLedgers,
-		}
+	queryServerParams = &ledgerbackend.HTTPQueryServerParams{
+		Port:            cfg.CaptiveCoreHTTPQueryPort,
+		ThreadPoolSize:  cfg.CaptiveCoreHTTPQueryThreadPoolSize,
+		SnapshotLedgers: cfg.CaptiveCoreHTTPQuerySnapshotLedgers,
 	}
 
 	httpPort := uint(cfg.CaptiveCoreHTTPPort)
@@ -251,10 +248,6 @@ func createStellarCoreClient(cfg *config.Config) stellarcore.Client {
 }
 
 func createHighperfStellarCoreClient(cfg *config.Config) interfaces.FastCoreClient {
-	// It doesn't make sense to create a client if the local server is not enabled
-	if cfg.CaptiveCoreHTTPQueryPort == 0 {
-		return nil
-	}
 	return &stellarcore.Client{
 		URL:  fmt.Sprintf("http://localhost:%d", cfg.CaptiveCoreHTTPQueryPort),
 		HTTP: &http.Client{Timeout: cfg.CoreRequestTimeout},
@@ -289,14 +282,12 @@ func createIngestService(cfg *config.Config, logger *supportlog.Entry, daemon *D
 }
 
 func createPreflightWorkerPool(cfg *config.Config, logger *supportlog.Entry, daemon *Daemon) *preflight.WorkerPool {
-	ledgerEntryReader := db.NewLedgerEntryReader(daemon.db)
 	return preflight.NewPreflightWorkerPool(
 		preflight.WorkerPoolConfig{
 			Daemon:            daemon,
 			WorkerCount:       cfg.PreflightWorkerCount,
 			JobQueueCapacity:  cfg.PreflightWorkerQueueSize,
 			EnableDebug:       cfg.PreflightEnableDebug,
-			LedgerEntryReader: ledgerEntryReader,
 			NetworkPassphrase: cfg.NetworkPassphrase,
 			Logger:            logger,
 		},

--- a/cmd/stellar-rpc/internal/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/daemon/daemon.go
@@ -122,8 +122,7 @@ func (d *Daemon) Close() error {
 
 // newCaptiveCore creates a new captive core backend instance and returns it.
 func newCaptiveCore(cfg *config.Config, logger *supportlog.Entry) (*ledgerbackend.CaptiveStellarCore, error) {
-	var queryServerParams *ledgerbackend.HTTPQueryServerParams
-	queryServerParams = &ledgerbackend.HTTPQueryServerParams{
+	queryServerParams := &ledgerbackend.HTTPQueryServerParams{
 		Port:            cfg.CaptiveCoreHTTPQueryPort,
 		ThreadPoolSize:  cfg.CaptiveCoreHTTPQueryThreadPoolSize,
 		SnapshotLedgers: cfg.CaptiveCoreHTTPQuerySnapshotLedgers,

--- a/cmd/stellar-rpc/internal/integrationtest/archive_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/archive_test.go
@@ -20,7 +20,7 @@ func TestArchiveUserAgent(t *testing.T) {
 		t.Log("agent", agent)
 		userAgents.Store(agent, "")
 		if r.URL.Path == "/.well-known/stellar-history.json" || r.URL.Path == "/history/00/00/00/history-0000001f.json" {
-			w.Write([]byte(`{
+			_, _ = w.Write([]byte(`{
     "version": 1,
     "server": "stellar-core 21.0.1 (dfd3dbff1d9cad4dc31e022de6ac2db731b4b326)",
     "currentLedger": 31,

--- a/cmd/stellar-rpc/internal/integrationtest/get_ledger_entries_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/get_ledger_entries_test.go
@@ -18,18 +18,7 @@ import (
 )
 
 func TestGetLedgerEntriesNotFound(t *testing.T) {
-	t.Run("WithCore", func(t *testing.T) {
-		testGetLedgerEntriesNotFound(t, true)
-	})
-	t.Run("WithoutCore", func(t *testing.T) {
-		testGetLedgerEntriesNotFound(t, false)
-	})
-}
-
-func testGetLedgerEntriesNotFound(t *testing.T, useCore bool) {
-	test := infrastructure.NewTest(t, &infrastructure.TestConfig{
-		EnableCoreHTTPQueryServer: useCore,
-	})
+	test := infrastructure.NewTest(t, nil)
 	client := test.GetRPCLient()
 
 	hash := xdr.Hash{0xa, 0xb}
@@ -62,18 +51,7 @@ func testGetLedgerEntriesNotFound(t *testing.T, useCore bool) {
 }
 
 func TestGetLedgerEntriesInvalidParams(t *testing.T) {
-	t.Run("WithCore", func(t *testing.T) {
-		testGetLedgerEntriesInvalidParams(t, true)
-	})
-	t.Run("WithoutCore", func(t *testing.T) {
-		testGetLedgerEntriesInvalidParams(t, false)
-	})
-}
-
-func testGetLedgerEntriesInvalidParams(t *testing.T, useCore bool) {
-	test := infrastructure.NewTest(t, &infrastructure.TestConfig{
-		EnableCoreHTTPQueryServer: useCore,
-	})
+	test := infrastructure.NewTest(t, nil)
 
 	client := test.GetRPCLient()
 
@@ -91,18 +69,7 @@ func testGetLedgerEntriesInvalidParams(t *testing.T, useCore bool) {
 }
 
 func TestGetLedgerEntriesSucceeds(t *testing.T) {
-	t.Run("WithCore", func(t *testing.T) {
-		testGetLedgerEntriesSucceeds(t, true)
-	})
-	t.Run("WithoutCore", func(t *testing.T) {
-		testGetLedgerEntriesSucceeds(t, false)
-	})
-}
-
-func testGetLedgerEntriesSucceeds(t testing.TB, useCore bool) {
-	test := infrastructure.NewTest(t, &infrastructure.TestConfig{
-		EnableCoreHTTPQueryServer: useCore,
-	})
+	test := infrastructure.NewTest(t, nil)
 	_, contractID, contractHash := test.CreateHelloWorldContract()
 
 	contractCodeKeyB64, err := xdr.MarshalBase64(xdr.LedgerKey{
@@ -166,7 +133,7 @@ func testGetLedgerEntriesSucceeds(t testing.TB, useCore bool) {
 	}))
 }
 
-func benchmarkGetLedgerEntries(b *testing.B, useCore bool) {
+func BenchmarkGetLedgerEntries(b *testing.B) {
 	sqlitePath := ""
 	captivecoreStoragePath := ""
 	// Needed to test performance on specific storage types (e.g. AWS EBS directories)
@@ -194,10 +161,9 @@ func benchmarkGetLedgerEntries(b *testing.B, useCore bool) {
 		}
 	}
 	test := infrastructure.NewTest(b, &infrastructure.TestConfig{
-		EnableCoreHTTPQueryServer: useCore,
-		SQLitePath:                sqlitePath,
-		CaptiveCoreStoragePath:    captivecoreStoragePath,
-		OnlyRPC:                   testOnlyRPC,
+		SQLitePath:             sqlitePath,
+		CaptiveCoreStoragePath: captivecoreStoragePath,
+		OnlyRPC:                testOnlyRPC,
 	})
 	_, contractID, contractHash := test.CreateHelloWorldContract()
 
@@ -246,13 +212,4 @@ func benchmarkGetLedgerEntries(b *testing.B, useCore bool) {
 		require.Positive(b, result.LatestLedger)
 		b.StartTimer()
 	}
-}
-
-func BenchmarkGetLedgerEntries(b *testing.B) {
-	b.Run("WithCore", func(b *testing.B) {
-		benchmarkGetLedgerEntries(b, true)
-	})
-	b.Run("WithoutCore", func(b *testing.B) {
-		benchmarkGetLedgerEntries(b, false)
-	})
 }

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
@@ -74,8 +74,7 @@ type TestConfig struct {
 	CaptiveCoreStoragePath string
 	OnlyRPC                *TestOnlyRPCConfig
 	// Do not mark the test as running in parallel
-	NoParallel                bool
-	EnableCoreHTTPQueryServer bool
+	NoParallel bool
 }
 
 type TestCorePorts struct {
@@ -115,11 +114,10 @@ type Test struct {
 
 	daemon *daemon.Daemon
 
-	masterAccount             txnbuild.Account
-	shutdownOnce              sync.Once
-	shutdown                  func()
-	onlyRPC                   bool
-	enableCoreHTTPQueryServer bool
+	masterAccount txnbuild.Account
+	shutdownOnce  sync.Once
+	shutdown      func()
+	onlyRPC       bool
 }
 
 func NewTest(t testing.TB, cfg *TestConfig) *Test {
@@ -146,11 +144,6 @@ func NewTest(t testing.TB, cfg *TestConfig) *Test {
 			shouldWaitForRPC = !cfg.OnlyRPC.DontWait
 		}
 		parallel = !cfg.NoParallel
-		i.enableCoreHTTPQueryServer = cfg.EnableCoreHTTPQueryServer
-	}
-
-	if i.enableCoreHTTPQueryServer && GetCoreMaxSupportedProtocol() < 22 {
-		t.Skip("Core's HTTP Query server is only available from protocol 22")
 	}
 
 	if i.sqlitePath == "" {
@@ -200,9 +193,7 @@ func (i *Test) spawnContainers() {
 	if i.runRPCInContainer() {
 		// The container needs to use the sqlite mount point
 		i.rpcContainerSQLiteMountDir = filepath.Dir(i.sqlitePath)
-		if i.enableCoreHTTPQueryServer {
-			i.testPorts.captiveCoreHTTPQueryPort = inContainerCoreHTTPQueryPort
-		}
+		i.testPorts.captiveCoreHTTPQueryPort = inContainerCoreHTTPQueryPort
 		i.generateCaptiveCoreCfgForContainer()
 		rpcCfg := i.getRPConfigForContainer()
 		i.generateRPCConfigFile(rpcCfg)
@@ -481,9 +472,7 @@ func (i *Test) spawnRPCDaemon() {
 	// Unfortunately this isn't completely clash-free, but there is no way to
 	// tell core to allocate the port dynamically
 	i.testPorts.captiveCorePeerPort = getFreeTCPPort(i.t)
-	if i.enableCoreHTTPQueryServer {
-		i.testPorts.captiveCoreHTTPQueryPort = getFreeTCPPort(i.t)
-	}
+	i.testPorts.captiveCoreHTTPQueryPort = getFreeTCPPort(i.t)
 	i.generateCaptiveCoreCfgForDaemon()
 	rpcCfg := i.getRPConfigForDaemon()
 	i.daemon = i.createRPCDaemon(rpcCfg)

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
@@ -562,7 +562,7 @@ func (i *Test) prepareShutdownHandlers() {
 			i.stopContainers()
 		}
 		if i.rpcContainerLogsCommand != nil {
-			i.rpcContainerLogsCommand.Wait()
+			_ = i.rpcContainerLogsCommand.Wait()
 		}
 	}
 

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
@@ -334,7 +334,7 @@ func (vars rpcConfig) toMap() map[string]string {
 		"STELLAR_CAPTIVE_CORE_HTTP_PORT":                   strconv.FormatUint(uint64(vars.captiveCoreHTTPPort), 10),
 		"STELLAR_CAPTIVE_CORE_HTTP_QUERY_PORT":             strconv.FormatUint(uint64(vars.captiveCoreHTTPQueryPort), 10),
 		"STELLAR_CAPTIVE_CORE_HTTP_QUERY_THREAD_POOL_SIZE": strconv.Itoa(runtime.NumCPU()),
-		"STELLAR_CAPTIVE_CORE_HTTP_QUERY_SNAPSHOT_LEDGERS": "4",
+		"STELLAR_CAPTIVE_CORE_HTTP_QUERY_SNAPSHOT_LEDGERS": "10",
 		"FRIENDBOT_URL":                                    FriendbotURL,
 		"NETWORK_PASSPHRASE":                               StandaloneNetworkPassphrase,
 		"HISTORY_ARCHIVE_URLS":                             vars.archiveURL,

--- a/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
@@ -506,6 +506,7 @@ func waitUntilLedgerEntryTTL(t *testing.T, client *client.Client, ledgerKey xdr.
 		require.NotEmpty(t, result.Entries)
 		require.NoError(t, xdr.SafeUnmarshalBase64(result.Entries[0].DataXDR, &entry))
 		require.NotEqual(t, xdr.LedgerEntryTypeTtl, entry.Type)
+		require.NotNil(t, result.Entries[0].LiveUntilLedgerSeq)
 		liveUntilLedgerSeq := xdr.Uint32(*result.Entries[0].LiveUntilLedgerSeq)
 		// See https://soroban.stellar.org/docs/fundamentals-and-concepts/state-expiration#expiration-ledger
 		currentLedger := result.LatestLedger + 1
@@ -514,7 +515,7 @@ func waitUntilLedgerEntryTTL(t *testing.T, client *client.Client, ledgerKey xdr.
 			t.Logf("ledger entry ttl'ed")
 			break
 		}
-		t.Log("waiting for ledger entry to ttl at ledger", liveUntilLedgerSeq)
+		t.Logf("waiting for ledger entry to ttl at ledger %d (current ledger = %d)", liveUntilLedgerSeq, currentLedger)
 		time.Sleep(time.Second)
 	}
 	require.True(t, ttled)

--- a/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
@@ -29,6 +29,7 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 	client := test.GetRPCLient()
 	result := infrastructure.SimulateTransactionFromTxParams(t, client, params)
 
+	require.Empty(t, result.Error)
 	contractHash := sha256.Sum256(contractBinary)
 	contractHashBytes := xdr.ScBytes(contractHash[:])
 	expectedXdr := xdr.ScVal{Type: xdr.ScValTypeScvBytes, Bytes: &contractHashBytes}
@@ -128,6 +129,7 @@ func TestSimulateTransactionWithAuth(t *testing.T) {
 
 	client := test.GetRPCLient()
 	response := infrastructure.SimulateTransactionFromTxParams(t, client, deployContractParams)
+	require.Empty(t, response.Error)
 	require.NotEmpty(t, response.Results)
 	require.NotNil(t, response.Results[0].AuthXDR)
 	require.Len(t, *response.Results[0].AuthXDR, 1)

--- a/cmd/stellar-rpc/internal/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc.go
@@ -156,15 +156,6 @@ func NewJSONRPCHandler(cfg *config.Config, params HandlerParams) Handler {
 
 	retentionWindow := cfg.HistoryRetentionWindow
 
-	getLedgerEntriesHandler := methods.NewGetLedgerEntriesFromDBHandler(params.Logger, params.LedgerEntryReader)
-	if params.Daemon.FastCoreClient() != nil {
-		// Prioritize getting ledger entries from core if available
-		getLedgerEntriesHandler = methods.NewGetLedgerEntriesFromCoreHandler(
-			params.Logger,
-			params.Daemon.FastCoreClient(),
-			params.LedgerEntryReader)
-	}
-
 	handlers := []struct {
 		methodName           string
 		underlyingHandler    jrpc2.Handler
@@ -231,7 +222,7 @@ func NewJSONRPCHandler(cfg *config.Config, params HandlerParams) Handler {
 		},
 		{
 			methodName:           protocol.GetLedgerEntriesMethodName,
-			underlyingHandler:    getLedgerEntriesHandler,
+			underlyingHandler:    methods.NewGetLedgerEntriesHandler(params.Logger, params.Daemon.FastCoreClient(), params.LedgerEntryReader),
 			longName:             toSnakeCase(protocol.GetLedgerEntriesMethodName),
 			queueLimit:           cfg.RequestBacklogGetLedgerEntriesQueueLimit,
 			requestDurationLimit: cfg.MaxGetLedgerEntriesExecutionDuration,
@@ -263,7 +254,8 @@ func NewJSONRPCHandler(cfg *config.Config, params HandlerParams) Handler {
 			methodName: protocol.SimulateTransactionMethodName,
 			underlyingHandler: methods.NewSimulateTransactionHandler(
 				params.Logger, params.LedgerEntryReader, params.LedgerReader,
-				params.Daemon, params.PreflightGetter),
+				params.Daemon.FastCoreClient(), params.PreflightGetter),
+
 			longName:             toSnakeCase(protocol.SimulateTransactionMethodName),
 			queueLimit:           cfg.RequestBacklogSimulateTransactionQueueLimit,
 			requestDurationLimit: cfg.MaxSimulateTransactionExecutionDuration,

--- a/cmd/stellar-rpc/internal/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc.go
@@ -221,8 +221,9 @@ func NewJSONRPCHandler(cfg *config.Config, params HandlerParams) Handler {
 			requestDurationLimit: cfg.MaxGetLedgersExecutionDuration,
 		},
 		{
-			methodName:           protocol.GetLedgerEntriesMethodName,
-			underlyingHandler:    methods.NewGetLedgerEntriesHandler(params.Logger, params.Daemon.FastCoreClient(), params.LedgerEntryReader),
+			methodName: protocol.GetLedgerEntriesMethodName,
+			underlyingHandler: methods.NewGetLedgerEntriesHandler(params.Logger,
+				params.Daemon.FastCoreClient(), params.LedgerEntryReader),
 			longName:             toSnakeCase(protocol.GetLedgerEntriesMethodName),
 			queueLimit:           cfg.RequestBacklogGetLedgerEntriesQueueLimit,
 			requestDurationLimit: cfg.MaxGetLedgerEntriesExecutionDuration,

--- a/cmd/stellar-rpc/internal/ledgerentries/main.go
+++ b/cmd/stellar-rpc/internal/ledgerentries/main.go
@@ -1,0 +1,91 @@
+package ledgerentries
+
+import (
+	"context"
+	"fmt"
+
+	coreProto "github.com/stellar/go/protocols/stellarcore"
+	"github.com/stellar/go/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/daemon/interfaces"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
+)
+
+type LedgerEntryGetter interface {
+	GetLedgerEntries(ctx context.Context, keys []xdr.LedgerKey) ([]db.LedgerKeyAndEntry, uint32, error)
+}
+
+// NewLedgerEntryGetter creates a LedgerEntryGetter which obtains the latest known value of the given ledger entries
+func NewLedgerEntryGetter(coreClient interfaces.FastCoreClient, latestLedgerReader db.LedgerEntryReader) LedgerEntryGetter {
+	return &coreLedgerEntryGetter{
+		coreClient: coreClient,
+		// use the latest ledger
+		atLedger:           0,
+		latestLedgerReader: latestLedgerReader,
+	}
+}
+
+// NewLedgerEntryAtGetter NewLedgerEntryGetter creates a LedgerEntryGetter which obtains the value of the given ledger entries at a fixed ledger
+func NewLedgerEntryAtGetter(coreClient interfaces.FastCoreClient, atLedger uint32) LedgerEntryGetter {
+	return &coreLedgerEntryGetter{
+		coreClient: coreClient,
+		atLedger:   atLedger,
+	}
+}
+
+type coreLedgerEntryGetter struct {
+	coreClient         interfaces.FastCoreClient
+	atLedger           uint32
+	latestLedgerReader db.LedgerEntryReader
+}
+
+func (c coreLedgerEntryGetter) GetLedgerEntries(
+	ctx context.Context,
+	keys []xdr.LedgerKey,
+) ([]db.LedgerKeyAndEntry, uint32, error) {
+	atLedger := c.atLedger
+	if atLedger == 0 {
+		var err error
+		// Pass latest ledger in case Core is ahead of us (0 would be Core's latest).
+		atLedger, err = c.latestLedgerReader.GetLatestLedgerSequence(ctx)
+		if err != nil {
+			return nil, 0, fmt.Errorf("could not get latest ledger: %w", err)
+		}
+	}
+	resp, err := c.coreClient.GetLedgerEntries(ctx, atLedger, keys...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("could not query captive core: %w", err)
+	}
+
+	result := make([]db.LedgerKeyAndEntry, 0, len(resp.Entries))
+	for _, entry := range resp.Entries {
+		// This could happen if the user tries to fetch a ledger entry that
+		// doesn't exist, making it a 404 equivalent, so just skip it.
+		if entry.State == coreProto.LedgerEntryStateNew {
+			continue
+		}
+
+		var xdrEntry xdr.LedgerEntry
+		err := xdr.SafeUnmarshalBase64(entry.Entry, &xdrEntry)
+		if err != nil {
+			return nil, 0, fmt.Errorf("could not decode ledger entry: %w", err)
+		}
+
+		// Generate the entry key. We cannot simply reuse the positional keys from the request since
+		// the response may miss unknown entries or be out of order.
+		key, err := xdrEntry.LedgerKey()
+		if err != nil {
+			return nil, 0, fmt.Errorf("could not obtain ledger key: %w", err)
+		}
+		newEntry := db.LedgerKeyAndEntry{
+			Key:   key,
+			Entry: xdrEntry,
+		}
+		if entry.Ttl != 0 {
+			newEntry.LiveUntilLedgerSeq = &entry.Ttl
+		}
+		result = append(result, newEntry)
+	}
+
+	return result, atLedger, nil
+}

--- a/cmd/stellar-rpc/internal/ledgerentries/main.go
+++ b/cmd/stellar-rpc/internal/ledgerentries/main.go
@@ -84,8 +84,11 @@ func (c coreLedgerEntryGetter) GetLedgerEntries(
 			Key:   key,
 			Entry: xdrEntry,
 		}
-		if entry.Ttl != 0 {
-			newEntry.LiveUntilLedgerSeq = &entry.Ttl
+		if entry.Ttl != 0 || entry.State == coreProto.LedgerEntryStateArchived {
+			// Core doesn't provide the specific TTL in which an entry was archived.
+			// We use TTL placeholder of 0 for archived entries.
+			ttl := entry.Ttl
+			newEntry.LiveUntilLedgerSeq = &ttl
 		}
 		result = append(result, newEntry)
 	}

--- a/cmd/stellar-rpc/internal/ledgerentries/main.go
+++ b/cmd/stellar-rpc/internal/ledgerentries/main.go
@@ -25,7 +25,7 @@ func NewLedgerEntryGetter(coreClient interfaces.FastCoreClient, latestLedgerRead
 	}
 }
 
-// NewLedgerEntryAtGetter NewLedgerEntryGetter creates a LedgerEntryGetter which obtains the value of the given ledger entries at a fixed ledger
+// NewLedgerEntryAtGetter creates a LedgerEntryGetter which obtains the value of the given ledger entries at a fixed ledger
 func NewLedgerEntryAtGetter(coreClient interfaces.FastCoreClient, atLedger uint32) LedgerEntryGetter {
 	return &coreLedgerEntryGetter{
 		coreClient: coreClient,

--- a/cmd/stellar-rpc/internal/ledgerentries/main.go
+++ b/cmd/stellar-rpc/internal/ledgerentries/main.go
@@ -16,7 +16,9 @@ type LedgerEntryGetter interface {
 }
 
 // NewLedgerEntryGetter creates a LedgerEntryGetter which obtains the latest known value of the given ledger entries
-func NewLedgerEntryGetter(coreClient interfaces.FastCoreClient, latestLedgerReader db.LedgerEntryReader) LedgerEntryGetter {
+func NewLedgerEntryGetter(coreClient interfaces.FastCoreClient,
+	latestLedgerReader db.LedgerEntryReader,
+) LedgerEntryGetter {
 	return &coreLedgerEntryGetter{
 		coreClient: coreClient,
 		// use the latest ledger
@@ -25,7 +27,8 @@ func NewLedgerEntryGetter(coreClient interfaces.FastCoreClient, latestLedgerRead
 	}
 }
 
-// NewLedgerEntryAtGetter creates a LedgerEntryGetter which obtains the value of the given ledger entries at a fixed ledger
+// NewLedgerEntryAtGetter creates a LedgerEntryGetter which gets the value
+// of the given ledger entries at a fixed ledger
 func NewLedgerEntryAtGetter(coreClient interfaces.FastCoreClient, atLedger uint32) LedgerEntryGetter {
 	return &coreLedgerEntryGetter{
 		coreClient: coreClient,
@@ -60,7 +63,7 @@ func (c coreLedgerEntryGetter) GetLedgerEntries(
 	result := make([]db.LedgerKeyAndEntry, 0, len(resp.Entries))
 	for _, entry := range resp.Entries {
 		// This could happen if the user tries to fetch a ledger entry that
-		// doesn't exist, making it a 404 equivalent, so just skip it.
+		// doesn't exist, making it a 404 equivalent, so skip it.
 		if entry.State == coreProto.LedgerEntryStateNew {
 			continue
 		}

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction.go
@@ -127,7 +127,7 @@ func AddLedgerEntryChangeJSON(l *protocol.LedgerEntryChange, diff preflight.XDRD
 	return nil
 }
 
-// NewSimulateTransactionHandler returns a json rpc handler to run preflight simulations
+// NewSimulateTransactionHandler returns a JSON rpc handler to run preflight simulations
 func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.LedgerEntryReader, ledgerReader db.LedgerReader, coreClient interfaces.FastCoreClient, getter PreflightGetter) jrpc2.Handler {
 	return NewHandler(func(ctx context.Context, request protocol.SimulateTransactionRequest,
 	) protocol.SimulateTransactionResponse {

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction.go
@@ -127,8 +127,134 @@ func AddLedgerEntryChangeJSON(l *protocol.LedgerEntryChange, diff preflight.XDRD
 	return nil
 }
 
+func getRestorePreamble(preflight preflight.Preflight, format string) (*protocol.RestorePreamble, error) {
+	var restorePreamble *protocol.RestorePreamble
+	if len(preflight.PreRestoreTransactionData) == 0 {
+		return restorePreamble, nil
+	}
+	switch format {
+	case protocol.FormatJSON:
+		txDataJs, err := xdr2json.ConvertBytes(
+			xdr.SorobanTransactionData{},
+			preflight.PreRestoreTransactionData)
+		if err != nil {
+			return nil, err
+		}
+
+		restorePreamble = &protocol.RestorePreamble{
+			TransactionDataJSON: txDataJs,
+			MinResourceFee:      preflight.PreRestoreMinFee,
+		}
+
+	default:
+		restorePreamble = &protocol.RestorePreamble{
+			TransactionDataXDR: base64.StdEncoding.EncodeToString(preflight.PreRestoreTransactionData),
+			MinResourceFee:     preflight.PreRestoreMinFee,
+		}
+	}
+	return restorePreamble, nil
+}
+
+func getSimulationResults(preflight preflight.Preflight, format string) ([]protocol.SimulateHostFunctionResult, error) {
+	var results []protocol.SimulateHostFunctionResult
+	if len(preflight.Result) == 0 {
+		return nil, nil
+	}
+	switch format {
+	case protocol.FormatJSON:
+		rvJs, err := xdr2json.ConvertBytes(xdr.ScVal{}, preflight.Result)
+		if err != nil {
+			return nil, err
+		}
+
+		auths, err := jsonifySlice(xdr.SorobanAuthorizationEntry{}, preflight.Auth)
+		if err != nil {
+			return nil, err
+		}
+
+		results = []protocol.SimulateHostFunctionResult{
+			{
+				ReturnValueJSON: rvJs,
+				AuthJSON:        auths,
+			},
+		}
+
+	default:
+		rv := base64.StdEncoding.EncodeToString(preflight.Result)
+		auth := base64EncodeSlice(preflight.Auth)
+		results = []protocol.SimulateHostFunctionResult{
+			{
+				ReturnValueXDR: &rv,
+				AuthXDR:        &auth,
+			},
+		}
+	}
+	return results, nil
+}
+
+func formatResponse(preflight preflight.Preflight, format string, latestLedger uint32) (protocol.SimulateTransactionResponse, error) {
+	results, err := getSimulationResults(preflight, format)
+	if err != nil {
+		return protocol.SimulateTransactionResponse{}, err
+	}
+
+	restorePreamble, err := getRestorePreamble(preflight, format)
+	if err != nil {
+		return protocol.SimulateTransactionResponse{}, err
+	}
+
+	stateChanges := make([]protocol.LedgerEntryChange, len(preflight.LedgerEntryDiff))
+	for i := range stateChanges {
+		var err error
+		change, err := LedgerEntryChangeFromXDRDiff(preflight.LedgerEntryDiff[i], format)
+		if err != nil {
+			// Intentionally ignore "no before and after" entries because
+			// they're possible but shouldn't result in a full failure.
+			if errors.Is(err, errMissingDiff) {
+				continue
+			}
+			return protocol.SimulateTransactionResponse{}, err
+		}
+
+		stateChanges[i] = change
+	}
+
+	simResp := protocol.SimulateTransactionResponse{
+		Error:           preflight.Error,
+		Results:         results,
+		MinResourceFee:  preflight.MinFee,
+		LatestLedger:    latestLedger,
+		RestorePreamble: restorePreamble,
+		StateChanges:    stateChanges,
+	}
+
+	switch format {
+	case protocol.FormatJSON:
+		simResp.TransactionDataJSON, err = xdr2json.ConvertBytes(
+			xdr.SorobanTransactionData{},
+			preflight.TransactionData)
+		if err != nil {
+			return protocol.SimulateTransactionResponse{}, err
+		}
+
+		simResp.EventsJSON, err = jsonifySlice(xdr.DiagnosticEvent{}, preflight.Events)
+		if err != nil {
+			return protocol.SimulateTransactionResponse{}, err
+		}
+
+	default:
+		simResp.EventsXDR = base64EncodeSlice(preflight.Events)
+		simResp.TransactionDataXDR = base64.StdEncoding.EncodeToString(preflight.TransactionData)
+	}
+
+	return simResp, nil
+}
+
 // NewSimulateTransactionHandler returns a JSON rpc handler to run preflight simulations
-func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.LedgerEntryReader, ledgerReader db.LedgerReader, coreClient interfaces.FastCoreClient, getter PreflightGetter) jrpc2.Handler {
+func NewSimulateTransactionHandler(logger *log.Entry,
+	ledgerEntryReader db.LedgerEntryReader, ledgerReader db.LedgerReader,
+	coreClient interfaces.FastCoreClient, getter PreflightGetter,
+) jrpc2.Handler {
 	return NewHandler(func(ctx context.Context, request protocol.SimulateTransactionRequest,
 	) protocol.SimulateTransactionResponse {
 		if err := protocol.IsValidFormat(request.Format); err != nil {
@@ -183,7 +309,8 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		bucketListSize, protocolVersion, err := getBucketListSizeAndProtocolVersion(ctx, ledgerReader, latestLedger)
 		if err != nil {
 			return protocol.SimulateTransactionResponse{
-				Error: err.Error(),
+				Error:        err.Error(),
+				LatestLedger: latestLedger,
 			}
 		}
 
@@ -210,121 +337,13 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 			}
 		}
 
-		var results []protocol.SimulateHostFunctionResult
-		if len(result.Result) != 0 {
-			switch request.Format {
-			case protocol.FormatJSON:
-				rvJs, err := xdr2json.ConvertBytes(xdr.ScVal{}, result.Result)
-				if err != nil {
-					return protocol.SimulateTransactionResponse{
-						Error:        err.Error(),
-						LatestLedger: latestLedger,
-					}
-				}
-
-				auths, err := jsonifySlice(xdr.SorobanAuthorizationEntry{}, result.Auth)
-				if err != nil {
-					return protocol.SimulateTransactionResponse{
-						Error:        err.Error(),
-						LatestLedger: latestLedger,
-					}
-				}
-
-				results = append(results, protocol.SimulateHostFunctionResult{
-					ReturnValueJSON: rvJs,
-					AuthJSON:        auths,
-				})
-
-			default:
-				rv := base64.StdEncoding.EncodeToString(result.Result)
-				auth := base64EncodeSlice(result.Auth)
-				results = append(results, protocol.SimulateHostFunctionResult{
-					ReturnValueXDR: &rv,
-					AuthXDR:        &auth,
-				})
+		simResp, err := formatResponse(result, request.Format, latestLedger)
+		if err != nil {
+			return protocol.SimulateTransactionResponse{
+				Error:        err.Error(),
+				LatestLedger: latestLedger,
 			}
 		}
-
-		var restorePreamble *protocol.RestorePreamble
-		if len(result.PreRestoreTransactionData) != 0 {
-			switch request.Format {
-			case protocol.FormatJSON:
-				txDataJs, err := xdr2json.ConvertBytes(
-					xdr.SorobanTransactionData{},
-					result.PreRestoreTransactionData)
-				if err != nil {
-					return protocol.SimulateTransactionResponse{
-						Error:        err.Error(),
-						LatestLedger: latestLedger,
-					}
-				}
-
-				restorePreamble = &protocol.RestorePreamble{
-					TransactionDataJSON: txDataJs,
-					MinResourceFee:      result.PreRestoreMinFee,
-				}
-
-			default:
-				restorePreamble = &protocol.RestorePreamble{
-					TransactionDataXDR: base64.StdEncoding.EncodeToString(result.PreRestoreTransactionData),
-					MinResourceFee:     result.PreRestoreMinFee,
-				}
-			}
-		}
-
-		stateChanges := make([]protocol.LedgerEntryChange, len(result.LedgerEntryDiff))
-		for i := range stateChanges {
-			var err error
-			change, err := LedgerEntryChangeFromXDRDiff(result.LedgerEntryDiff[i], request.Format)
-			if err != nil {
-				// Intentionally ignore "no before and after" entries because
-				// they're possible but shouldn't result in a full failure.
-				if errors.Is(err, errMissingDiff) {
-					continue
-				}
-				return protocol.SimulateTransactionResponse{
-					Error:        err.Error(),
-					LatestLedger: latestLedger,
-				}
-			}
-
-			stateChanges[i] = change
-		}
-
-		simResp := protocol.SimulateTransactionResponse{
-			Error:           result.Error,
-			Results:         results,
-			MinResourceFee:  result.MinFee,
-			LatestLedger:    latestLedger,
-			RestorePreamble: restorePreamble,
-			StateChanges:    stateChanges,
-		}
-
-		switch request.Format {
-		case protocol.FormatJSON:
-			simResp.TransactionDataJSON, err = xdr2json.ConvertBytes(
-				xdr.SorobanTransactionData{},
-				result.TransactionData)
-			if err != nil {
-				return protocol.SimulateTransactionResponse{
-					Error:        err.Error(),
-					LatestLedger: latestLedger,
-				}
-			}
-
-			simResp.EventsJSON, err = jsonifySlice(xdr.DiagnosticEvent{}, result.Events)
-			if err != nil {
-				return protocol.SimulateTransactionResponse{
-					Error:        err.Error(),
-					LatestLedger: latestLedger,
-				}
-			}
-
-		default:
-			simResp.EventsXDR = base64EncodeSlice(result.Events)
-			simResp.TransactionDataXDR = base64.StdEncoding.EncodeToString(result.TransactionData)
-		}
-
 		return simResp
 	})
 }

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction.go
@@ -192,7 +192,9 @@ func getSimulationResults(preflight preflight.Preflight, format string) ([]proto
 	return results, nil
 }
 
-func formatResponse(preflight preflight.Preflight, format string, latestLedger uint32) (protocol.SimulateTransactionResponse, error) {
+func formatResponse(preflight preflight.Preflight,
+	format string, latestLedger uint32,
+) (protocol.SimulateTransactionResponse, error) {
 	results, err := getSimulationResults(preflight, format)
 	if err != nil {
 		return protocol.SimulateTransactionResponse{}, err

--- a/cmd/stellar-rpc/internal/preflight/pool.go
+++ b/cmd/stellar-rpc/internal/preflight/pool.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/daemon/interfaces"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/ledgerentries"
+	"github.com/stellar/stellar-rpc/protocol"
 )
 
 const (
@@ -50,14 +52,12 @@ type WorkerPoolConfig struct {
 	WorkerCount       uint
 	JobQueueCapacity  uint
 	EnableDebug       bool
-	LedgerEntryReader db.LedgerEntryReader
 	NetworkPassphrase string
 	Logger            *log.Entry
 }
 
 func NewPreflightWorkerPool(cfg WorkerPoolConfig) *WorkerPool {
 	preflightWP := WorkerPool{
-		ledgerEntryReader: cfg.LedgerEntryReader,
 		networkPassphrase: cfg.NetworkPassphrase,
 		enableDebug:       cfg.EnableDebug,
 		logger:            cfg.Logger,
@@ -140,33 +140,45 @@ func (pwp *WorkerPool) Close() {
 
 var ErrPreflightQueueFull = errors.New("preflight queue full")
 
-type metricsLedgerEntryWrapper struct {
-	db.LedgerEntryReadTx
+type metricsLedgerEntryGetterWrapper struct {
+	ledgerentries.LedgerEntryGetter
 	totalDurationMs      uint64
 	ledgerEntriesFetched uint32
 }
 
-func (m *metricsLedgerEntryWrapper) GetLedgerEntries(keys ...xdr.LedgerKey) ([]db.LedgerKeyAndEntry, error) {
+func (m *metricsLedgerEntryGetterWrapper) GetLedgerEntries(ctx context.Context, keys []xdr.LedgerKey) ([]db.LedgerKeyAndEntry, uint32, error) {
 	startTime := time.Now()
-	entries, err := m.LedgerEntryReadTx.GetLedgerEntries(keys...)
+	entries, seq, err := m.LedgerEntryGetter.GetLedgerEntries(ctx, keys)
 	atomic.AddUint64(&m.totalDurationMs, uint64(time.Since(startTime).Milliseconds()))
 	atomic.AddUint32(&m.ledgerEntriesFetched, uint32(len(keys)))
-	return entries, err
+	return entries, seq, err
+}
+
+type GetterParameters struct {
+	BucketListSize    uint64
+	SourceAccount     xdr.AccountId
+	OperationBody     xdr.OperationBody
+	Footprint         xdr.LedgerFootprint
+	ResourceConfig    protocol.ResourceConfig
+	ProtocolVersion   uint32
+	LedgerEntryGetter ledgerentries.LedgerEntryGetter
+	LedgerSeq         uint32
 }
 
 func (pwp *WorkerPool) GetPreflight(ctx context.Context, params GetterParameters) (Preflight, error) {
 	if pwp.isClosed.Load() {
 		return Preflight{}, errors.New("preflight worker pool is closed")
 	}
-	wrappedTx := metricsLedgerEntryWrapper{
-		LedgerEntryReadTx: params.LedgerEntryReadTx,
+	wrappedGetter := &metricsLedgerEntryGetterWrapper{
+		LedgerEntryGetter: params.LedgerEntryGetter,
 	}
 	preflightParams := Parameters{
 		Logger:            pwp.logger,
 		SourceAccount:     params.SourceAccount,
 		OpBody:            params.OperationBody,
 		NetworkPassphrase: pwp.networkPassphrase,
-		LedgerEntryReadTx: &wrappedTx,
+		LedgerEntryGetter: wrappedGetter,
+		LedgerSeq:         params.LedgerSeq,
 		BucketListSize:    params.BucketListSize,
 		Footprint:         params.Footprint,
 		ResourceConfig:    params.ResourceConfig,
@@ -177,16 +189,16 @@ func (pwp *WorkerPool) GetPreflight(ctx context.Context, params GetterParameters
 	select {
 	case pwp.requestChan <- workerRequest{ctx, preflightParams, resultC}:
 		result := <-resultC
-		if wrappedTx.ledgerEntriesFetched > 0 {
+		if wrappedGetter.ledgerEntriesFetched > 0 {
 			status := "ok"
 			if result.err != nil {
 				status = "error"
 			}
 			pwp.durationMetric.With(
 				prometheus.Labels{"type": "db", "status": status},
-			).Observe(float64(wrappedTx.totalDurationMs) / dbMetricsDurationConversionValue)
+			).Observe(float64(wrappedGetter.totalDurationMs) / dbMetricsDurationConversionValue)
 		}
-		pwp.ledgerEntriesFetchedMetric.Observe(float64(wrappedTx.ledgerEntriesFetched))
+		pwp.ledgerEntriesFetchedMetric.Observe(float64(wrappedGetter.ledgerEntriesFetched))
 		return result.preflight, result.err
 	case <-ctx.Done():
 		return Preflight{}, ctx.Err()

--- a/cmd/stellar-rpc/internal/preflight/pool.go
+++ b/cmd/stellar-rpc/internal/preflight/pool.go
@@ -146,7 +146,9 @@ type metricsLedgerEntryGetterWrapper struct {
 	ledgerEntriesFetched uint32
 }
 
-func (m *metricsLedgerEntryGetterWrapper) GetLedgerEntries(ctx context.Context, keys []xdr.LedgerKey) ([]db.LedgerKeyAndEntry, uint32, error) {
+func (m *metricsLedgerEntryGetterWrapper) GetLedgerEntries(ctx context.Context,
+	keys []xdr.LedgerKey,
+) ([]db.LedgerKeyAndEntry, uint32, error) {
 	startTime := time.Now()
 	entries, seq, err := m.LedgerEntryGetter.GetLedgerEntries(ctx, keys)
 	atomic.AddUint64(&m.totalDurationMs, uint64(time.Since(startTime).Milliseconds()))

--- a/cmd/stellar-rpc/internal/preflight/preflight.go
+++ b/cmd/stellar-rpc/internal/preflight/preflight.go
@@ -33,7 +33,7 @@ import (
 
 type snapshotSourceHandle struct {
 	ledgerEntryGetter ledgerentries.LedgerEntryGetter
-	ctx               context.Context
+	ctx               context.Context //nolint:containedctx
 	logger            *log.Entry
 }
 

--- a/cmd/stellar-rpc/internal/preflight/preflight.go
+++ b/cmd/stellar-rpc/internal/preflight/preflight.go
@@ -20,7 +20,6 @@ import "C"
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"runtime/cgo"
 	"time"
 	"unsafe"
@@ -34,7 +33,6 @@ import (
 
 type snapshotSourceHandle struct {
 	ledgerEntryGetter ledgerentries.LedgerEntryGetter
-	pinner            runtime.Pinner
 	ctx               context.Context //nolint:containedctx
 	logger            *log.Entry
 }
@@ -199,7 +197,6 @@ func getFootprintTTLPreflight(ctx context.Context, params Parameters) (Preflight
 		ctx:               ctx,
 		logger:            params.Logger,
 	}
-	defer ssh.pinner.Unpin()
 	handle := cgo.NewHandle(ssh)
 	defer handle.Delete()
 
@@ -233,7 +230,6 @@ func getInvokeHostFunctionPreflight(ctx context.Context, params Parameters) (Pre
 		ctx:               ctx,
 		logger:            params.Logger,
 	}
-	defer ssh.pinner.Unpin()
 	handle := cgo.NewHandle(ssh)
 	defer handle.Delete()
 	resourceConfig := C.resource_config_t{

--- a/cmd/stellar-rpc/internal/preflight/preflight.go
+++ b/cmd/stellar-rpc/internal/preflight/preflight.go
@@ -37,11 +37,8 @@ type snapshotSourceHandle struct {
 	logger            *log.Entry
 }
 
-const (
-
-	// Current base reserve is 0.5XLM (in stroops)
-	defaultBaseReserve = 5_000_000
-)
+// Current base reserve is 0.5XLM (in stroops)
+const defaultBaseReserve = 5_000_000
 
 // SnapshotSourceGet takes a LedgerKey XDR in base64 string and returns its matching LedgerEntry XDR in base64 string
 // It's used by the Rust preflight code to obtain ledger entries.

--- a/cmd/stellar-rpc/internal/preflight/preflight_test.go
+++ b/cmd/stellar-rpc/internal/preflight/preflight_test.go
@@ -215,7 +215,8 @@ var mockLedgerEntries = func() []xdr.LedgerEntry {
 	for _, entry := range mockLedgerEntriesWithoutTTLs {
 		result = append(result, entry)
 
-		if entry.Data.Type == xdr.LedgerEntryTypeContractData || entry.Data.Type == xdr.LedgerEntryTypeContractCode {
+		switch entry.Data.Type {
+		case xdr.LedgerEntryTypeContractData | xdr.LedgerEntryTypeContractCode:
 			key, err := entry.LedgerKey()
 			if err != nil {
 				panic(err)

--- a/cmd/stellar-rpc/internal/preflight/preflight_test.go
+++ b/cmd/stellar-rpc/internal/preflight/preflight_test.go
@@ -216,7 +216,7 @@ var mockLedgerEntries = func() []xdr.LedgerEntry {
 		result = append(result, entry)
 
 		switch entry.Data.Type {
-		case xdr.LedgerEntryTypeContractData | xdr.LedgerEntryTypeContractCode:
+		case xdr.LedgerEntryTypeContractData, xdr.LedgerEntryTypeContractCode:
 			key, err := entry.LedgerKey()
 			if err != nil {
 				panic(err)
@@ -276,7 +276,7 @@ func (m inMemoryLedgerEntryGetter) GetLedgerEntries(
 			Entry: entry,
 		}
 		switch entry.Data.Type {
-		case xdr.LedgerEntryTypeContractData | xdr.LedgerEntryTypeContractCode:
+		case xdr.LedgerEntryTypeContractData, xdr.LedgerEntryTypeContractCode:
 			// Make sure it doesn't ttl
 			ttl := uint32(entryTTLValue)
 			toAppend.LiveUntilLedgerSeq = &ttl

--- a/cmd/stellar-rpc/internal/preflight/preflight_test.go
+++ b/cmd/stellar-rpc/internal/preflight/preflight_test.go
@@ -215,8 +215,7 @@ var mockLedgerEntries = func() []xdr.LedgerEntry {
 	for _, entry := range mockLedgerEntriesWithoutTTLs {
 		result = append(result, entry)
 
-		switch entry.Data.Type {
-		case xdr.LedgerEntryTypeContractData, xdr.LedgerEntryTypeContractCode:
+		if entry.Data.Type == xdr.LedgerEntryTypeContractData || entry.Data.Type == xdr.LedgerEntryTypeContractCode {
 			key, err := entry.LedgerKey()
 			if err != nil {
 				panic(err)
@@ -275,8 +274,7 @@ func (m inMemoryLedgerEntryGetter) GetLedgerEntries(
 			Key:   key,
 			Entry: entry,
 		}
-		switch entry.Data.Type {
-		case xdr.LedgerEntryTypeContractData, xdr.LedgerEntryTypeContractCode:
+		if entry.Data.Type == xdr.LedgerEntryTypeContractData || entry.Data.Type == xdr.LedgerEntryTypeContractCode {
 			// Make sure it doesn't ttl
 			ttl := uint32(entryTTLValue)
 			toAppend.LiveUntilLedgerSeq = &ttl

--- a/cmd/stellar-rpc/internal/preflight/preflight_test.go
+++ b/cmd/stellar-rpc/internal/preflight/preflight_test.go
@@ -253,7 +253,10 @@ type inMemoryLedgerEntryGetter struct {
 	latestLedgerSequence uint32
 }
 
-func (m inMemoryLedgerEntryGetter) GetLedgerEntries(ctx context.Context, keys []xdr.LedgerKey) ([]db.LedgerKeyAndEntry, uint32, error) {
+func (m inMemoryLedgerEntryGetter) GetLedgerEntries(
+	_ context.Context,
+	keys []xdr.LedgerKey,
+) ([]db.LedgerKeyAndEntry, uint32, error) {
 	result := make([]db.LedgerKeyAndEntry, 0, len(keys))
 	for _, key := range keys {
 		serializedKey, err := key.MarshalBinaryBase64()
@@ -273,7 +276,9 @@ func (m inMemoryLedgerEntryGetter) GetLedgerEntries(ctx context.Context, keys []
 	return result, m.latestLedgerSequence, nil
 }
 
-func newInMemoryLedgerEntryGetter(entries []xdr.LedgerEntry, latestLedgerSeq uint32) (inMemoryLedgerEntryGetter, error) {
+func newInMemoryLedgerEntryGetter(
+	entries []xdr.LedgerEntry, latestLedgerSeq uint32,
+) (inMemoryLedgerEntryGetter, error) {
 	entriesMap := make(map[string]xdr.LedgerEntry, len(entries))
 	for _, entry := range entries {
 		key, err := entry.LedgerKey()

--- a/cmd/stellar-rpc/lib/preflight.h
+++ b/cmd/stellar-rpc/lib/preflight.h
@@ -60,9 +60,13 @@ preflight_result_t *preflight_footprint_ttl_op(uintptr_t   handle, // Go Handle 
                                                const ledger_info_t ledger_info);
 
 
-// LedgerKey XDR to LedgerEntry XDR
-extern xdr_t SnapshotSourceGet(uintptr_t handle, xdr_t ledger_key);
+// LedgerKey XDR to LedgerEntry XDR AND TTL
+typedef struct ledger_entry_and_ttl_t {
+    xdr_t entry;
+    int64_t ttl; // TTL missing if -1
+} ledger_entry_and_ttl_t;
+extern ledger_entry_and_ttl_t SnapshotSourceGet(uintptr_t handle, xdr_t ledger_key);
 
 void free_preflight_result(preflight_result_t *result);
 
-extern void FreeGoXDR(xdr_t xdr);
+extern void FreeGoLedgerEntryAndTTL(ledger_entry_and_ttl_t ledger_entry_and_ttl);

--- a/cmd/stellar-rpc/lib/preflight/src/lib.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/lib.rs
@@ -322,12 +322,19 @@ fn free_c_xdr_diff_array(xdr_array: CXDRDiffVector) {
     }
 }
 
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct CLedgerEntryAndTTL {
+    pub entry: CXDR,
+    pub ttl: i64, // -1 indicates that the TTL is missing
+}
+
 // Functions imported from Golang
 extern "C" {
-    // Free Strings returned from Go functions
-    fn FreeGoXDR(xdr: CXDR);
-    // LedgerKey XDR in base64 string to LedgerEntry XDR in base64 string
-    fn SnapshotSourceGet(handle: libc::uintptr_t, ledger_key: CXDR) -> CXDR;
+    // Free data returned from Go functions
+    fn FreeGoLedgerEntryAndTTL(ledger_entry_and_ttl: CLedgerEntryAndTTL);
+    // LedgerKey XDR to LedgerEntry XDR and TTL
+    fn SnapshotSourceGet(handle: libc::uintptr_t, ledger_key: CXDR) -> CLedgerEntryAndTTL;
 }
 
 struct GoLedgerStorage {
@@ -343,19 +350,23 @@ impl GoLedgerStorage {
         }
     }
 
-    // Get the XDR, regardless of ttl
-    fn get_xdr_internal(&self, key_xdr: &mut Vec<u8>) -> Option<Vec<u8>> {
+    // Get the entry XDR and TTL
+    fn get_xdr_internal(&self, key_xdr: &mut Vec<u8>) -> Option<(Vec<u8>, Option<u32>)> {
         let key_c_xdr = CXDR {
             xdr: key_xdr.as_mut_ptr(),
             len: key_xdr.len(),
         };
         let res = unsafe { SnapshotSourceGet(self.golang_handle, key_c_xdr) };
-        if res.xdr.is_null() {
+        if res.entry.xdr.is_null() {
             return None;
         }
-        let v = unsafe { from_c_xdr(res) };
-        unsafe { FreeGoXDR(res) };
-        Some(v)
+        let v = unsafe { from_c_xdr(res.entry) };
+        unsafe { FreeGoLedgerEntryAndTTL(res) };
+        if res.ttl < 0 {
+            Some((v, None))
+        } else {
+            Some((v, Some(res.ttl as u32)))
+        }
     }
 }
 

--- a/cmd/stellar-rpc/lib/preflight/src/lib.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/lib.rs
@@ -365,7 +365,8 @@ impl GoLedgerStorage {
         if res.ttl < 0 {
             Some((v, None))
         } else {
-            Some((v, Some(res.ttl as u32)))
+            let ttl = u32::try_from(res.ttl).ok()?;
+            Some((v, Some(ttl)))
         }
     }
 }

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -14,9 +14,8 @@
 
 use super::soroban_env_host::storage::EntryWithLiveUntil;
 use super::soroban_env_host::xdr::{
-    AccountId, ExtendFootprintTtlOp, InvokeHostFunctionOp, LedgerEntry,
-    LedgerFootprint, LedgerKey, OperationBody, ReadXdr, ScErrorCode, ScErrorType,
-    SorobanTransactionData, WriteXdr,
+    AccountId, ExtendFootprintTtlOp, InvokeHostFunctionOp, LedgerEntry, LedgerFootprint, LedgerKey,
+    OperationBody, ReadXdr, ScErrorCode, ScErrorType, SorobanTransactionData, WriteXdr,
 };
 use super::soroban_env_host::{HostError, LedgerInfo, DEFAULT_XDR_RW_LIMITS};
 use super::soroban_simulation::simulation::{

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -14,9 +14,9 @@
 
 use super::soroban_env_host::storage::EntryWithLiveUntil;
 use super::soroban_env_host::xdr::{
-    AccountId, ExtendFootprintTtlOp, Hash, InvokeHostFunctionOp, LedgerEntry, LedgerEntryData,
-    LedgerFootprint, LedgerKey, LedgerKeyTtl, OperationBody, ReadXdr, ScErrorCode, ScErrorType,
-    SorobanTransactionData, TtlEntry, WriteXdr,
+    AccountId, ExtendFootprintTtlOp, InvokeHostFunctionOp, LedgerEntry,
+    LedgerFootprint, LedgerKey, OperationBody, ReadXdr, ScErrorCode, ScErrorType,
+    SorobanTransactionData, WriteXdr,
 };
 use super::soroban_env_host::{HostError, LedgerInfo, DEFAULT_XDR_RW_LIMITS};
 use super::soroban_simulation::simulation::{
@@ -33,7 +33,7 @@ use super::soroban_simulation::{
 // of the `shared` module import the same definitions for these.
 
 use crate::{
-    anyhow, bail, extract_error_string, from_c_string, from_c_xdr, string_to_c, vec_to_c_array,
+    anyhow, extract_error_string, from_c_string, from_c_xdr, string_to_c, vec_to_c_array,
     CLedgerInfo, CPreflightResult, CResourceConfig, CXDRDiff, CXDRDiffVector, CXDRVector, Digest,
     GoLedgerStorage, Result, Sha256, CXDR,
 };
@@ -312,41 +312,9 @@ fn get_fallible_from_go_ledger_storage(
     key: &LedgerKey,
 ) -> Result<Option<EntryWithLiveUntil>> {
     let mut key_xdr = key.to_xdr(DEFAULT_XDR_RW_LIMITS)?;
-    let Some(xdr) = storage.get_xdr_internal(&mut key_xdr) else {
+    let Some((xdr, live_until_ledger_seq)) = storage.get_xdr_internal(&mut key_xdr) else {
         return Ok(None);
     };
-
-    let live_until_ledger_seq = match key {
-        // TODO: it would probably be more efficient to do all of this in the Go side
-        //       (e.g. it would allow us to query multiple entries at once)
-        LedgerKey::ContractData(_) | LedgerKey::ContractCode(_) => {
-            let key_hash: [u8; 32] = Sha256::digest(key_xdr).into();
-            let ttl_key = LedgerKey::Ttl(LedgerKeyTtl {
-                key_hash: Hash(key_hash),
-            });
-            let mut ttl_key_xdr = ttl_key.to_xdr(DEFAULT_XDR_RW_LIMITS)?;
-            let ttl_entry_xdr = storage.get_xdr_internal(&mut ttl_key_xdr).ok_or_else(|| {
-                anyhow!(
-                    "TTL entry is missing for an entry that should have TTL with key: '{key:?}'"
-                )
-            })?;
-            let ttl_entry = LedgerEntry::from_xdr(ttl_entry_xdr, DEFAULT_XDR_RW_LIMITS)?;
-            let LedgerEntryData::Ttl(TtlEntry {
-                live_until_ledger_seq,
-                ..
-            }) = ttl_entry.data
-            else {
-                bail!(
-                    "unexpected non-TTL entry '{:?}' has been fetched for TTL key '{:?}'",
-                    ttl_entry,
-                    ttl_key
-                );
-            };
-            Some(live_until_ledger_seq)
-        }
-        _ => None,
-    };
-
     let entry = LedgerEntry::from_xdr(xdr, DEFAULT_XDR_RW_LIMITS)?;
     Ok(Some((Rc::new(entry), live_until_ledger_seq)))
 }


### PR DESCRIPTION
### What

Closes https://github.com/stellar/stellar-rpc/issues/368 by querying ledger entries for simulationTransaction through core

It also makes Core ledger-entry querying mandatory (removing the optionality introduced in https://github.com/stellar/stellar-rpc/pull/353 )

### Why

From protocol 23 Core will be handling ledger entries.

### Known limitations

Simulations may be slower