### PR TITLE
Add support for flexible topics length matching using wildcard in getEvents

### DIFF
--- a/cmd/stellar-rpc/internal/methods/get_events_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_events_test.go
@@ -381,7 +381,7 @@ func TestGetEvents(t *testing.T) {
 	t.Run("filtering by topic, flexible length matching", func(t *testing.T) {
 		doubleStar := "**"
 		dbx := newTestDB(t)
-		ctx := context.TODO()
+		ctx := t.Context()
 		log := log.DefaultLogger
 		log.SetLevel(logrus.TraceLevel)
 
@@ -439,7 +439,7 @@ func TestGetEvents(t *testing.T) {
 		require.NoError(t, err)
 
 		// strict topic length matching by default
-		results, err := handler.getEvents(context.TODO(), protocol.GetEventsRequest{
+		results, err := handler.getEvents(t.Context(), protocol.GetEventsRequest{
 			StartLedger: 1,
 			Filters: []protocol.EventFilter{
 				{
@@ -448,7 +448,8 @@ func TestGetEvents(t *testing.T) {
 							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter}},
 							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number}},
 						},
-					}},
+					},
+				},
 			},
 		})
 		require.NoError(t, err)
@@ -465,7 +466,7 @@ func TestGetEvents(t *testing.T) {
 		)
 
 		// strict topic length matching
-		results, err = handler.getEvents(context.TODO(), protocol.GetEventsRequest{
+		results, err = handler.getEvents(t.Context(), protocol.GetEventsRequest{
 			StartLedger: 1,
 			Filters: []protocol.EventFilter{
 				{
@@ -474,7 +475,8 @@ func TestGetEvents(t *testing.T) {
 							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter}},
 							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number}},
 						},
-					}},
+					},
+				},
 			},
 		})
 		require.NoError(t, err)
@@ -502,7 +504,8 @@ func TestGetEvents(t *testing.T) {
 							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number}},
 							{Wildcard: &doubleStar},
 						},
-					}},
+					},
+				},
 			},
 		})
 		require.NoError(t, err)

--- a/cmd/stellar-rpc/internal/methods/get_events_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_events_test.go
@@ -379,6 +379,7 @@ func TestGetEvents(t *testing.T) {
 	})
 
 	t.Run("filtering by topic, flexible length matching", func(t *testing.T) {
+		doubleStar := "**"
 		dbx := newTestDB(t)
 		ctx := context.TODO()
 		log := log.DefaultLogger
@@ -468,7 +469,6 @@ func TestGetEvents(t *testing.T) {
 			StartLedger: 1,
 			Filters: []protocol.EventFilter{
 				{
-					FlexibleTopicLength: false,
 					Topics: []protocol.TopicFilter{
 						[]protocol.SegmentFilter{
 							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter}},
@@ -496,11 +496,11 @@ func TestGetEvents(t *testing.T) {
 			Format:      protocol.FormatJSON,
 			Filters: []protocol.EventFilter{
 				{
-					FlexibleTopicLength: true,
 					Topics: []protocol.TopicFilter{
 						[]protocol.SegmentFilter{
 							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter}},
 							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number}},
+							{Wildcard: &doubleStar},
 						},
 					}},
 			},

--- a/cmd/stellar-rpc/internal/methods/get_events_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_events_test.go
@@ -379,7 +379,7 @@ func TestGetEvents(t *testing.T) {
 	})
 
 	t.Run("filtering by topic, flexible length matching", func(t *testing.T) {
-		doubleStar := "**"
+		wildCardZeroOrMore := "**"
 		dbx := newTestDB(t)
 		ctx := t.Context()
 		log := log.DefaultLogger
@@ -502,7 +502,7 @@ func TestGetEvents(t *testing.T) {
 						[]protocol.SegmentFilter{
 							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter}},
 							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number}},
-							{Wildcard: &doubleStar},
+							{Wildcard: &wildCardZeroOrMore},
 						},
 					},
 				},

--- a/cmd/stellar-rpc/internal/methods/get_events_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_events_test.go
@@ -394,7 +394,8 @@ func TestGetEvents(t *testing.T) {
 
 		var txMeta []xdr.TransactionMeta
 		contractID := xdr.Hash([32]byte{})
-		for i := range []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9} {
+		contractCount := 10
+		for i := range contractCount {
 			number := xdr.Uint64(i)
 			txMeta = append(txMeta, transactionMetaWithEvents(
 				// Generate a unique topic like /counter/4 for each event so we can check
@@ -493,23 +494,6 @@ func TestGetEvents(t *testing.T) {
 		)
 
 		// flexible topic length matching
-		results, err = handler.getEvents(ctx, protocol.GetEventsRequest{
-			StartLedger: 1,
-			Format:      protocol.FormatJSON,
-			Filters: []protocol.EventFilter{
-				{
-					Topics: []protocol.TopicFilter{
-						[]protocol.SegmentFilter{
-							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter}},
-							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number}},
-							{Wildcard: &wildCardZeroOrMore},
-						},
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-
 		expected := []protocol.EventInfo{
 			{
 				EventType:                protocol.EventTypeContract,
@@ -525,6 +509,39 @@ func TestGetEvents(t *testing.T) {
 				OpIndex:                  0,
 			},
 		}
+		require.NoError(t, err)
+
+		results, err = handler.getEvents(ctx, protocol.GetEventsRequest{
+			StartLedger: 1,
+			Format:      protocol.FormatJSON,
+			Filters: []protocol.EventFilter{
+				{
+					Topics: []protocol.TopicFilter{
+						[]protocol.SegmentFilter{
+							{Wildcard: &wildCardZeroOrMore},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, contractCount, len(results.Events))
+
+		results, err = handler.getEvents(ctx, protocol.GetEventsRequest{
+			StartLedger: 1,
+			Format:      protocol.FormatJSON,
+			Filters: []protocol.EventFilter{
+				{
+					Topics: []protocol.TopicFilter{
+						[]protocol.SegmentFilter{
+							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter}},
+							{ScVal: &xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number}},
+							{Wildcard: &wildCardZeroOrMore},
+						},
+					},
+				},
+			},
+		})
 		require.NoError(t, err)
 
 		//

--- a/cmd/stellar-rpc/internal/methods/get_events_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_events_test.go
@@ -379,7 +379,7 @@ func TestGetEvents(t *testing.T) {
 	})
 
 	t.Run("filtering by topic, flexible length matching", func(t *testing.T) {
-		wildCardZeroOrMore := "**"
+		wildCardZeroOrMore := protocol.WildCardZeroOrMore
 		dbx := newTestDB(t)
 		ctx := t.Context()
 		log := log.DefaultLogger

--- a/cmd/stellar-rpc/internal/methods/get_events_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_events_test.go
@@ -525,7 +525,7 @@ func TestGetEvents(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		assert.Equal(t, contractCount, len(results.Events))
+		assert.Len(t, results.Events, contractCount)
 
 		results, err = handler.getEvents(ctx, protocol.GetEventsRequest{
 			StartLedger: 1,

--- a/protocol/get_events.go
+++ b/protocol/get_events.go
@@ -333,9 +333,18 @@ func (s *SegmentFilter) Valid() error {
 	if s.Wildcard == nil && s.ScVal == nil {
 		return errors.New("must set either wildcard or scval")
 	}
-	if s.Wildcard != nil && *s.Wildcard != WildCardExactOne {
-		return errors.New("wildcard must be '*'")
+
+	if s.Wildcard != nil {
+		switch *s.Wildcard {
+		case WildCardExactOne:
+			return nil
+		case WildCardZeroOrMore:
+			return errors.New("wildcard '**' is only allowed as the last segment")
+		default:
+			return errors.New("wildcard must be '*'")
+		}
 	}
+
 	return nil
 }
 

--- a/protocol/get_events.go
+++ b/protocol/get_events.go
@@ -145,9 +145,10 @@ func (e EventTypeSet) matches(event xdr.ContractEvent) bool {
 }
 
 type EventFilter struct {
-	EventType   EventTypeSet  `json:"type,omitempty"`
-	ContractIDs []string      `json:"contractIds,omitempty"`
-	Topics      []TopicFilter `json:"topics,omitempty"`
+	EventType           EventTypeSet  `json:"type,omitempty"`
+	ContractIDs         []string      `json:"contractIds,omitempty"`
+	Topics              []TopicFilter `json:"topics,omitempty"`
+	FlexibleTopicLength bool          `json:"flexibleTopicLength,omitempty"`
 }
 
 type GetEventsRequest struct {
@@ -225,7 +226,7 @@ func (e *EventFilter) matchesTopics(event xdr.ContractEvent) bool {
 		return false
 	}
 	for _, topicFilter := range e.Topics {
-		if topicFilter.Matches(v0.Topics) {
+		if topicFilter.Matches(v0.Topics, e.FlexibleTopicLength) {
 			return true
 		}
 	}
@@ -252,8 +253,8 @@ func (t TopicFilter) Valid() error {
 // An event matches a topic filter iff:
 //   - the event has EXACTLY as many topic segments as the filter AND
 //   - each segment either: matches exactly OR is a wildcard.
-func (t TopicFilter) Matches(event []xdr.ScVal) bool {
-	if len(event) != len(t) {
+func (t TopicFilter) Matches(event []xdr.ScVal, flexibleTopicLength bool) bool {
+	if len(event) < len(t) || (!flexibleTopicLength && len(event) != len(t)) {
 		return false
 	}
 

--- a/protocol/get_events.go
+++ b/protocol/get_events.go
@@ -18,6 +18,8 @@ const (
 	MaxContractIDsLimit = 5
 	MinTopicCount       = 1
 	MaxTopicCount       = 4
+	WildCardOne         = "*"
+	WildCardZeroOrMore  = "**"
 )
 
 type EventInfo struct {
@@ -266,7 +268,7 @@ func (t TopicFilter) flexibleTopicLengthAllowed() bool {
 		return false
 	}
 	last := t[len(t)-1]
-	return last.Wildcard != nil && *last.Wildcard == "**"
+	return last.Wildcard != nil && *last.Wildcard == WildCardZeroOrMore
 }
 
 // Matches a topic filter if:
@@ -308,7 +310,7 @@ type SegmentFilter struct {
 
 func (s *SegmentFilter) Matches(segment xdr.ScVal) bool {
 	switch {
-	case s.Wildcard != nil && *s.Wildcard == "*":
+	case s.Wildcard != nil && *s.Wildcard == WildCardOne:
 		return true
 	case s.ScVal != nil:
 		if !s.ScVal.Equals(segment) {
@@ -328,7 +330,7 @@ func (s *SegmentFilter) Valid() error {
 	if s.Wildcard == nil && s.ScVal == nil {
 		return errors.New("must set either wildcard or scval")
 	}
-	if s.Wildcard != nil && *s.Wildcard != "*" {
+	if s.Wildcard != nil && *s.Wildcard != WildCardOne {
 		return errors.New("wildcard must be '*'")
 	}
 	return nil
@@ -342,7 +344,7 @@ func (s *SegmentFilter) UnmarshalJSON(p []byte) error {
 	if err := json.Unmarshal(p, &tmp); err != nil {
 		return err
 	}
-	if tmp == "*" {
+	if tmp == WildCardOne {
 		s.Wildcard = &tmp
 	} else {
 		var out xdr.ScVal

--- a/protocol/get_events.go
+++ b/protocol/get_events.go
@@ -237,24 +237,27 @@ func (e *EventFilter) matchesTopics(event xdr.ContractEvent) bool {
 type TopicFilter []SegmentFilter
 
 // Valid checks if the filter is properly structured:
-// - must have at least one segment (excluding trailing "**").
+// - must have at least one segment.
 // - cannot have more than 4 segments total (excluding trailing "**").
 // - each segment must be valid.
 // - The "**" wildcard, representing a flexible-length match, is only allowed as the last segment.
 // Returns an error if any of the rules fail.
 func (t TopicFilter) Valid() error {
+	if len(t) < MinTopicCount {
+		return fmt.Errorf("topic must have at least %d segment", MinTopicCount)
+	}
+
 	var topics []SegmentFilter
 	if t.hasTrailingZeroOrMoreWildcard() {
 		topics = t[:len(t)-1]
 	} else {
 		topics = t
 	}
-	if len(topics) < MinTopicCount {
-		return errors.New("topic must have at least one segment")
-	}
+
 	if len(topics) > MaxTopicCount {
-		return errors.New("topic cannot have more than 4 segments")
+		return fmt.Errorf("topic cannot have more than %d segments", MaxTopicCount)
 	}
+
 	for i, segment := range topics {
 		if err := segment.Valid(); err != nil {
 			return fmt.Errorf("segment %d invalid: %w", i+1, err)

--- a/protocol/get_events_test.go
+++ b/protocol/get_events_test.go
@@ -663,7 +663,7 @@ func TestGetEventsRequestValid(t *testing.T) {
 			}},
 		},
 		Pagination: nil,
-	}).Valid(1000), "filter 1 invalid: topic 1 invalid: topic must have at least one segment")
+	}).Valid(1000), "filter 1 invalid: topic 1 invalid: topic must have at least 1 segment")
 
 	require.EqualError(t, (&GetEventsRequest{
 		StartLedger: 1,
@@ -699,6 +699,22 @@ func TestGetEventsRequestValid(t *testing.T) {
 		Pagination: nil,
 	}).Valid(1000))
 
+	require.NoError(t, (&GetEventsRequest{
+		StartLedger: 1,
+		Filters: []EventFilter{
+			{Topics: []TopicFilter{
+				[]SegmentFilter{
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardZeroOrMore},
+				},
+			}},
+		},
+		Pagination: nil,
+	}).Valid(1000))
+
 	require.EqualError(t, (&GetEventsRequest{
 		StartLedger: 1,
 		Filters: []EventFilter{
@@ -716,7 +732,7 @@ func TestGetEventsRequestValid(t *testing.T) {
 		Pagination: nil,
 	}).Valid(1000), "filter 1 invalid: topic 1 invalid: topic cannot have more than 4 segments")
 
-	require.EqualError(t, (&GetEventsRequest{
+	require.NoError(t, (&GetEventsRequest{
 		StartLedger: 1,
 		Filters: []EventFilter{
 			{Topics: []TopicFilter{
@@ -726,7 +742,7 @@ func TestGetEventsRequestValid(t *testing.T) {
 			}},
 		},
 		Pagination: nil,
-	}).Valid(1000), "filter 1 invalid: topic 1 invalid: topic must have at least one segment")
+	}).Valid(1000))
 
 	require.EqualError(t, (&GetEventsRequest{
 		StartLedger: 1,

--- a/protocol/get_events_test.go
+++ b/protocol/get_events_test.go
@@ -740,7 +740,8 @@ func TestGetEventsRequestValid(t *testing.T) {
 			}},
 		},
 		Pagination: nil,
-	}).Valid(1000), "filter 1 invalid: topic 1 invalid: segment 2 invalid: wildcard must be '*'")
+	}).Valid(1000), "filter 1 invalid: topic 1 invalid: "+
+		"segment 2 invalid: wildcard '**' is only allowed as the last segment")
 
 	require.EqualError(t, (&GetEventsRequest{
 		StartLedger: 1,
@@ -754,5 +755,6 @@ func TestGetEventsRequestValid(t *testing.T) {
 			}},
 		},
 		Pagination: nil,
-	}).Valid(1000), "filter 1 invalid: topic 1 invalid: segment 1 invalid: wildcard must be '*'")
+	}).Valid(1000), "filter 1 invalid: topic 1 invalid: "+
+		"segment 1 invalid: wildcard '**' is only allowed as the last segment")
 }

--- a/protocol/get_events_test.go
+++ b/protocol/get_events_test.go
@@ -352,6 +352,7 @@ func TestTopicFilterMatches(t *testing.T) {
 	}
 }
 
+//nolint:funlen
 func TestTopicFilterMatchesFlexibleTopicLength(t *testing.T) {
 	transferSym := xdr.ScSymbol("transfer")
 	transfer := xdr.ScVal{

--- a/protocol/get_events_test.go
+++ b/protocol/get_events_test.go
@@ -198,7 +198,7 @@ func TestTopicFilterMatches(t *testing.T) {
 		Type: xdr.ScValTypeScvU64,
 		U64:  &sixtyfour,
 	}
-	wildCardOne := "*"
+	wildCardExactOne := WildCardExactOne
 	for _, tc := range []struct {
 		name     string
 		filter   TopicFilter
@@ -235,7 +235,7 @@ func TestTopicFilterMatches(t *testing.T) {
 		{
 			name: "*",
 			filter: []SegmentFilter{
-				{Wildcard: &wildCardOne},
+				{Wildcard: &wildCardExactOne},
 			},
 			includes: []xdr.ScVec{
 				{transfer},
@@ -247,7 +247,7 @@ func TestTopicFilterMatches(t *testing.T) {
 		{
 			name: "*/transfer",
 			filter: []SegmentFilter{
-				{Wildcard: &wildCardOne},
+				{Wildcard: &wildCardExactOne},
 				{ScVal: &transfer},
 			},
 			includes: []xdr.ScVec{
@@ -267,7 +267,7 @@ func TestTopicFilterMatches(t *testing.T) {
 			name: "transfer/*",
 			filter: []SegmentFilter{
 				{ScVal: &transfer},
-				{Wildcard: &wildCardOne},
+				{Wildcard: &wildCardExactOne},
 			},
 			includes: []xdr.ScVec{
 				{transfer, number},
@@ -286,8 +286,8 @@ func TestTopicFilterMatches(t *testing.T) {
 			name: "transfer/*/*",
 			filter: []SegmentFilter{
 				{ScVal: &transfer},
-				{Wildcard: &wildCardOne},
-				{Wildcard: &wildCardOne},
+				{Wildcard: &wildCardExactOne},
+				{Wildcard: &wildCardExactOne},
 			},
 			includes: []xdr.ScVec{
 				{transfer, number, number},
@@ -306,7 +306,7 @@ func TestTopicFilterMatches(t *testing.T) {
 			name: "transfer/*/number",
 			filter: []SegmentFilter{
 				{ScVal: &transfer},
-				{Wildcard: &wildCardOne},
+				{Wildcard: &wildCardExactOne},
 				{ScVal: &number},
 			},
 			includes: []xdr.ScVec{
@@ -364,7 +364,7 @@ func TestTopicFilterMatchesFlexibleTopicLength(t *testing.T) {
 		Type: xdr.ScValTypeScvU64,
 		U64:  &sixtyfour,
 	}
-	wildCardOne := WildCardOne
+	wildCardExactOne := WildCardExactOne
 	wildCardZeroOrMore := WildCardZeroOrMore
 	for _, tc := range []struct {
 		name     string
@@ -393,7 +393,7 @@ func TestTopicFilterMatchesFlexibleTopicLength(t *testing.T) {
 		{
 			name: "*/**",
 			filter: []SegmentFilter{
-				{Wildcard: &wildCardOne},
+				{Wildcard: &wildCardExactOne},
 				{Wildcard: &wildCardZeroOrMore},
 			},
 			includes: []xdr.ScVec{
@@ -407,7 +407,7 @@ func TestTopicFilterMatchesFlexibleTopicLength(t *testing.T) {
 		{
 			name: "*/transfer/**",
 			filter: []SegmentFilter{
-				{Wildcard: &wildCardOne},
+				{Wildcard: &wildCardExactOne},
 				{ScVal: &transfer},
 				{Wildcard: &wildCardZeroOrMore},
 			},
@@ -428,7 +428,7 @@ func TestTopicFilterMatchesFlexibleTopicLength(t *testing.T) {
 			name: "transfer/*/**",
 			filter: []SegmentFilter{
 				{ScVal: &transfer},
-				{Wildcard: &wildCardOne},
+				{Wildcard: &wildCardExactOne},
 				{Wildcard: &wildCardZeroOrMore},
 			},
 			includes: []xdr.ScVec{
@@ -448,8 +448,8 @@ func TestTopicFilterMatchesFlexibleTopicLength(t *testing.T) {
 			name: "transfer/*/*/**",
 			filter: []SegmentFilter{
 				{ScVal: &transfer},
-				{Wildcard: &wildCardOne},
-				{Wildcard: &wildCardOne},
+				{Wildcard: &wildCardExactOne},
+				{Wildcard: &wildCardExactOne},
 				{Wildcard: &wildCardZeroOrMore},
 			},
 			includes: []xdr.ScVec{
@@ -470,7 +470,7 @@ func TestTopicFilterMatchesFlexibleTopicLength(t *testing.T) {
 			name: "transfer/*/number/**",
 			filter: []SegmentFilter{
 				{ScVal: &transfer},
-				{Wildcard: &wildCardOne},
+				{Wildcard: &wildCardExactOne},
 				{ScVal: &number},
 				{Wildcard: &wildCardZeroOrMore},
 			},
@@ -525,9 +525,9 @@ func TestTopicFilterJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte("[]"), &got))
 	assert.Equal(t, TopicFilter{}, got)
 
-	wildCardOne := "*"
+	wildCardExactOne := "*"
 	require.NoError(t, json.Unmarshal([]byte("[\"*\"]"), &got))
-	assert.Equal(t, TopicFilter{{Wildcard: &wildCardOne}}, got)
+	assert.Equal(t, TopicFilter{{Wildcard: &wildCardExactOne}}, got)
 
 	sixtyfour := xdr.Uint64(64)
 	scval := xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &sixtyfour}
@@ -681,17 +681,17 @@ func TestGetEventsRequestValid(t *testing.T) {
 		Pagination: nil,
 	}).Valid(1000), "filter 1 invalid: topic 1 invalid: topic cannot have more than 4 segments")
 
-	wildCardOne := WildCardOne
+	wildCardExactOne := WildCardExactOne
 	wildCardZeroOrMore := WildCardZeroOrMore
 	require.NoError(t, (&GetEventsRequest{
 		StartLedger: 1,
 		Filters: []EventFilter{
 			{Topics: []TopicFilter{
 				[]SegmentFilter{
-					{Wildcard: &wildCardOne},
-					{Wildcard: &wildCardOne},
-					{Wildcard: &wildCardOne},
-					{Wildcard: &wildCardOne},
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardExactOne},
 					{Wildcard: &wildCardZeroOrMore},
 				},
 			}},
@@ -704,11 +704,11 @@ func TestGetEventsRequestValid(t *testing.T) {
 		Filters: []EventFilter{
 			{Topics: []TopicFilter{
 				[]SegmentFilter{
-					{Wildcard: &wildCardOne},
-					{Wildcard: &wildCardOne},
-					{Wildcard: &wildCardOne},
-					{Wildcard: &wildCardOne},
-					{Wildcard: &wildCardOne},
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardExactOne},
+					{Wildcard: &wildCardExactOne},
 					{Wildcard: &wildCardZeroOrMore},
 				},
 			}},
@@ -733,7 +733,7 @@ func TestGetEventsRequestValid(t *testing.T) {
 		Filters: []EventFilter{
 			{Topics: []TopicFilter{
 				[]SegmentFilter{
-					{Wildcard: &wildCardOne},
+					{Wildcard: &wildCardExactOne},
 					{Wildcard: &wildCardZeroOrMore},
 					{Wildcard: &wildCardZeroOrMore},
 				},
@@ -748,7 +748,7 @@ func TestGetEventsRequestValid(t *testing.T) {
 			{Topics: []TopicFilter{
 				[]SegmentFilter{
 					{Wildcard: &wildCardZeroOrMore},
-					{Wildcard: &wildCardOne},
+					{Wildcard: &wildCardExactOne},
 					{Wildcard: &wildCardZeroOrMore},
 				},
 			}},


### PR DESCRIPTION
### What

A new wildcard `"**"` is introduced in the `getEvents` RPC endpoint for flexible topic length matching of zero or more topics.

This eliminates the need for manual padding in filters. For eg, previously, to match events where the first topic is `"X"` followed by any number of subsequent topics, you'd need to specify multiple filters like `["X"], ["X", "*"], ["X", "*", "*"]` and so on. The new "**" wildcard simplifies this to a single filter like `["X", "**"]`.

Rules for the new wildcard
1. `"**"` wildcard can only appear as the last segment in a filter
Invalid: `["X", "**", "*"]` ❌ 
Valid: `["X", "*", "**"]` ✅ -  matches events with at least two topics, where the first topic is "X".

2. The existing limit of max of 4 filter segments per filter is unchanged. The "**" wildcard is exempt from this count.
Invalid ["A","B","C","D","*"] ❌ 
Valid: ["A","B","C","D","**"] ✅  


### Why

Fixes #358 

### Known limitations
