### PR TITLE
Update integration test to use the stellar-rpc docker image

### DIFF
--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/docker/docker-compose.rpc.yml
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/docker/docker-compose.rpc.yml
@@ -3,7 +3,7 @@ include:
 services:
   rpc:
     platform: linux/amd64
-    image: stellar/soroban-rpc:${RPC_IMAGE_TAG}
+    image: stellar/stellar-rpc:${RPC_IMAGE_TAG}
     depends_on:
       - core
     ports: # we omit the host-side ports to allocate them dynamically


### PR DESCRIPTION
### What

Update integration test .yaml to use the stellar-rpc image instead of soroban-rpc.

### Why

DB migration integration tests rely on a published rpc docker image but since the last release we’ve stopped publishing the soroban-rpc image. This caused integration test failures which this fixes.

### Known limitations

N/A