### PR TITLE
Allow segment filters to be serializable

### DIFF
--- a/protocol/get_events.go
+++ b/protocol/get_events.go
@@ -267,8 +267,8 @@ func (t TopicFilter) Matches(event []xdr.ScVal) bool {
 }
 
 type SegmentFilter struct {
-	Wildcard *string
-	ScVal    *xdr.ScVal
+	Wildcard *string    `json:"-"`
+	ScVal    *xdr.ScVal `json:"-"`
 }
 
 func (s *SegmentFilter) Matches(segment xdr.ScVal) bool {
@@ -317,6 +317,19 @@ func (s *SegmentFilter) UnmarshalJSON(p []byte) error {
 		s.ScVal = &out
 	}
 	return nil
+}
+
+func (s SegmentFilter) MarshalJSON() ([]byte, error) {
+	if err := s.Valid(); err != nil {
+		return nil, err
+	}
+
+	if s.Wildcard != nil {
+		return []byte("\"*\""), nil
+	}
+
+	scv, err := xdr.MarshalBase64(s.ScVal)
+	return []byte(fmt.Sprintf("\"%s\"", scv)), err
 }
 
 type PaginationOptions struct {

--- a/protocol/get_events_test.go
+++ b/protocol/get_events_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/xdr"
 )
 
@@ -513,4 +514,41 @@ func TestGetEventsRequestValid(t *testing.T) {
 		},
 		Pagination: nil,
 	}).Valid(1000), "filter 1 invalid: topic 1 invalid: topic cannot have more than 4 segments")
+}
+
+func TestEventFilterSerialization(t *testing.T) {
+	acct, err := xdr.AddressToAccountId(keypair.MustRandom().Address())
+	require.NoError(t, err)
+
+	scv := xdr.ScVal{
+		Type: xdr.ScValTypeScvAddress,
+		Address: &xdr.ScAddress{
+			Type:      xdr.ScAddressTypeScAddressTypeAccount,
+			AccountId: &acct,
+		},
+	}
+	wc := "*"
+	b64, err := xdr.MarshalBase64(scv)
+	require.NoError(t, err)
+
+	for _, testCase := range []struct {
+		Filter  SegmentFilter
+		Encoded string
+	}{
+		{SegmentFilter{Wildcard: &wc}, "\"*\""},
+		{SegmentFilter{ScVal: &scv}, fmt.Sprintf("\"%s\"", b64)},
+	} {
+		filter := EventFilter{Topics: []TopicFilter{{testCase.Filter}}}
+
+		b, err := json.Marshal(testCase.Filter)
+		require.NoError(t, err)
+		require.Equal(t, testCase.Encoded, string(b))
+
+		f, err := json.Marshal(filter)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("{\"topics\":[[%s]]}", string(b)), string(f))
+	}
+
+	_, err = json.Marshal(SegmentFilter{})
+	require.Error(t, err)
 }


### PR DESCRIPTION
### What
Allow `SegmentFilter`s to be serializable for client SDK usage.

### Why
Closes #404

### Known Limitations
This will have to be updated for Protocol 23 due to https://github.com/stellar/stellar-rpc/pull/419, but I'm targeting `main` so we can tag that off faster to unblock clients.