### PR TITLE
Add support for external datastore as source of historical ledger data

### DIFF
--- a/cmd/stellar-rpc/internal/config/main.go
+++ b/cmd/stellar-rpc/internal/config/main.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/support/datastore"
 )
 
 // Config represents the configuration of a stellar-rpc server
@@ -75,6 +77,9 @@ type Config struct {
 	MaxSendTransactionExecutionDuration            time.Duration
 	MaxSimulateTransactionExecutionDuration        time.Duration
 	MaxGetFeeStatsExecutionDuration                time.Duration
+	ServeLedgersFromDatastore                      bool
+	BufferedStorageBackendConfig                   ledgerbackend.BufferedStorageBackendConfig
+	DataStoreConfig                                datastore.DataStoreConfig
 
 	// We memoize these, so they bind to pflags correctly
 	optionsCache *Options

--- a/cmd/stellar-rpc/internal/config/option.go
+++ b/cmd/stellar-rpc/internal/config/option.go
@@ -30,7 +30,7 @@ func (options Options) Validate() error {
 				missingOptions = append(missingOptions, missingOptionErr)
 				continue
 			}
-			return errors.New("Invalid config value for " + option.Name)
+			return fmt.Errorf("invalid config value for %s: %w", option.Name, err)
 		}
 	}
 	if len(missingOptions) > 0 {

--- a/cmd/stellar-rpc/internal/config/options.go
+++ b/cmd/stellar-rpc/internal/config/options.go
@@ -544,17 +544,7 @@ func (cfg *Config) options() Options {
 			ConfigKey: &cfg.BufferedStorageBackendConfig,
 			Usage:     "Buffered storage backend configuration for reading ledgers from the datastore.",
 			CustomSetValue: func(option *Option, i interface{}) error {
-				tree, ok := i.(*toml.Tree)
-				if !ok {
-					return fmt.Errorf("expected TOML table for buffered_storage_backend_config, got %T", i)
-				}
-
-				tomlBytes, err := toml.Marshal(tree.ToMap())
-				if err != nil {
-					return fmt.Errorf("failed to marshal buffered_storage_backend_config: %w", err)
-				}
-
-				return toml.Unmarshal(tomlBytes, option.ConfigKey)
+				return unmarshalTOMLTree(i, option.ConfigKey, "buffered_storage_backend_config")
 			},
 			MarshalTOML: func(_ *Option) (interface{}, error) {
 				tomlBytes, err := toml.Marshal(defaultBufferedStorageBackendConfig())
@@ -569,17 +559,7 @@ func (cfg *Config) options() Options {
 			ConfigKey: &cfg.DataStoreConfig,
 			Usage:     "External datastore configuration including type, bucket name and schema.",
 			CustomSetValue: func(option *Option, i interface{}) error {
-				tree, ok := i.(*toml.Tree)
-				if !ok {
-					return fmt.Errorf("expected TOML table for datastore_config, got %T", i)
-				}
-
-				tomlBytes, err := toml.Marshal(tree.ToMap())
-				if err != nil {
-					return fmt.Errorf("failed to marshal datastore_config: %w", err)
-				}
-
-				return toml.Unmarshal(tomlBytes, option.ConfigKey)
+				return unmarshalTOMLTree(i, option.ConfigKey, "datastore_config")
 			},
 			MarshalTOML: func(_ *Option) (interface{}, error) {
 				tomlBytes, err := toml.Marshal(defaultDataStoreConfig())
@@ -611,6 +591,20 @@ func defaultDataStoreConfig() datastore.DataStoreConfig {
 			FilesPerPartition: 64000,
 		},
 	}
+}
+
+func unmarshalTOMLTree(tree interface{}, out interface{}, configName string) error {
+	t, ok := tree.(*toml.Tree)
+	if !ok {
+		return fmt.Errorf("expected TOML table for %s, got %T", configName, tree)
+	}
+
+	tomlBytes, err := toml.Marshal(t.ToMap())
+	if err != nil {
+		return fmt.Errorf("failed to marshal TOML tree for %s: %w", configName, err)
+	}
+
+	return toml.Unmarshal(tomlBytes, out)
 }
 
 type missingRequiredOptionError struct {

--- a/cmd/stellar-rpc/internal/config/options.go
+++ b/cmd/stellar-rpc/internal/config/options.go
@@ -2,7 +2,6 @@
 package config
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,7 +12,6 @@ import (
 	"github.com/pelletier/go-toml"
 	"github.com/sirupsen/logrus"
 	"github.com/stellar/go/network"
-	"github.com/stellar/go/support/datastore"
 	"github.com/stellar/go/support/strutils"
 )
 
@@ -588,17 +586,6 @@ func (cfg *Config) options() Options {
 					return nil, fmt.Errorf("unable to marshal datastore_config: %w", err)
 				}
 				return toml.LoadBytes(tomlBytes)
-			},
-			Validate: func(_ *Option) error {
-				if cfg.ServeLedgersFromDatastore {
-					// performs a basic check to verify credentials, bucket name and access.
-					dataStore, err := datastore.NewDataStore(context.Background(), cfg.DataStoreConfig)
-					if err != nil {
-						return fmt.Errorf("failed to initialize datastore: %w", err)
-					}
-					defer dataStore.Close()
-				}
-				return nil
 			},
 		},
 	}

--- a/cmd/stellar-rpc/internal/config/options.go
+++ b/cmd/stellar-rpc/internal/config/options.go
@@ -512,7 +512,7 @@ func (cfg *Config) options() Options {
 			TomlKey:      strutils.KebabToConstantCase("max-get-ledgers-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getLedgers request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetLedgersExecutionDuration,
-			DefaultValue: 5 * time.Second,
+			DefaultValue: 10 * time.Second,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-send-transaction-execution-duration"),
@@ -577,8 +577,9 @@ func defaultBufferedStorageBackendConfig() ledgerbackend.BufferedStorageBackendC
 	return ledgerbackend.BufferedStorageBackendConfig{
 		BufferSize: 100,
 		NumWorkers: 10,
-		RetryLimit: 3,
-		RetryWait:  30 * time.Second,
+		// disable retries
+		RetryLimit: 0,
+		RetryWait:  0 * time.Second,
 	}
 }
 

--- a/cmd/stellar-rpc/internal/config/toml_test.go
+++ b/cmd/stellar-rpc/internal/config/toml_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/support/datastore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -125,6 +127,20 @@ func TestRoundTrip(t *testing.T) {
 			*v = logrus.InfoLevel
 		case *LogFormat:
 			*v = LogFormatText
+		case *ledgerbackend.BufferedStorageBackendConfig:
+			*v = ledgerbackend.BufferedStorageBackendConfig{
+				BufferSize: 100,
+				NumWorkers: 20,
+				RetryLimit: 3,
+				RetryWait:  30 * time.Second,
+			}
+		case *datastore.DataStoreConfig:
+			*v = datastore.DataStoreConfig{
+				Type:   "xyz",
+				Params: nil,
+				Schema: datastore.DataStoreSchema{},
+			}
+
 		default:
 			t.Fatalf("TestRoundTrip not implemented for type %s, on option %s, "+
 				"please add a test value", optType.Kind(), option.Name)

--- a/cmd/stellar-rpc/internal/config/toml_test.go
+++ b/cmd/stellar-rpc/internal/config/toml_test.go
@@ -9,11 +9,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/datastore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stellar/go/network"
 )
 
 const basicToml = `

--- a/cmd/stellar-rpc/internal/config/toml_test.go
+++ b/cmd/stellar-rpc/internal/config/toml_test.go
@@ -127,19 +127,9 @@ func TestRoundTrip(t *testing.T) {
 		case *LogFormat:
 			*v = LogFormatText
 		case *ledgerbackend.BufferedStorageBackendConfig:
-			*v = ledgerbackend.BufferedStorageBackendConfig{
-				BufferSize: 100,
-				NumWorkers: 20,
-				RetryLimit: 3,
-				RetryWait:  30 * time.Second,
-			}
+			*v = defaultBufferedStorageBackendConfig()
 		case *datastore.DataStoreConfig:
-			*v = datastore.DataStoreConfig{
-				Type:   "xyz",
-				Params: nil,
-				Schema: datastore.DataStoreSchema{},
-			}
-
+			*v = defaultDataStoreConfig()
 		default:
 			t.Fatalf("TestRoundTrip not implemented for type %s, on option %s, "+
 				"please add a test value", optType.Kind(), option.Name)

--- a/cmd/stellar-rpc/internal/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/daemon/daemon.go
@@ -295,7 +295,6 @@ func createPreflightWorkerPool(cfg *config.Config, logger *supportlog.Entry, dae
 func createJSONRPCHandler(cfg *config.Config, logger *supportlog.Entry, daemon *Daemon,
 	feewindows *feewindow.FeeWindows,
 ) *internal.Handler {
-
 	var dataStoreLedgerReader *datastore.LedgerReader
 	if cfg.ServeLedgersFromDatastore {
 		dataStoreLedgerReader = datastore.NewLedgerReader(cfg.BufferedStorageBackendConfig, cfg.DataStoreConfig)

--- a/cmd/stellar-rpc/internal/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/daemon/daemon.go
@@ -192,7 +192,7 @@ func MustNew(cfg *config.Config, logger *supportlog.Entry) *Daemon {
 	}
 	daemon.ingestService = createIngestService(cfg, logger, daemon, feewindows, historyArchive)
 	daemon.preflightWorkerPool = createPreflightWorkerPool(cfg, logger, daemon)
-	daemon.jsonRPCHandler = mustCreateJSONRPCHandler(cfg, logger, daemon, feewindows)
+	daemon.jsonRPCHandler = createJSONRPCHandler(cfg, logger, daemon, feewindows)
 
 	daemon.setupHTTPServers(cfg)
 	daemon.registerMetrics()
@@ -314,7 +314,7 @@ func createPreflightWorkerPool(cfg *config.Config, logger *supportlog.Entry, dae
 	)
 }
 
-func mustCreateJSONRPCHandler(cfg *config.Config, logger *supportlog.Entry, daemon *Daemon,
+func createJSONRPCHandler(cfg *config.Config, logger *supportlog.Entry, daemon *Daemon,
 	feewindows *feewindow.FeeWindows,
 ) *internal.Handler {
 	var dataStoreLedgerReader rpcdatastore.LedgerReader

--- a/cmd/stellar-rpc/internal/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/daemon/daemon.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/config"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/daemon/interfaces"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/datastore"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/feewindow"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/ingest"
@@ -294,14 +295,21 @@ func createPreflightWorkerPool(cfg *config.Config, logger *supportlog.Entry, dae
 func createJSONRPCHandler(cfg *config.Config, logger *supportlog.Entry, daemon *Daemon,
 	feewindows *feewindow.FeeWindows,
 ) *internal.Handler {
+
+	var dataStoreLedgerReader *datastore.LedgerReader
+	if cfg.ServeLedgersFromDatastore {
+		dataStoreLedgerReader = datastore.NewLedgerReader(cfg.BufferedStorageBackendConfig, cfg.DataStoreConfig)
+	}
+
 	rpcHandler := internal.NewJSONRPCHandler(cfg, internal.HandlerParams{
-		Daemon:            daemon,
-		FeeStatWindows:    feewindows,
-		Logger:            logger,
-		LedgerReader:      db.NewLedgerReader(daemon.db),
-		TransactionReader: db.NewTransactionReader(logger, daemon.db, cfg.NetworkPassphrase),
-		EventReader:       db.NewEventReader(logger, daemon.db, cfg.NetworkPassphrase),
-		PreflightGetter:   daemon.preflightWorkerPool,
+		Daemon:                daemon,
+		FeeStatWindows:        feewindows,
+		Logger:                logger,
+		LedgerReader:          db.NewLedgerReader(daemon.db),
+		TransactionReader:     db.NewTransactionReader(logger, daemon.db, cfg.NetworkPassphrase),
+		EventReader:           db.NewEventReader(logger, daemon.db, cfg.NetworkPassphrase),
+		PreflightGetter:       daemon.preflightWorkerPool,
+		DataStoreLedgerReader: dataStoreLedgerReader,
 	})
 	return &rpcHandler
 }

--- a/cmd/stellar-rpc/internal/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/daemon/daemon.go
@@ -178,7 +178,7 @@ func MustNew(cfg *config.Config, logger *supportlog.Entry) *Daemon {
 
 	daemon.ingestService = createIngestService(cfg, logger, daemon, feewindows, historyArchive)
 	daemon.preflightWorkerPool = createPreflightWorkerPool(cfg, logger, daemon)
-	daemon.jsonRPCHandler = createJSONRPCHandler(cfg, logger, daemon, feewindows)
+	daemon.jsonRPCHandler = mustCreateJSONRPCHandler(cfg, logger, daemon, feewindows)
 
 	daemon.setupHTTPServers(cfg)
 	daemon.registerMetrics()
@@ -292,12 +292,16 @@ func createPreflightWorkerPool(cfg *config.Config, logger *supportlog.Entry, dae
 	)
 }
 
-func createJSONRPCHandler(cfg *config.Config, logger *supportlog.Entry, daemon *Daemon,
+func mustCreateJSONRPCHandler(cfg *config.Config, logger *supportlog.Entry, daemon *Daemon,
 	feewindows *feewindow.FeeWindows,
 ) *internal.Handler {
-	var dataStoreLedgerReader *datastore.LedgerReader
+	var dataStoreLedgerReader datastore.LedgerReader
 	if cfg.ServeLedgersFromDatastore {
-		dataStoreLedgerReader = datastore.NewLedgerReader(cfg.BufferedStorageBackendConfig, cfg.DataStoreConfig)
+		var err error
+		dataStoreLedgerReader, err = datastore.NewLedgerReader(context.Background(), cfg.BufferedStorageBackendConfig, cfg.DataStoreConfig)
+		if err != nil {
+			logger.WithError(err).Fatal("failed to initialize datastore reader")
+		}
 	}
 
 	rpcHandler := internal.NewJSONRPCHandler(cfg, internal.HandlerParams{

--- a/cmd/stellar-rpc/internal/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/daemon/daemon.go
@@ -114,6 +114,15 @@ func (d *Daemon) close() {
 		closeErrors = append(closeErrors, err)
 	}
 	d.preflightWorkerPool.Close()
+
+	if d.dataStore != nil {
+		err := d.dataStore.Close()
+		if err != nil {
+			d.logger.WithError(err).Error("error closing datastore")
+			closeErrors = append(closeErrors, err)
+		}
+	}
+
 	d.closeError = errors.Join(closeErrors...)
 	close(d.done)
 }

--- a/cmd/stellar-rpc/internal/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/daemon/daemon.go
@@ -298,7 +298,8 @@ func mustCreateJSONRPCHandler(cfg *config.Config, logger *supportlog.Entry, daem
 	var dataStoreLedgerReader datastore.LedgerReader
 	if cfg.ServeLedgersFromDatastore {
 		var err error
-		dataStoreLedgerReader, err = datastore.NewLedgerReader(context.Background(), cfg.BufferedStorageBackendConfig, cfg.DataStoreConfig)
+		dataStoreLedgerReader, err = datastore.NewLedgerReader(context.Background(),
+			cfg.BufferedStorageBackendConfig, cfg.DataStoreConfig)
 		if err != nil {
 			logger.WithError(err).Fatal("failed to initialize datastore reader")
 		}

--- a/cmd/stellar-rpc/internal/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/daemon/daemon.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/support/datastore"
 	supporthttp "github.com/stellar/go/support/http"
 	supportlog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/storage"
@@ -29,11 +30,11 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/config"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/daemon/interfaces"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/datastore"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/feewindow"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/ingest"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/preflight"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcdatastore"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/util"
 )
 
@@ -65,6 +66,7 @@ type Daemon struct {
 	closeError          error
 	done                chan struct{}
 	metricsRegistry     *prometheus.Registry
+	dataStore           datastore.DataStore
 }
 
 func (d *Daemon) GetDB() *db.DB {
@@ -176,6 +178,9 @@ func MustNew(cfg *config.Config, logger *supportlog.Entry) *Daemon {
 
 	feewindows := daemon.mustInitializeStorage(cfg)
 
+	if cfg.ServeLedgersFromDatastore {
+		daemon.dataStore = mustCreateDataStore(cfg, logger)
+	}
 	daemon.ingestService = createIngestService(cfg, logger, daemon, feewindows, historyArchive)
 	daemon.preflightWorkerPool = createPreflightWorkerPool(cfg, logger, daemon)
 	daemon.jsonRPCHandler = mustCreateJSONRPCHandler(cfg, logger, daemon, feewindows)
@@ -184,6 +189,14 @@ func MustNew(cfg *config.Config, logger *supportlog.Entry) *Daemon {
 	daemon.registerMetrics()
 
 	return daemon
+}
+
+func mustCreateDataStore(cfg *config.Config, logger *supportlog.Entry) datastore.DataStore {
+	dataStore, err := datastore.NewDataStore(context.Background(), cfg.DataStoreConfig)
+	if err != nil {
+		logger.WithError(err).Fatal("failed to initialize datastore")
+	}
+	return dataStore
 }
 
 func setupLogger(cfg *config.Config, logger *supportlog.Entry) *supportlog.Entry {
@@ -295,14 +308,9 @@ func createPreflightWorkerPool(cfg *config.Config, logger *supportlog.Entry, dae
 func mustCreateJSONRPCHandler(cfg *config.Config, logger *supportlog.Entry, daemon *Daemon,
 	feewindows *feewindow.FeeWindows,
 ) *internal.Handler {
-	var dataStoreLedgerReader datastore.LedgerReader
+	var dataStoreLedgerReader rpcdatastore.LedgerReader
 	if cfg.ServeLedgersFromDatastore {
-		var err error
-		dataStoreLedgerReader, err = datastore.NewLedgerReader(context.Background(),
-			cfg.BufferedStorageBackendConfig, cfg.DataStoreConfig)
-		if err != nil {
-			logger.WithError(err).Fatal("failed to initialize datastore reader")
-		}
+		dataStoreLedgerReader = rpcdatastore.NewLedgerReader(cfg.BufferedStorageBackendConfig, daemon.dataStore)
 	}
 
 	rpcHandler := internal.NewJSONRPCHandler(cfg, internal.HandlerParams{

--- a/cmd/stellar-rpc/internal/datastore/ledger_reader.go
+++ b/cmd/stellar-rpc/internal/datastore/ledger_reader.go
@@ -1,0 +1,68 @@
+package datastore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/support/datastore"
+	"github.com/stellar/go/xdr"
+)
+
+// LedgerReader provides access to historical ledger data
+// stored in a remote object store (e.g., S3 or GCS) via buffered storage backend.
+type LedgerReader struct {
+	storageBackendConfig ledgerbackend.BufferedStorageBackendConfig
+	dataStoreConfig      datastore.DataStoreConfig
+}
+
+// NewLedgerReader constructs a new LedgerReader with the provided storage backend
+// and datastore configuration.
+func NewLedgerReader(
+	storageBackendConfig ledgerbackend.BufferedStorageBackendConfig,
+	dataStoreConfig datastore.DataStoreConfig,
+) *LedgerReader {
+	return &LedgerReader{
+		storageBackendConfig: storageBackendConfig,
+		dataStoreConfig:      dataStoreConfig,
+	}
+}
+
+// GetLedgers retrieves a contiguous batch of ledgers in the range [start, end] (inclusive)
+// from the configured datastore using the buffered storage backend.
+//
+// Returns an error if the datastore is misconfigured, unreachable
+// or if any ledger in the specified range is unavailable.
+func (lr *LedgerReader) GetLedgers(ctx context.Context, start uint32, end uint32) ([]xdr.LedgerCloseMeta, error) {
+	// Initialize the data store
+	dataStore, err := datastore.NewDataStore(context.Background(), lr.dataStoreConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create data store: %w", err)
+	}
+	defer dataStore.Close()
+
+	// Initialize the buffered storage backend
+	bufferedBackend, err := ledgerbackend.NewBufferedStorageBackend(lr.storageBackendConfig, dataStore)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create buffered storage backend: %w", err)
+	}
+	defer bufferedBackend.Close()
+
+	// Prepare the requested ledger range in the backend
+	ledgerRange := ledgerbackend.BoundedRange(start, end)
+	if err := bufferedBackend.PrepareRange(context.Background(), ledgerRange); err != nil {
+		return nil, err
+	}
+
+	// Fetch each ledger in the range
+	ledgers := make([]xdr.LedgerCloseMeta, 0, end-start+1)
+	for sequence := ledgerRange.From(); sequence <= ledgerRange.To(); sequence++ {
+		ledger, err := bufferedBackend.GetLedger(ctx, sequence)
+		if err != nil {
+			return nil, err
+		}
+		ledgers = append(ledgers, ledger)
+	}
+
+	return ledgers, nil
+}

--- a/cmd/stellar-rpc/internal/datastore/ledger_reader.go
+++ b/cmd/stellar-rpc/internal/datastore/ledger_reader.go
@@ -11,38 +11,39 @@ import (
 
 // LedgerReader provides access to historical ledger data
 // stored in a remote object store (e.g., S3 or GCS) via buffered storage backend.
-type LedgerReader struct {
-	storageBackendConfig ledgerbackend.BufferedStorageBackendConfig
-	dataStoreConfig      datastore.DataStoreConfig
+type LedgerReader interface {
+	GetLedgers(ctx context.Context, start, end uint32) ([]xdr.LedgerCloseMeta, error)
 }
 
-// NewLedgerReader constructs a new LedgerReader with the provided storage backend
-// and datastore configuration.
-func NewLedgerReader(
+type ledgerReader struct {
+	storageBackendConfig ledgerbackend.BufferedStorageBackendConfig
+	dataStore            datastore.DataStore
+}
+
+// NewLedgerReader constructs a new LedgerReader using the provided
+// buffered storage backend configuration and datastore configuration.
+// Returns an error if the datastore cannot be initialized.
+func NewLedgerReader(ctx context.Context,
 	storageBackendConfig ledgerbackend.BufferedStorageBackendConfig,
 	dataStoreConfig datastore.DataStoreConfig,
-) *LedgerReader {
-	return &LedgerReader{
-		storageBackendConfig: storageBackendConfig,
-		dataStoreConfig:      dataStoreConfig,
-	}
-}
-
-// GetLedgers retrieves a contiguous batch of ledgers in the range [start, end] (inclusive)
-// from the configured datastore using the buffered storage backend.
-//
-// Returns an error if the datastore is misconfigured, unreachable
-// or if any ledger in the specified range is unavailable.
-func (lr *LedgerReader) GetLedgers(ctx context.Context, start uint32, end uint32) ([]xdr.LedgerCloseMeta, error) {
-	// Initialize the data store
-	dataStore, err := datastore.NewDataStore(ctx, lr.dataStoreConfig)
+) (LedgerReader, error) {
+	// Initialize the datastore
+	dataStore, err := datastore.NewDataStore(ctx, dataStoreConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create data store: %w", err)
 	}
-	defer dataStore.Close()
+	return &ledgerReader{
+		storageBackendConfig: storageBackendConfig,
+		dataStore:            dataStore,
+	}, nil
+}
 
+// GetLedgers retrieves a contiguous batch of ledgers in the range [start, end] (inclusive)
+// from the configured datastore using a buffered storage backend.
+// Returns an error if any ledger in the specified range is unavailable.
+func (r *ledgerReader) GetLedgers(ctx context.Context, start uint32, end uint32) ([]xdr.LedgerCloseMeta, error) {
 	// Initialize the buffered storage backend
-	bufferedBackend, err := ledgerbackend.NewBufferedStorageBackend(lr.storageBackendConfig, dataStore)
+	bufferedBackend, err := ledgerbackend.NewBufferedStorageBackend(r.storageBackendConfig, r.dataStore)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create buffered storage backend: %w", err)
 	}

--- a/cmd/stellar-rpc/internal/datastore/ledger_reader.go
+++ b/cmd/stellar-rpc/internal/datastore/ledger_reader.go
@@ -35,7 +35,7 @@ func NewLedgerReader(
 // or if any ledger in the specified range is unavailable.
 func (lr *LedgerReader) GetLedgers(ctx context.Context, start uint32, end uint32) ([]xdr.LedgerCloseMeta, error) {
 	// Initialize the data store
-	dataStore, err := datastore.NewDataStore(context.Background(), lr.dataStoreConfig)
+	dataStore, err := datastore.NewDataStore(ctx, lr.dataStoreConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create data store: %w", err)
 	}
@@ -50,7 +50,7 @@ func (lr *LedgerReader) GetLedgers(ctx context.Context, start uint32, end uint32
 
 	// Prepare the requested ledger range in the backend
 	ledgerRange := ledgerbackend.BoundedRange(start, end)
-	if err := bufferedBackend.PrepareRange(context.Background(), ledgerRange); err != nil {
+	if err := bufferedBackend.PrepareRange(ctx, ledgerRange); err != nil {
 		return nil, err
 	}
 

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -65,7 +65,7 @@ func (l ledgerReaderTx) GetLedgerRange(ctx context.Context) (ledgerbucketwindow.
 func (l ledgerReaderTx) BatchGetLedgers(ctx context.Context, start uint32,
 	end uint32,
 ) ([]xdr.LedgerCloseMeta, error) {
-	if start >= end {
+	if start > end {
 		return nil, errors.New("batch size must be greater than zero")
 	}
 	sql := sq.Select("meta").

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -32,7 +32,7 @@ type LedgerReader interface {
 type LedgerReaderTx interface {
 	GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error)
 	GetLedgerRange(ctx context.Context) (ledgerbucketwindow.LedgerRange, error)
-	BatchGetLedgers(ctx context.Context, sequence uint32, end uint32) ([]xdr.LedgerCloseMeta, error)
+	BatchGetLedgers(ctx context.Context, start uint32, end uint32) ([]xdr.LedgerCloseMeta, error)
 	Done() error
 }
 

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -32,7 +32,7 @@ type LedgerReader interface {
 type LedgerReaderTx interface {
 	GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error)
 	GetLedgerRange(ctx context.Context) (ledgerbucketwindow.LedgerRange, error)
-	BatchGetLedgers(ctx context.Context, start uint32, end uint32) ([]xdr.LedgerCloseMeta, error)
+	BatchGetLedgers(ctx context.Context, sequence uint32, end uint32) ([]xdr.LedgerCloseMeta, error)
 	Done() error
 }
 

--- a/cmd/stellar-rpc/internal/db/ledger_test.go
+++ b/cmd/stellar-rpc/internal/db/ledger_test.go
@@ -202,9 +202,11 @@ func BenchmarkBatchGetLedgers(b *testing.B) {
 	require.NoError(b, err)
 	batchSize := uint(200) // using the current maximum value for getLedgers endpoint
 
+	start := uint32(1334)
+	end := start + uint32(batchSize) - 1
 	b.ResetTimer()
 	for range b.N {
-		ledgers, err := readTx.BatchGetLedgers(context.TODO(), 1334, batchSize)
+		ledgers, err := readTx.BatchGetLedgers(context.TODO(), start, end)
 		require.NoError(b, err)
 		assert.Equal(b, lcms[0].LedgerSequence(), ledgers[0].LedgerSequence())
 		assert.Equal(b, lcms[batchSize-1].LedgerSequence(), ledgers[batchSize-1].LedgerSequence())

--- a/cmd/stellar-rpc/internal/db/ledger_test.go
+++ b/cmd/stellar-rpc/internal/db/ledger_test.go
@@ -206,7 +206,7 @@ func BenchmarkBatchGetLedgers(b *testing.B) {
 	end := start + uint32(batchSize) - 1
 	b.ResetTimer()
 	for range b.N {
-		ledgers, err := readTx.BatchGetLedgers(context.TODO(), start, end)
+		ledgers, err := readTx.BatchGetLedgers(b.Context(), start, end)
 		require.NoError(b, err)
 		assert.Equal(b, lcms[0].LedgerSequence(), ledgers[0].LedgerSequence())
 		assert.Equal(b, lcms[batchSize-1].LedgerSequence(), ledgers[batchSize-1].LedgerSequence())

--- a/cmd/stellar-rpc/internal/integrationtest/get_ledgers_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/get_ledgers_test.go
@@ -1,20 +1,26 @@
 package integrationtest
 
 import (
-	"context"
+	"bytes"
+	"fmt"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/support/compressxdr"
+	"github.com/stellar/go/support/datastore"
+	"github.com/stellar/go/xdr"
+
+	"github.com/stellar/stellar-rpc/client"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/config"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/integrationtest/infrastructure"
 	"github.com/stellar/stellar-rpc/protocol"
 )
 
-func TestGetLedgers(t *testing.T) {
-	test := infrastructure.NewTest(t, nil)
-	client := test.GetRPCLient()
-
+func testGetLedgers(t *testing.T, client *client.Client) {
 	// Get all ledgers
 	request := protocol.GetLedgersRequest{
 		StartLedger: 8,
@@ -23,9 +29,9 @@ func TestGetLedgers(t *testing.T) {
 		},
 	}
 
-	result, err := client.GetLedgers(context.Background(), request)
+	result, err := client.GetLedgers(t.Context(), request)
 	require.NoError(t, err)
-	assert.Len(t, result.Ledgers, 3)
+	require.Len(t, result.Ledgers, 3)
 	prevLedgers := result.Ledgers
 
 	// Get ledgers using previous result's cursor
@@ -35,10 +41,10 @@ func TestGetLedgers(t *testing.T) {
 			Limit:  2,
 		},
 	}
-	result, err = client.GetLedgers(context.Background(), request)
+	result, err = client.GetLedgers(t.Context(), request)
 	require.NoError(t, err)
-	assert.Len(t, result.Ledgers, 2)
-	assert.Equal(t, prevLedgers[len(prevLedgers)-1].Sequence+1, result.Ledgers[0].Sequence)
+	require.Len(t, result.Ledgers, 2)
+	require.Equal(t, prevLedgers[len(prevLedgers)-1].Sequence+1, result.Ledgers[0].Sequence)
 
 	// Test with JSON format
 	request = protocol.GetLedgersRequest{
@@ -48,10 +54,10 @@ func TestGetLedgers(t *testing.T) {
 		},
 		Format: protocol.FormatJSON,
 	}
-	result, err = client.GetLedgers(context.Background(), request)
+	result, err = client.GetLedgers(t.Context(), request)
 	require.NoError(t, err)
-	assert.NotEmpty(t, result.Ledgers[0].LedgerHeaderJSON)
-	assert.NotEmpty(t, result.Ledgers[0].LedgerMetadataJSON)
+	require.NotEmpty(t, result.Ledgers[0].LedgerHeaderJSON)
+	require.NotEmpty(t, result.Ledgers[0].LedgerMetadataJSON)
 
 	// Test invalid requests
 	invalidRequests := []protocol.GetLedgersRequest{
@@ -65,7 +71,97 @@ func TestGetLedgers(t *testing.T) {
 	}
 
 	for _, req := range invalidRequests {
-		_, err = client.GetLedgers(context.Background(), req)
-		assert.Error(t, err)
+		_, err = client.GetLedgers(t.Context(), req)
+		require.Error(t, err)
 	}
+}
+
+func TestGetLedgers(t *testing.T) {
+	test := infrastructure.NewTest(t, nil)
+	client := test.GetRPCLient()
+	testGetLedgers(t, client)
+}
+
+func TestGetLedgersFromDatastore(t *testing.T) {
+	// setup fake GCS server
+	opts := fakestorage.Options{
+		Scheme:     "http",
+		PublicHost: "127.0.0.1",
+	}
+	gcsServer, err := fakestorage.NewServerWithOptions(opts)
+	require.NoError(t, err)
+	defer gcsServer.Stop()
+
+	t.Setenv("STORAGE_EMULATOR_HOST", gcsServer.URL())
+	bucketName := "test-bucket"
+	gcsServer.CreateBucketWithOpts(fakestorage.CreateBucketOpts{Name: bucketName})
+
+	// add files to GCS
+	for i, seq := range []uint32{8, 9, 10} {
+		objectName := fmt.Sprintf("FFFFFFF%d--%d.xdr.zstd", 7-i, seq)
+		gcsServer.CreateObject(fakestorage.Object{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: bucketName,
+				Name:       objectName,
+			},
+			Content: createLCMBatchBuffer(seq),
+		})
+	}
+
+	// datastore configuration function
+	setDatastoreConfig := func(cfg *config.Config) {
+		cfg.ServeLedgersFromDatastore = true
+		cfg.BufferedStorageBackendConfig = ledgerbackend.BufferedStorageBackendConfig{
+			BufferSize: 10,
+			NumWorkers: 2,
+			RetryLimit: 3,
+			RetryWait:  30 * time.Second,
+		}
+		cfg.DataStoreConfig = datastore.DataStoreConfig{
+			Type:   "GCS",
+			Params: map[string]string{"destination_bucket_path": bucketName},
+			Schema: datastore.DataStoreSchema{
+				FilesPerPartition: 1,
+				LedgersPerFile:    1,
+			},
+		}
+		// reduce retention windows to force usage of datastore
+		cfg.HistoryRetentionWindow = 10
+		cfg.ClassicFeeStatsLedgerRetentionWindow = 10
+		cfg.SorobanFeeStatsLedgerRetentionWindow = 10
+	}
+
+	test := infrastructure.NewTest(t, &infrastructure.TestConfig{
+		NoParallel:          true, // can't use parallel due to env vars
+		DatastoreConfigFunc: setDatastoreConfig,
+	})
+	client := test.GetRPCLient()
+
+	// run tests
+	testGetLedgers(t, client)
+}
+
+func createLCMBatchBuffer(seq uint32) []byte {
+	lcm := xdr.LedgerCloseMetaBatch{
+		StartSequence: xdr.Uint32(seq),
+		EndSequence:   xdr.Uint32(seq),
+		LedgerCloseMetas: []xdr.LedgerCloseMeta{
+			{
+				V: int32(0),
+				V0: &xdr.LedgerCloseMetaV0{
+					LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+						Header: xdr.LedgerHeader{
+							LedgerSeq: xdr.Uint32(seq),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	encoder := compressxdr.NewXDREncoder(compressxdr.DefaultCompressor, lcm)
+	_, _ = encoder.WriteTo(&buf)
+
+	return buf.Bytes()
 }

--- a/cmd/stellar-rpc/internal/integrationtest/get_ledgers_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/get_ledgers_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/stretchr/testify/require"
@@ -114,8 +113,6 @@ func TestGetLedgersFromDatastore(t *testing.T) {
 		cfg.BufferedStorageBackendConfig = ledgerbackend.BufferedStorageBackendConfig{
 			BufferSize: 10,
 			NumWorkers: 2,
-			RetryLimit: 3,
-			RetryWait:  30 * time.Second,
 		}
 		cfg.DataStoreConfig = datastore.DataStoreConfig{
 			Type:   "GCS",

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
@@ -75,6 +75,8 @@ type TestConfig struct {
 	OnlyRPC                *TestOnlyRPCConfig
 	// Do not mark the test as running in parallel
 	NoParallel bool
+
+	DatastoreConfigFunc func(*config.Config)
 }
 
 type TestCorePorts struct {
@@ -118,6 +120,8 @@ type Test struct {
 	shutdownOnce  sync.Once
 	shutdown      func()
 	onlyRPC       bool
+
+	datastoreConfigFunc func(*config.Config)
 }
 
 func NewTest(t testing.TB, cfg *TestConfig) *Test {
@@ -144,6 +148,7 @@ func NewTest(t testing.TB, cfg *TestConfig) *Test {
 			shouldWaitForRPC = !cfg.OnlyRPC.DontWait
 		}
 		parallel = !cfg.NoParallel
+		i.datastoreConfigFunc = cfg.DatastoreConfigFunc
 	}
 
 	if i.sqlitePath == "" {
@@ -450,6 +455,10 @@ func (i *Test) createRPCDaemon(c rpcConfig) *daemon.Daemon {
 	}
 	require.NoError(i.t, cfg.SetValues(lookup))
 	require.NoError(i.t, cfg.Validate())
+
+	if i.datastoreConfigFunc != nil {
+		i.datastoreConfigFunc(&cfg)
+	}
 
 	logger := supportlog.New()
 	logger.SetOutput(newTestLogWriter(i.t, `rpc="daemon" `))

--- a/cmd/stellar-rpc/internal/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc.go
@@ -16,9 +16,7 @@ import (
 	"github.com/go-chi/chi/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
-
 	"github.com/stellar/go/support/log"
-
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/config"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/daemon/interfaces"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/datastore"
@@ -53,14 +51,14 @@ func (h Handler) Close() {
 }
 
 type HandlerParams struct {
-	FeeStatWindows            *feewindow.FeeWindows
-	TransactionReader         db.TransactionReader
-	EventReader               db.EventReader
-	LedgerReader              db.LedgerReader
-	Logger                    *log.Entry
-	PreflightGetter           methods.PreflightGetter
-	Daemon                    interfaces.Daemon
-	DataStoreLedgerReader     datastore.LedgerReader
+	FeeStatWindows        *feewindow.FeeWindows
+	TransactionReader     db.TransactionReader
+	EventReader           db.EventReader
+	LedgerReader          db.LedgerReader
+	Logger                *log.Entry
+	PreflightGetter       methods.PreflightGetter
+	Daemon                interfaces.Daemon
+	DataStoreLedgerReader datastore.LedgerReader
 }
 
 func decorateHandlers(daemon interfaces.Daemon, logger *log.Entry, m handler.Map) handler.Map {

--- a/cmd/stellar-rpc/internal/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc.go
@@ -53,14 +53,14 @@ func (h Handler) Close() {
 }
 
 type HandlerParams struct {
-	FeeStatWindows        *feewindow.FeeWindows
-	TransactionReader     db.TransactionReader
-	EventReader           db.EventReader
-	LedgerReader          db.LedgerReader
-	Logger                *log.Entry
-	PreflightGetter       methods.PreflightGetter
-	Daemon                interfaces.Daemon
-	DataStoreLedgerReader *datastore.LedgerReader
+	FeeStatWindows            *feewindow.FeeWindows
+	TransactionReader         db.TransactionReader
+	EventReader               db.EventReader
+	LedgerReader              db.LedgerReader
+	Logger                    *log.Entry
+	PreflightGetter           methods.PreflightGetter
+	Daemon                    interfaces.Daemon
+	DataStoreLedgerReader     datastore.LedgerReader
 }
 
 func decorateHandlers(daemon interfaces.Daemon, logger *log.Entry, m handler.Map) handler.Map {

--- a/cmd/stellar-rpc/internal/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/config"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/daemon/interfaces"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/datastore"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/feewindow"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/methods"
@@ -52,13 +53,14 @@ func (h Handler) Close() {
 }
 
 type HandlerParams struct {
-	FeeStatWindows    *feewindow.FeeWindows
-	TransactionReader db.TransactionReader
-	EventReader       db.EventReader
-	LedgerReader      db.LedgerReader
-	Logger            *log.Entry
-	PreflightGetter   methods.PreflightGetter
-	Daemon            interfaces.Daemon
+	FeeStatWindows        *feewindow.FeeWindows
+	TransactionReader     db.TransactionReader
+	EventReader           db.EventReader
+	LedgerReader          db.LedgerReader
+	Logger                *log.Entry
+	PreflightGetter       methods.PreflightGetter
+	Daemon                interfaces.Daemon
+	DataStoreLedgerReader *datastore.LedgerReader
 }
 
 func decorateHandlers(daemon interfaces.Daemon, logger *log.Entry, m handler.Map) handler.Map {
@@ -213,7 +215,7 @@ func NewJSONRPCHandler(cfg *config.Config, params HandlerParams) Handler {
 		{
 			methodName: protocol.GetLedgersMethodName,
 			underlyingHandler: methods.NewGetLedgersHandler(params.LedgerReader,
-				cfg.MaxLedgersLimit, cfg.DefaultLedgersLimit),
+				cfg.MaxLedgersLimit, cfg.DefaultLedgersLimit, params.DataStoreLedgerReader),
 			longName:             toSnakeCase(protocol.GetLedgersMethodName),
 			queueLimit:           cfg.RequestBacklogGetLedgersQueueLimit,
 			requestDurationLimit: cfg.MaxGetLedgersExecutionDuration,

--- a/cmd/stellar-rpc/internal/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc.go
@@ -17,13 +17,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
 	"github.com/stellar/go/support/log"
+
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/config"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/daemon/interfaces"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/datastore"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/feewindow"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/methods"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/network"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcdatastore"
 	"github.com/stellar/stellar-rpc/protocol"
 )
 
@@ -58,7 +59,7 @@ type HandlerParams struct {
 	Logger                *log.Entry
 	PreflightGetter       methods.PreflightGetter
 	Daemon                interfaces.Daemon
-	DataStoreLedgerReader datastore.LedgerReader
+	DataStoreLedgerReader rpcdatastore.LedgerReader
 }
 
 func decorateHandlers(daemon interfaces.Daemon, logger *log.Entry, m handler.Map) handler.Map {
@@ -213,7 +214,7 @@ func NewJSONRPCHandler(cfg *config.Config, params HandlerParams) Handler {
 		{
 			methodName: protocol.GetLedgersMethodName,
 			underlyingHandler: methods.NewGetLedgersHandler(params.LedgerReader,
-				cfg.MaxLedgersLimit, cfg.DefaultLedgersLimit, params.DataStoreLedgerReader),
+				cfg.MaxLedgersLimit, cfg.DefaultLedgersLimit, params.DataStoreLedgerReader, params.Logger),
 			longName:             toSnakeCase(protocol.GetLedgersMethodName),
 			queueLimit:           cfg.RequestBacklogGetLedgersQueueLimit,
 			requestDurationLimit: cfg.MaxGetLedgersExecutionDuration,

--- a/cmd/stellar-rpc/internal/methods/get_ledgers.go
+++ b/cmd/stellar-rpc/internal/methods/get_ledgers.go
@@ -218,7 +218,7 @@ func (h ledgersHandler) fetchLedgers(ctx context.Context, start uint32,
 	// convert raw lcm to protocol.LedgerInfo
 	result := make([]protocol.LedgerInfo, 0, limit)
 	for _, ledger := range ledgers {
-		if uint32(len(result)) >= limit {
+		if len(result) >= int(limit) {
 			break
 		}
 

--- a/cmd/stellar-rpc/internal/methods/get_ledgers.go
+++ b/cmd/stellar-rpc/internal/methods/get_ledgers.go
@@ -189,8 +189,8 @@ func (h ledgersHandler) fetchLedgers(ctx context.Context, start uint32,
 		return ledgers, nil
 	}
 
-	var ledgers []xdr.LedgerCloseMeta
-
+	limit := end - start + 1
+	ledgers := make([]xdr.LedgerCloseMeta, 0, limit)
 	switch {
 	case start >= localLedgerRange.FirstLedger:
 		// entire range is available in local DB
@@ -225,7 +225,6 @@ func (h ledgersHandler) fetchLedgers(ctx context.Context, start uint32,
 		ledgers = append(ledgers, localLedgers...)
 	}
 
-	limit := end - start + 1
 	// convert raw lcm to protocol.LedgerInfo
 	result := make([]protocol.LedgerInfo, 0, limit)
 	for _, ledger := range ledgers {

--- a/cmd/stellar-rpc/internal/methods/get_ledgers.go
+++ b/cmd/stellar-rpc/internal/methods/get_ledgers.go
@@ -24,7 +24,8 @@ type ledgersHandler struct {
 
 // NewGetLedgersHandler returns a jrpc2.Handler for the getLedgers method.
 func NewGetLedgersHandler(ledgerReader db.LedgerReader, maxLimit, defaultLimit uint,
-	datastoreLedgerReader *datastore.LedgerReader) jrpc2.Handler {
+	datastoreLedgerReader *datastore.LedgerReader,
+) jrpc2.Handler {
 	return NewHandler((&ledgersHandler{
 		ledgerReader:          ledgerReader,
 		maxLimit:              maxLimit,
@@ -177,7 +178,7 @@ func (h ledgersHandler) fetchLedgers(ctx context.Context, start uint32,
 	}
 
 	var ledgers []xdr.LedgerCloseMeta
-	end := start + uint32(limit) - 1
+	end := start + uint32(limit) - 1 //nolint:gosec
 
 	switch {
 	case start >= localLedgerRange.FirstLedger:

--- a/cmd/stellar-rpc/internal/methods/get_ledgers.go
+++ b/cmd/stellar-rpc/internal/methods/get_ledgers.go
@@ -17,11 +17,11 @@ import (
 )
 
 type ledgersHandler struct {
-	logger                *log.Entry
 	ledgerReader          db.LedgerReader
-	datastoreLedgerReader rpcdatastore.LedgerReader
 	maxLimit              uint
 	defaultLimit          uint
+	datastoreLedgerReader rpcdatastore.LedgerReader
+	logger                *log.Entry
 }
 
 // NewGetLedgersHandler returns a jrpc2.Handler for the getLedgers method.
@@ -29,11 +29,11 @@ func NewGetLedgersHandler(ledgerReader db.LedgerReader, maxLimit, defaultLimit u
 	datastoreLedgerReader rpcdatastore.LedgerReader, logger *log.Entry,
 ) jrpc2.Handler {
 	return NewHandler((&ledgersHandler{
-		logger:                logger,
 		ledgerReader:          ledgerReader,
 		maxLimit:              maxLimit,
 		defaultLimit:          defaultLimit,
 		datastoreLedgerReader: datastoreLedgerReader,
+		logger:                logger,
 	}).getLedgers)
 }
 

--- a/cmd/stellar-rpc/internal/methods/get_ledgers_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_ledgers_test.go
@@ -115,6 +115,23 @@ func TestGetLedgers_WithCursor(t *testing.T) {
 	assert.Equal(t, uint32(8), response.Ledgers[2].Sequence)
 }
 
+func TestGetLedgers_InvalidStartLedger(t *testing.T) {
+	testDB := setupTestDB(t, 10)
+	handler := ledgersHandler{
+		ledgerReader: db.NewLedgerReader(testDB),
+		maxLimit:     100,
+		defaultLimit: 5,
+	}
+
+	request := protocol.GetLedgersRequest{
+		StartLedger: 12,
+	}
+
+	_, err := handler.getLedgers(context.TODO(), request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be between the oldest ledger")
+}
+
 func TestGetLedgers_LimitExceedsMaxLimit(t *testing.T) {
 	testDB := setupTestDB(t, 10)
 	handler := ledgersHandler{

--- a/cmd/stellar-rpc/internal/methods/get_ledgers_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_ledgers_test.go
@@ -192,10 +192,9 @@ func TestGetLedgers_JSONFormat(t *testing.T) {
 func TestGetLedgers_NoLedgers(t *testing.T) {
 	testDB := setupTestDB(t, 0)
 	handler := ledgersHandler{
-		ledgerReader:          db.NewLedgerReader(testDB),
-		maxLimit:              100,
-		defaultLimit:          5,
-		datastoreLedgerReader: new(MockDatastoreReader),
+		ledgerReader: db.NewLedgerReader(testDB),
+		maxLimit:     100,
+		defaultLimit: 5,
 	}
 
 	request := protocol.GetLedgersRequest{
@@ -286,7 +285,7 @@ func createLedgerCloseMeta(ledgerSeq uint32) xdr.LedgerCloseMeta {
 }
 
 func getLedgerRange(sequences []uint32) []xdr.LedgerCloseMeta {
-	var ledgers []xdr.LedgerCloseMeta
+	ledgers := make([]xdr.LedgerCloseMeta, 0, len(sequences))
 	for _, seq := range sequences {
 		ledgers = append(ledgers, createLedgerCloseMeta(seq))
 	}
@@ -350,7 +349,9 @@ func TestGetLedgers(t *testing.T) {
 			mockReader.On("NewTx", ctx).Return(mockReaderTx, nil)
 			mockReaderTx.On("Done").Return(nil)
 			mockReaderTx.On("GetLedgerRange", ctx).Return(localRange, nil)
-
+			mockStore.On("GetAvailableLedgerRange", ctx).Return(protocol.LedgerSeqRange{
+				FirstLedger: 2,
+			}, nil)
 			if len(tc.expectLocal) > 0 {
 				mockReaderTx.On("BatchGetLedgers", ctx, tc.expectLocal[0], tc.expectLocal[len(tc.expectLocal)-1]).
 					Return(getLedgerRange(tc.expectLocal), nil)

--- a/cmd/stellar-rpc/internal/methods/mocks.go
+++ b/cmd/stellar-rpc/internal/methods/mocks.go
@@ -3,8 +3,9 @@ package methods
 import (
 	"context"
 
-	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/go/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/datastore"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"

--- a/cmd/stellar-rpc/internal/methods/mocks.go
+++ b/cmd/stellar-rpc/internal/methods/mocks.go
@@ -20,22 +20,22 @@ type MockLedgerReaderTx struct {
 	mock.Mock
 }
 
-func (m MockLedgerReaderTx) GetLedgerRange(ctx context.Context) (ledgerbucketwindow.LedgerRange, error) {
+func (m *MockLedgerReaderTx) GetLedgerRange(ctx context.Context) (ledgerbucketwindow.LedgerRange, error) {
 	args := m.Called(ctx)
-	return args.Get(0).(ledgerbucketwindow.LedgerRange), args.Error(1)
+	return args.Get(0).(ledgerbucketwindow.LedgerRange), args.Error(1) //nolint:forcetypeassert
 }
 
-func (m MockLedgerReaderTx) BatchGetLedgers(ctx context.Context, start, end uint32) ([]xdr.LedgerCloseMeta, error) {
+func (m *MockLedgerReaderTx) BatchGetLedgers(ctx context.Context, start, end uint32) ([]xdr.LedgerCloseMeta, error) {
 	args := m.Called(ctx, start, end)
-	return args.Get(0).([]xdr.LedgerCloseMeta), args.Error(1)
+	return args.Get(0).([]xdr.LedgerCloseMeta), args.Error(1) //nolint:forcetypeassert
 }
 
-func (m MockLedgerReaderTx) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {
+func (m *MockLedgerReaderTx) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {
 	args := m.Called(ctx, sequence)
-	return args.Get(0).(xdr.LedgerCloseMeta), args.Bool(1), args.Error(2)
+	return args.Get(0).(xdr.LedgerCloseMeta), args.Bool(1), args.Error(2) //nolint:forcetypeassert
 }
 
-func (m MockLedgerReaderTx) Done() error {
+func (m *MockLedgerReaderTx) Done() error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -46,5 +46,5 @@ type MockDatastoreReader struct {
 
 func (m *MockDatastoreReader) GetLedgers(ctx context.Context, start, end uint32) ([]xdr.LedgerCloseMeta, error) {
 	args := m.Called(ctx, start, end)
-	return args.Get(0).([]xdr.LedgerCloseMeta), args.Error(1)
+	return args.Get(0).([]xdr.LedgerCloseMeta), args.Error(1) //nolint:forcetypeassert
 }

--- a/cmd/stellar-rpc/internal/methods/mocks.go
+++ b/cmd/stellar-rpc/internal/methods/mocks.go
@@ -13,9 +13,46 @@ import (
 )
 
 var (
+	_ db.LedgerReader        = &MockLedgerReader{}
 	_ db.LedgerReaderTx      = &MockLedgerReaderTx{}
 	_ datastore.LedgerReader = &MockDatastoreReader{}
 )
+
+type MockLedgerReader struct {
+	mock.Mock
+}
+
+func (m *MockLedgerReader) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {
+	args := m.Called(ctx, sequence)
+	return args.Get(0).(xdr.LedgerCloseMeta), args.Bool(1), args.Error(2) //nolint:forcetypeassert
+}
+
+func (m *MockLedgerReader) StreamAllLedgers(ctx context.Context, f db.StreamLedgerFn) error {
+	args := m.Called(ctx, f)
+	return args.Error(0)
+}
+
+func (m *MockLedgerReader) GetLedgerRange(ctx context.Context) (ledgerbucketwindow.LedgerRange, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(ledgerbucketwindow.LedgerRange), args.Error(1) //nolint:forcetypeassert
+}
+
+func (m *MockLedgerReader) StreamLedgerRange(ctx context.Context, startLedger, endLedger uint32,
+	f db.StreamLedgerFn,
+) error {
+	args := m.Called(ctx, startLedger, endLedger, f)
+	return args.Error(0)
+}
+
+func (m *MockLedgerReader) NewTx(ctx context.Context) (db.LedgerReaderTx, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(db.LedgerReaderTx), args.Error(1) //nolint:forcetypeassert
+}
+
+func (m *MockLedgerReader) GetLatestLedgerSequence(ctx context.Context) (uint32, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(uint32), args.Error(1) //nolint:forcetypeassert
+}
 
 type MockLedgerReaderTx struct {
 	mock.Mock

--- a/cmd/stellar-rpc/internal/methods/mocks.go
+++ b/cmd/stellar-rpc/internal/methods/mocks.go
@@ -1,0 +1,50 @@
+package methods
+
+import (
+	"context"
+
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/datastore"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/ledgerbucketwindow"
+)
+
+var (
+	_ db.LedgerReaderTx      = &MockLedgerReaderTx{}
+	_ datastore.LedgerReader = &MockDatastoreReader{}
+)
+
+type MockLedgerReaderTx struct {
+	mock.Mock
+}
+
+func (m MockLedgerReaderTx) GetLedgerRange(ctx context.Context) (ledgerbucketwindow.LedgerRange, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(ledgerbucketwindow.LedgerRange), args.Error(1)
+}
+
+func (m MockLedgerReaderTx) BatchGetLedgers(ctx context.Context, start, end uint32) ([]xdr.LedgerCloseMeta, error) {
+	args := m.Called(ctx, start, end)
+	return args.Get(0).([]xdr.LedgerCloseMeta), args.Error(1)
+}
+
+func (m MockLedgerReaderTx) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {
+	args := m.Called(ctx, sequence)
+	return args.Get(0).(xdr.LedgerCloseMeta), args.Bool(1), args.Error(2)
+}
+
+func (m MockLedgerReaderTx) Done() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+type MockDatastoreReader struct {
+	mock.Mock
+}
+
+func (m *MockDatastoreReader) GetLedgers(ctx context.Context, start, end uint32) ([]xdr.LedgerCloseMeta, error) {
+	args := m.Called(ctx, start, end)
+	return args.Get(0).([]xdr.LedgerCloseMeta), args.Error(1)
+}

--- a/cmd/stellar-rpc/internal/methods/mocks.go
+++ b/cmd/stellar-rpc/internal/methods/mocks.go
@@ -7,15 +7,16 @@ import (
 
 	"github.com/stellar/go/xdr"
 
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/datastore"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/ledgerbucketwindow"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcdatastore"
+	"github.com/stellar/stellar-rpc/protocol"
 )
 
 var (
-	_ db.LedgerReader        = &MockLedgerReader{}
-	_ db.LedgerReaderTx      = &MockLedgerReaderTx{}
-	_ datastore.LedgerReader = &MockDatastoreReader{}
+	_ db.LedgerReader           = &MockLedgerReader{}
+	_ db.LedgerReaderTx         = &MockLedgerReaderTx{}
+	_ rpcdatastore.LedgerReader = &MockDatastoreReader{}
 )
 
 type MockLedgerReader struct {
@@ -80,6 +81,11 @@ func (m *MockLedgerReaderTx) Done() error {
 
 type MockDatastoreReader struct {
 	mock.Mock
+}
+
+func (m *MockDatastoreReader) GetAvailableLedgerRange(ctx context.Context) (protocol.LedgerSeqRange, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(protocol.LedgerSeqRange), args.Error(1) //nolint:forcetypeassert
 }
 
 func (m *MockDatastoreReader) GetLedgers(ctx context.Context, start, end uint32) ([]xdr.LedgerCloseMeta, error) {

--- a/cmd/stellar-rpc/internal/rpcdatastore/ledger_reader_test.go
+++ b/cmd/stellar-rpc/internal/rpcdatastore/ledger_reader_test.go
@@ -1,0 +1,108 @@
+package rpcdatastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/support/datastore"
+	"github.com/stellar/go/xdr"
+)
+
+type mockLedgerBackend struct {
+	mock.Mock
+}
+
+var _ ledgerbackend.LedgerBackend = (*mockLedgerBackend)(nil)
+
+func (m *mockLedgerBackend) GetLatestLedgerSequence(ctx context.Context) (uint32, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(uint32), args.Error(1) //nolint:forcetypeassert
+}
+
+func (m *mockLedgerBackend) GetLedger(ctx context.Context, seq uint32) (xdr.LedgerCloseMeta, error) {
+	args := m.Called(ctx, seq)
+	return args.Get(0).(xdr.LedgerCloseMeta), args.Error(1) //nolint:forcetypeassert
+}
+
+func (m *mockLedgerBackend) PrepareRange(ctx context.Context, r ledgerbackend.Range) error {
+	args := m.Called(ctx, r)
+	return args.Error(0)
+}
+
+func (m *mockLedgerBackend) IsPrepared(ctx context.Context, r ledgerbackend.Range) (bool, error) {
+	args := m.Called(ctx, r)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *mockLedgerBackend) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func createLedgerCloseMeta(ledgerSeq uint32) xdr.LedgerCloseMeta {
+	return xdr.LedgerCloseMeta{
+		V0: &xdr.LedgerCloseMetaV0{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					LedgerSeq: xdr.Uint32(ledgerSeq),
+				},
+			},
+		},
+		V1: nil,
+	}
+}
+
+type mockBackendFactory struct {
+	mock.Mock
+}
+
+func (m *mockBackendFactory) NewBufferedBackend(cfg ledgerbackend.BufferedStorageBackendConfig,
+	ds datastore.DataStore,
+) (ledgerbackend.LedgerBackend, error) {
+	args := m.Called(cfg, ds)
+	return args.Get(0).(ledgerbackend.LedgerBackend), args.Error(1) //nolint:forcetypeassert
+}
+
+func TestLedgerReaderGetLedgers(t *testing.T) {
+	ctx := t.Context()
+
+	mockBackend := new(mockLedgerBackend)
+	mockDatastore := new(datastore.MockDataStore)
+	mockFactory := mockBackendFactory{}
+	start := uint32(100)
+	end := uint32(102)
+
+	var expected []xdr.LedgerCloseMeta
+	for seq := start; seq <= end; seq++ {
+		meta := createLedgerCloseMeta(seq)
+		mockBackend.On("GetLedger", ctx, seq).Return(meta, nil)
+		expected = append(expected, meta)
+	}
+	mockDatastore.On("GetSchema").Return(datastore.DataStoreSchema{
+		LedgersPerFile:    1,
+		FilesPerPartition: 1,
+	})
+	bsbConfig := ledgerbackend.BufferedStorageBackendConfig{
+		BufferSize: 10,
+		NumWorkers: 1,
+	}
+	mockBackend.On("PrepareRange", ctx, ledgerbackend.BoundedRange(start, end)).Return(nil)
+	mockBackend.On("Close").Return(nil)
+	mockFactory.On("NewBufferedBackend", bsbConfig, mockDatastore).Return(mockBackend, nil)
+
+	reader := &ledgerReader{
+		storageBackendConfig: bsbConfig,
+		dataStore:            mockDatastore,
+		ledgerBackendFactory: &mockFactory,
+	}
+
+	ledgers, err := reader.GetLedgers(ctx, start, end)
+	require.NoError(t, err)
+	require.Equal(t, expected, ledgers)
+
+	mockBackend.AssertExpectations(t)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/creachadair/jrpc2 v1.2.0
+	github.com/fsouza/fake-gcs-server v1.49.2
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/montanaflynn/stats v0.7.1
@@ -20,6 +21,14 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stellar/go v0.0.0-20250522155119-53d703e5aae1
 	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	cloud.google.com/go/pubsub v1.38.0 // indirect
+	github.com/google/renameio/v2 v2.0.0 // indirect
+	github.com/gorilla/handlers v1.5.2 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
+	github.com/pkg/xattr v0.4.9 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/iam v1.1.8 h1:r7umDwhj+BQyz0ScZMp4QrGXjSTI3ZINnpgU2nlB/K0=
 cloud.google.com/go/iam v1.1.8/go.mod h1:GvE6lyMmfxXauzNq8NbgJbeVQNspG+tcdL/W8QO1+zE=
+cloud.google.com/go/kms v1.17.1 h1:5k0wXqkxL+YcXd4viQzTqCgzzVKKxzgrK+rCZJytEQs=
+cloud.google.com/go/kms v1.17.1/go.mod h1:DCMnCF/apA6fZk5Cj4XsD979OyHAqFasPuA5Sd0kGlQ=
 cloud.google.com/go/longrunning v0.5.7 h1:WLbHekDbjK1fVFD3ibpFFVoyizlLRl73I7YKuAKilhU=
 cloud.google.com/go/longrunning v0.5.7/go.mod h1:8GClkudohy1Fxm3owmBGid8W0pSgodEMwEAztp38Xng=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
@@ -93,6 +95,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/djherbis/fscache v0.10.1 h1:hDv+RGyvD+UDKyRYuLoVNbuRTnf2SrA2K3VyR1br9lk=
 github.com/djherbis/fscache v0.10.1/go.mod h1:yyPYtkNnnPXsW+81lAcQS6yab3G2CRfnPLotBvtbf0c=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -135,6 +139,8 @@ github.com/gobuffalo/packd v1.0.2 h1:Yg523YqnOxGIWCp69W12yYBKsoChwI7mtu6ceM9Bwfw
 github.com/gobuffalo/packd v1.0.2/go.mod h1:sUc61tDqGMXON80zpKGp92lDb86Km28jfvX7IAyxFT8=
 github.com/gobuffalo/packr/v2 v2.8.3 h1:xE1yzvnO56cUC0sTpKR3DIbxZgB54AftTFMhB2XEWlY=
 github.com/gobuffalo/packr/v2 v2.8.3/go.mod h1:0SahksCVcx4IMnigTjiFuyldmTrdTctXsOdiU5KwbKc=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -196,7 +202,6 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
 github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
@@ -247,6 +252,8 @@ github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1q
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.6 h1:60eq2E/jlfwQXtvZEeBUYADs+BwKBWURIY+Gj2eRGjI=
 github.com/klauspost/compress v1.17.6/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/klauspost/cpuid/v2 v2.2.6 h1:ndNyv040zDGIDh8thGkXYjnFtiN02M1PVVF+JE/48xc=
+github.com/klauspost/cpuid/v2 v2.2.6/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -277,6 +284,10 @@ github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6
 github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
+github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
+github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
+github.com/minio/minio-go/v7 v7.0.71 h1:No9XfOKTYi6i0GnBj+WZwD8WP5GZfL7n7GOjRqCdAjA=
+github.com/minio/minio-go/v7 v7.0.71/go.mod h1:4yBA8v80xGA30cfM3fz0DKYMXunWl/AV/6tWEs9ryzo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
@@ -317,6 +328,8 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/cors v1.11.0 h1:0B9GE/r9Bc2UxRMMtymBkHTenPkHDv0CW4Y98GBY+po=
 github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
+github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rubenv/sql-migrate v1.5.2 h1:bMDqOnrJVV/6JQgQ/MxOpU+AdO8uzYYA/TxFUBzFtS0=
 github.com/rubenv/sql-migrate v1.5.2/go.mod h1:H38GW8Vqf8F0Su5XignRyaRcbXbJunSWxs+kmzlg0Is=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -386,6 +399,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.einride.tech/aip v0.67.1 h1:d/4TW92OxXBngkSOwWS2CH5rez869KpKMaN44mdxkFI=
+go.einride.tech/aip v0.67.1/go.mod h1:ZGX4/zKw8dcgzdLsrvpOOGxfxI2QSk12SlP7d6c0/XI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -552,6 +567,7 @@ golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
### What

This PR addresses [#425](https://github.com/stellar/stellar-rpc/issues/425) -  adding support for handling getLedgers requests that fall outside the rpc's local ledger retention window by proxies out of range requests to the datastore.

- Adds support for serving historical ledgers from a datastore when the requested range isn’t available locally.
- Uses BufferedStorageBackend to read from the datastore.
- The `gen-config-file` command now includes default `datastore_config` and `buffered_storage_backend_config` sections (commented out by default).
```
# Buffered storage backend configuration for reading ledgers from the datastore.
# [buffered_storage_backend_config]
  # buffer_size = 100
  # num_workers = 10
  # retry_limit = 3
  # retry_wait = "30s"

# External datastore configuration including type, bucket name and schema.
# [datastore_config]
  # type = "GCS"

  # [datastore_config.params]
    # destination_bucket_path = "path_to_bucket"

  # [datastore_config.schema]
    # files_per_partition = 64000
    # ledgers_per_file = 1
```

- Adds a new flag `serve_ledger_from_datastore`. The flag used instead of just relying on the presence of a datastore config because same datastore config can in future be also be used for ingestion from a datastore, so this flag control over which behavior is enabled.

- Includes basic unit tests. 

### Why
https://github.com/stellar/stellar-rpc/issues/425


### Known limitations

1. Currently, this assumes that the datastore has all ledgers starting from genesis. This is because there's no way yet to query datastore what range of ledgers it actually has. That limitation will be fixed once this [stellar/go#5498](https://github.com/stellar/go/issues/5498)) is done. We will then also use the real range to fill in the latestLedger and oldestLedger fields more accurately.

2. The `datastore_config` and `buffered_storage_backend_config`  can only be set through the config file and not with command-line flags. That’s because these settings can be complex or different depending on the type of datastore being used (like S3 or GCS). Supporting them in the config file keeps things simpler and more flexible.