### PR TITLE
Remove the UseDB flag from rpc configuration

### DIFF
--- a/cmd/stellar-rpc/internal/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/daemon/daemon.go
@@ -134,7 +134,6 @@ func newCaptiveCore(cfg *config.Config, logger *supportlog.Entry) (*ledgerbacken
 		HistoryArchiveURLs:                 cfg.HistoryArchiveURLs,
 		NetworkPassphrase:                  cfg.NetworkPassphrase,
 		Strict:                             true,
-		UseDB:                              true,
 		EnforceSorobanDiagnosticEvents:     true,
 		EnforceSorobanTransactionMetaExtV1: true,
 		CoreBinaryPath:                     cfg.StellarCoreBinaryPath,
@@ -154,7 +153,6 @@ func newCaptiveCore(cfg *config.Config, logger *supportlog.Entry) (*ledgerbacken
 		Log:                 logger.WithField("subservice", "stellar-core"),
 		Toml:                captiveCoreToml,
 		UserAgent:           cfg.ExtendedUserAgent("captivecore"),
-		UseDB:               true,
 	}
 	return ledgerbackend.NewCaptive(captiveConfig)
 }


### PR DESCRIPTION

### What
Remove the UseDB flag from rpc configuration

### Why

core in-memory mode fully removed in p23, so this flag will longer have any effect.

### Known limitations
N/A