### PR TITLE
Reset event indices at ledger level over transaction level

### DIFF
--- a/cmd/stellar-rpc/internal/db/event.go
+++ b/cmd/stellar-rpc/internal/db/event.go
@@ -104,8 +104,9 @@ func (eventHandler *eventHandler) InsertEvents(lcm xdr.LedgerCloseMeta) error {
 	//  - Post-application events have a TOID with { ledger seq, -1, 0 }
 	// where -1 is actually the largest possible uint32.
 	//
+	var beforeIndex, afterIndex uint32
 	insertableEvents := []dbEvent{}
-
+	
 	for {
 		var tx ingest.LedgerTransaction
 		tx, err = txReader.Read()
@@ -126,9 +127,10 @@ func (eventHandler *eventHandler) InsertEvents(lcm xdr.LedgerCloseMeta) error {
 		opEvents := allEvents.OperationEvents
 		txEvents := allEvents.TransactionEvents
 
+		var afterTxIndex uint32
+
 		// First, gather the transaction-level application events, tracking
 		// indices individually for each category.
-		var beforeIndex, afterIndex, afterTxIndex uint32
 		for _, event := range txEvents {
 			insertedEvent := dbEvent{
 				TxHash: tx.Hash,

--- a/cmd/stellar-rpc/internal/db/event_test.go
+++ b/cmd/stellar-rpc/internal/db/event_test.go
@@ -18,12 +18,38 @@ import (
 )
 
 func transactionMetaWithEvents(events ...xdr.ContractEvent) xdr.TransactionMeta {
+	// Invent some pre- and post-apply events.
+	stages := []xdr.TransactionEventStage{
+		xdr.TransactionEventStageTransactionEventStageAfterAllTxs,
+		xdr.TransactionEventStageTransactionEventStageBeforeAllTxs,
+		xdr.TransactionEventStageTransactionEventStageAfterTx,
+	}
+	body := xdr.ContractEventV0{
+		Data:   xdr.ScVal{Type: xdr.ScValTypeScvVoid},
+		Topics: []xdr.ScVal{{Type: xdr.ScValTypeScvVoid}},
+	}
+
+	txEvents := []xdr.TransactionEvent{}
+	for _, stage := range stages {
+		txEvents = append(txEvents, xdr.TransactionEvent{
+			Stage: stage,
+			Event: xdr.ContractEvent{
+				Type: xdr.ContractEventTypeSystem,
+				Body: xdr.ContractEventBody{
+					V:  0,
+					V0: &body,
+				},
+			},
+		})
+	}
+
 	return xdr.TransactionMeta{
-		V:          3,
+		V:          4,
 		Operations: &[]xdr.OperationMeta{},
-		V3: &xdr.TransactionMetaV3{
-			SorobanMeta: &xdr.SorobanTransactionMeta{
-				Events: events,
+		V4: &xdr.TransactionMetaV4{
+			Events: txEvents,
+			Operations: []xdr.OperationMetaV2{
+				{Events: events},
 			},
 		},
 	}
@@ -53,7 +79,7 @@ func ledgerCloseMetaWithEvents(
 
 	for _, item := range txMeta {
 		var operations []xdr.Operation
-		for range item.MustV3().SorobanMeta.Events {
+		for range item.MustV4().Operations {
 			operations = append(operations,
 				xdr.Operation{
 					Body: xdr.OperationBody{

--- a/protocol/get_events_test.go
+++ b/protocol/get_events_test.go
@@ -853,8 +853,8 @@ func TestEventFilterSerialization(t *testing.T) {
 		Encoded string
 	}{
 		{SegmentFilter{Wildcard: &wc1}, `"*"`},
-		{SegmentFilter{Wildcard: &wc0}, fmt.Sprintf(`"**"`)},
-		{SegmentFilter{ScVal: &scv}, fmt.Sprintf(`"%s"`, b64)},
+		{SegmentFilter{Wildcard: &wc0}, `"**"`},
+		{SegmentFilter{ScVal: &scv}, fmt.Sprintf("%q", b64)},
 	} {
 		filter := EventFilter{Topics: []TopicFilter{{testCase.Filter}}}
 

--- a/protocol/get_events_test.go
+++ b/protocol/get_events_test.go
@@ -116,11 +116,6 @@ func TestEventTypeSetValid(t *testing.T) {
 			false,
 		},
 		{
-			"set with three valid elements",
-			[]string{EventTypeSystem, EventTypeContract, EventTypeDiagnostic},
-			false,
-		},
-		{
 			"set with one invalid element",
 			[]string{"abc"},
 			true,
@@ -670,7 +665,7 @@ func TestGetEventsRequestValid(t *testing.T) {
 		},
 		Pagination: nil,
 	}).Valid(1000)
-	expectedErrStr := "filter 1 invalid: filter type invalid: if set, type must be either 'system', 'contract' or 'diagnostic'" //nolint:lll
+	expectedErrStr := "filter 1 invalid: filter type invalid: if set, type must be either 'system' or 'contract'" //nolint:lll
 	require.EqualError(t, err, expectedErrStr)
 
 	require.EqualError(t, (&GetEventsRequest{
@@ -850,12 +845,15 @@ func TestEventFilterSerialization(t *testing.T) {
 	b64, err := xdr.MarshalBase64(scv)
 	require.NoError(t, err)
 
+	wc1 := WildCardExactOne
+	wc0 := WildCardZeroOrMore
+
 	for _, testCase := range []struct {
 		Filter  SegmentFilter
 		Encoded string
 	}{
-		{SegmentFilter{Wildcard: &WildCardExactOne}, `"*"`},
-		{SegmentFilter{Wildcard: &wildCardZeroOrMore}, fmt.Sprintf(`"**"`)},
+		{SegmentFilter{Wildcard: &wc1}, `"*"`},
+		{SegmentFilter{Wildcard: &wc0}, fmt.Sprintf(`"**"`)},
 		{SegmentFilter{ScVal: &scv}, fmt.Sprintf(`"%s"`, b64)},
 	} {
 		filter := EventFilter{Topics: []TopicFilter{{testCase.Filter}}}


### PR DESCRIPTION
### What
The transaction-level event indices (`beforeIndex` and `afterIndex`) should never be reset, because this would create conflicts across cursors from transaction to transactions. Namely, notice the way the cursor is built:

```go
insertedEvent.Cursor = protocol.Cursor{
	Ledger: lcm.LedgerSequence(),
	Tx:     0, // min value
	Op:     0,
	Event:  beforeIndex,
}.String()
```

This would make the cursor identical for every event in the `TransactionEventStageTransactionEventStageBeforeAllTxs` for a ledger because `beforeIndex` would get reset for each transaction. However, these events are at the ledger level, so they need to be preserved in the outer loop. The same is the case for `...AfterAllTxs`.

### Why
Ingestion would halt on the uniqueness constraint of events otherwise.

This did not appear in integration testing because the ledger only contained a single transaction :facepalm: 
