### PR TITLE
Enforce autorestore for simulations in protocols > 22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "preflight"
-version = "22.0.0"
+version = "23.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/cmd/stellar-rpc/internal/integrationtest/migrate_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/migrate_test.go
@@ -22,7 +22,7 @@ func TestMigrate(t *testing.T) {
 		t.Skip("Only test this for the latest protocol: ", infrastructure.MaxSupportedProtocolVersion)
 	}
 	for _, originVersion := range getCurrentProtocolReleasedVersions(t) {
-		if originVersion == "22.0.0-rc2" || originVersion == "22.0.0-rc3" {
+		if originVersion == "22.0.0-rc2" || originVersion == "22.0.0-rc3" || originVersion == "23.0.0-rc.1" {
 			// This version of RPC wasn't published as a docker container w/ this tag
 			continue
 		}

--- a/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
@@ -413,7 +413,7 @@ func TestSimulateTransactionExtendAndRestoreFootprint(t *testing.T) {
 	},
 	)
 
-	getLedgerEntriesResult, err = client.GetLedgerEntries(context.Background(), getLedgerEntriesRequest)
+	getLedgerEntriesResult, err = client.GetLedgerEntries(t.Context(), getLedgerEntriesRequest)
 	require.NoError(t, err)
 
 	ledgerEntry = getLedgerEntriesResult.Entries[0]
@@ -497,7 +497,7 @@ func TestSimulateTransactionAutoRestore(t *testing.T) {
 		Keys: []string{keyB64},
 	}
 	client := test.GetRPCLient()
-	getLedgerEntriesResult, err := client.GetLedgerEntries(context.Background(), getLedgerEntriesRequest)
+	getLedgerEntriesResult, err := client.GetLedgerEntries(t.Context(), getLedgerEntriesRequest)
 	require.NoError(t, err)
 
 	var entry xdr.LedgerEntryData
@@ -525,7 +525,7 @@ func TestSimulateTransactionAutoRestore(t *testing.T) {
 	var transactionData xdr.SorobanTransactionData
 	err = xdr.SafeUnmarshalBase64(response.TransactionDataXDR, &transactionData)
 	require.NoError(t, err)
-	require.Equal(t, transactionData.Ext.V, int32(1))
+	require.Equal(t, int32(1), transactionData.Ext.V)
 	require.NotEmpty(t, transactionData.Ext.ResourceExt.ArchivedSorobanEntries)
 
 	preflightedParams := infrastructure.PreflightTransactionParamsLocally(t, params, response)

--- a/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
@@ -575,7 +575,8 @@ func waitUntilLedgerEntryTTL(t *testing.T, client *client.Client, ledgerKey xdr.
 		liveUntilLedgerSeq := xdr.Uint32(*result.Entries[0].LiveUntilLedgerSeq)
 		// See https://soroban.stellar.org/docs/fundamentals-and-concepts/state-expiration#expiration-ledger
 		currentLedger := result.LatestLedger + 1
-		if xdr.Uint32(currentLedger) > liveUntilLedgerSeq {
+		const ledgerWaitBuffer = 1
+		if xdr.Uint32(currentLedger) > liveUntilLedgerSeq+ledgerWaitBuffer {
 			ttled = true
 			t.Logf("ledger entry ttl'ed")
 			break

--- a/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
@@ -365,8 +365,11 @@ func TestSimulateTransactionUnmarshalError(t *testing.T) {
 }
 
 func TestSimulateTransactionExtendAndRestoreFootprint(t *testing.T) {
-	test := infrastructure.NewTest(t, nil)
+	if infrastructure.GetCoreMaxSupportedProtocol() > 22 {
+		t.Skip("Protocols > 22 support autorestore and generally don't require manual restoring")
+	}
 
+	test := infrastructure.NewTest(t, nil)
 	_, contractID, _ := test.CreateHelloWorldContract()
 	test.InvokeHostFunc(
 		contractID,
@@ -470,6 +473,67 @@ func TestSimulateTransactionExtendAndRestoreFootprint(t *testing.T) {
 	params = infrastructure.PreflightTransactionParamsLocally(t, invokeIncPresistentEntryParams, simulationResult)
 	tx, err = txnbuild.NewTransaction(params)
 	require.NoError(t, err)
+	test.SendMasterTransaction(tx)
+}
+
+func TestSimulateTransactionAutoRestore(t *testing.T) {
+	if infrastructure.GetCoreMaxSupportedProtocol() < 23 {
+		t.Skip("Protocols < 23 don't support autorestore")
+	}
+
+	test := infrastructure.NewTest(t, nil)
+	_, contractID, _ := test.CreateHelloWorldContract()
+	test.InvokeHostFunc(
+		contractID,
+		"inc",
+	)
+
+	// get the counter ledger entry TTL
+	key := getCounterLedgerKey(contractID)
+
+	keyB64, err := xdr.MarshalBase64(key)
+	require.NoError(t, err)
+	getLedgerEntriesRequest := protocol.GetLedgerEntriesRequest{
+		Keys: []string{keyB64},
+	}
+	client := test.GetRPCLient()
+	getLedgerEntriesResult, err := client.GetLedgerEntries(context.Background(), getLedgerEntriesRequest)
+	require.NoError(t, err)
+
+	var entry xdr.LedgerEntryData
+	require.NotEmpty(t, getLedgerEntriesResult.Entries)
+	ledgerEntry := getLedgerEntriesResult.Entries[0]
+	require.NoError(t, xdr.SafeUnmarshalBase64(ledgerEntry.DataXDR, &entry))
+	require.Equal(t, xdr.LedgerEntryTypeContractData, entry.Type)
+	require.NotNil(t, ledgerEntry.LiveUntilLedgerSeq)
+
+	// Wait until it is not live anymore
+	waitUntilLedgerEntryTTL(t, client, key)
+
+	// and implicitly autorestore it by calling the "inc" operation again
+
+	op := infrastructure.CreateInvokeHostOperation(test.MasterAccount().GetAccountID(), contractID, "inc")
+	params := infrastructure.CreateTransactionParams(
+		test.MasterAccount(),
+		op,
+	)
+	response := infrastructure.SimulateTransactionFromTxParams(t, client, params)
+	require.Empty(t, response.Error)
+	// The restore preamble should be zero
+	require.Nil(t, response.RestorePreamble)
+	// But the autorestore vector should not
+	var transactionData xdr.SorobanTransactionData
+	err = xdr.SafeUnmarshalBase64(response.TransactionDataXDR, &transactionData)
+	require.NoError(t, err)
+	require.Equal(t, transactionData.Ext.V, int32(1))
+	require.NotEmpty(t, transactionData.Ext.ResourceExt.ArchivedSorobanEntries)
+
+	preflightedParams := infrastructure.PreflightTransactionParamsLocally(t, params, response)
+
+	tx, err := txnbuild.NewTransaction(preflightedParams)
+	require.NoError(t, err)
+
+	// Execution with autorestoring should work
 	test.SendMasterTransaction(tx)
 }
 

--- a/cmd/stellar-rpc/lib/preflight/Cargo.toml
+++ b/cmd/stellar-rpc/lib/preflight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preflight"
-version = "22.0.0"
+version = "23.0.0"
 publish = false
 edition = "2021"
 

--- a/cmd/stellar-rpc/lib/preflight/src/lib.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/lib.rs
@@ -85,6 +85,18 @@ mod prev {
             shared::get_fallible_from_go_ledger_storage(self, key.as_ref())
         }
     }
+
+    impl soroban_env_host::storage::SnapshotSource for crate::GoLedgerStorage {
+        fn get(
+            &self,
+            key: &Rc<xdr::LedgerKey>,
+        ) -> Result<
+            Option<soroban_env_host::storage::EntryWithLiveUntil>,
+            soroban_env_host::HostError,
+        > {
+            shared::get_fallible_from_go_ledger_storage(self, key.as_ref())
+        }
+    }
 }
 
 use std::cell::RefCell;

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -180,6 +180,7 @@ pub(crate) fn preflight_invoke_hf_op_or_maybe_panic(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn preflight_invoke_hf_op_post_autorestore_or_maybe_panic(
     go_storage: &Rc<GoLedgerStorage>,
     network_config: &NetworkConfig,
@@ -223,6 +224,7 @@ pub(crate) fn preflight_invoke_hf_op_post_autorestore_or_maybe_panic(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn preflight_invoke_hf_op_pre_autorestore_or_maybe_panic(
     go_storage: &Rc<GoLedgerStorage>,
     network_config: &NetworkConfig,
@@ -236,7 +238,7 @@ pub(crate) fn preflight_invoke_hf_op_pre_autorestore_or_maybe_panic(
     // Use an autorestore wrapper to build the restore preamble
     let auto_restore_snapshot = Rc::new(AutoRestoringSnapshotSource::new(
         go_storage.clone(),
-        &ledger_info,
+        ledger_info,
     )?);
 
     // Invoke the host function. The user errors should normally be captured in
@@ -255,9 +257,9 @@ pub(crate) fn preflight_invoke_hf_op_pre_autorestore_or_maybe_panic(
     )?;
     let maybe_restore_result = match &invoke_hf_result.invoke_result {
         Ok(_) => auto_restore_snapshot.simulate_restore_keys_op(
-            &network_config,
+            network_config,
             &SimulationAdjustmentConfig::default_adjustment(),
-            &ledger_info,
+            ledger_info,
         ),
         Err(e) => Err(e.clone().into()),
     };

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -194,20 +194,7 @@ pub(crate) fn preflight_invoke_hf_op_post_autorestore_or_maybe_panic(
     enable_debug: bool,
 ) -> Result<CPreflightResult> {
     // TODO: A restore preamble should be generated when network limits are surpassed.
-    // The algorithm (suggested by Dima) would work as follows:
-    // 1. run simulation using regular (non-auto-restore) snapshot source. the result will contain
-    //    auto-restored entries (if any) in SorobanTransactionData . the result will also have proper
-    //    fees and limits for autorestoration.
-    // 2. verify the output SorobanTransactionData against the network limits.
-    //    2a. if it is below limits, return the result from step 1
-    //    2b. if it is above limits, re-run simulation using AutoRestoringSnapshotSource and
-    //        populate the restore preamble. now you'll have an invoke transaction without any
-    //        auto-restored entries, and a restore transaction.
-    //
-    // note, that step 2b doesn't guarantee that the original transaction without autorestore, or
-    // the restore transaction don't exceed the network limits. which is why I suggest to postpone
-    // that until after we have a more coherent design for handling the network limits in
-    // simulation. thus the algorithm can be shortcut to just step 1.
+    //       See https://github.com/stellar/stellar-rpc/issues/464
     let invoke_hf_result: InvokeHostFunctionSimulationResult = simulate_invoke_host_function_op(
         go_storage.clone(),
         network_config,

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -14,7 +14,7 @@
 use super::soroban_env_host::e2e_invoke::RecordingInvocationAuthMode;
 use super::soroban_env_host::xdr::{
     AccountId, ExtendFootprintTtlOp, InvokeHostFunctionOp, LedgerEntry, LedgerFootprint, LedgerKey,
-    OperationBody, ReadXdr, ScErrorCode, ScErrorType, SorobanTransactionData, WriteXdr,
+    OperationBody, ReadXdr, ScErrorCode, ScErrorType, SorobanTransactionData, WriteXdr, HostFunction,
 };
 use super::soroban_env_host::{LedgerInfo, DEFAULT_XDR_RW_LIMITS};
 use super::soroban_simulation::simulation::{
@@ -130,10 +130,6 @@ pub(crate) fn preflight_invoke_hf_op_or_maybe_panic(
     let network_config =
         NetworkConfig::load_from_snapshot(go_storage.as_ref(), c_ledger_info.bucket_list_size)?;
     let ledger_info = fill_ledger_info(c_ledger_info, &network_config);
-    let auto_restore_snapshot = Rc::new(AutoRestoringSnapshotSource::new(
-        go_storage.clone(),
-        &ledger_info,
-    )?);
 
     let mut adjustment_config = SimulationAdjustmentConfig::default_adjustment();
     // It would be reasonable to extend `resource_config` to be compatible with `adjustment_config`
@@ -156,17 +152,103 @@ pub(crate) fn preflight_invoke_hf_op_or_maybe_panic(
         AuthMode::RecordAllowNonroot => RecordingInvocationAuthMode::Recording(false),
     };
 
+    if ledger_info.protocol_version < 23 {
+        // Protocols lower than 23 don't support autorestore,
+        // we always use the restore preamble instead
+        preflight_invoke_hf_op_pre_autorestore_or_maybe_panic(
+            &go_storage,
+            &network_config,
+            &adjustment_config,
+            &ledger_info,
+            invoke_hf_op.host_function,
+            auth_mode,
+            &source_account,
+            enable_debug,
+        )
+    } else {
+        preflight_invoke_hf_op_post_autorestore_or_maybe_panic(
+            &go_storage,
+            &network_config,
+            &adjustment_config,
+            &ledger_info,
+            invoke_hf_op.host_function,
+            auth_mode,
+            &source_account,
+            enable_debug,
+        )
+    }
+}
+
+
+pub(crate) fn preflight_invoke_hf_op_post_autorestore_or_maybe_panic(
+    go_storage: &Rc<GoLedgerStorage>,
+    network_config: &NetworkConfig,
+    adjustment_config: &SimulationAdjustmentConfig,
+    ledger_info: &LedgerInfo,
+    hf: HostFunction,
+    auth_mode: RecordingInvocationAuthMode,
+    source_account: &AccountId,
+    enable_debug: bool) -> Result<CPreflightResult> {
+    // TODO: A restore preamble should be generated when network limits are surpassed.
+    // The algorithm (suggested by Dima) would work as follows: 
+    // 1. run simulation using regular (non-auto-restore) snapshot source. the result will contain 
+    //    auto-restored entries (if any) in SorobanTransactionData . the result will also have proper 
+    //    fees and limits for autorestoration. 
+    // 2. verify the output SorobanTransactionData against the network limits. 
+    //    2a. if it is below limits, return the result from step 1 
+    //    2b. if it is above limits, re-run simulation using AutoRestoringSnapshotSource and 
+    //        populate the restore preamble. now you'll have an invoke transaction without any 
+    //        auto-restored entries, and a restore transaction. 
+    //
+    // note, that step 2b doesn't guarantee that the original transaction without autorestore, or
+    // the restore transaction don't exceed the network limits. which is why I suggest to postpone
+    // that until after we have a more coherent design for handling the network limits in
+    // simulation. thus the algorithm can be shortcut to just step 1.
+    let invoke_hf_result: InvokeHostFunctionSimulationResult = simulate_invoke_host_function_op(
+        go_storage.clone(),
+        network_config,
+        adjustment_config,
+        ledger_info,
+        hf,
+        auth_mode,
+        source_account,
+        rand::Rng::gen(&mut rand::thread_rng()),
+        enable_debug,
+    )?;
+    Ok(new_cpreflight_result_from_invoke_host_function(
+        invoke_hf_result,
+        None,
+        String::new(),
+    ))
+}
+
+pub(crate) fn preflight_invoke_hf_op_pre_autorestore_or_maybe_panic(
+    go_storage: &Rc<GoLedgerStorage>,
+    network_config: &NetworkConfig,
+    adjustment_config: &SimulationAdjustmentConfig,
+    ledger_info: &LedgerInfo,
+    hf: HostFunction,
+    auth_mode: RecordingInvocationAuthMode,
+    source_account: &AccountId,
+    enable_debug: bool) -> Result<CPreflightResult> {
+
+    // Use an autorestore wrapper to build the restore preamble
+    let auto_restore_snapshot = Rc::new(AutoRestoringSnapshotSource::new(
+        go_storage.clone(),
+        &ledger_info,
+    )?);
+
     // Invoke the host function. The user errors should normally be captured in
     // `invoke_hf_result.invoke_result` and this should return Err result for
     // misconfigured ledger.
     let invoke_hf_result: InvokeHostFunctionSimulationResult = simulate_invoke_host_function_op(
         auto_restore_snapshot.clone(),
-        &network_config,
-        &adjustment_config,
-        &ledger_info,
-        invoke_hf_op.host_function,
+        network_config,
+        adjustment_config,
+        ledger_info,
+        hf,
         auth_mode,
-        &source_account,
+        source_account,
         rand::Rng::gen(&mut rand::thread_rng()),
         enable_debug,
     )?;

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -217,7 +217,10 @@ pub(crate) fn preflight_invoke_hf_op_post_autorestore_or_maybe_panic(
         rand::Rng::gen(&mut rand::thread_rng()),
         enable_debug,
     )?;
-    let invoke_result = invoke_hf_result.invoke_result.as_ref().map_err(|e| e.clone().into());
+    let invoke_result = invoke_hf_result
+        .invoke_result
+        .as_ref()
+        .map_err(|e| e.clone().into());
     let error_str = extract_error_string(&invoke_result, go_storage.as_ref());
     Ok(new_cpreflight_result_from_invoke_host_function(
         invoke_hf_result,

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -153,6 +153,8 @@ pub(crate) fn preflight_invoke_hf_op_or_maybe_panic(
         AuthMode::RecordAllowNonroot => RecordingInvocationAuthMode::Recording(false),
     };
 
+    // TODO: Deprecate this distinction after protocol 24
+    //       (since we only support the last two protocols)
     if ledger_info.protocol_version < 23 {
         // Protocols lower than 23 don't support autorestore,
         // we always use the restore preamble instead

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -217,10 +217,12 @@ pub(crate) fn preflight_invoke_hf_op_post_autorestore_or_maybe_panic(
         rand::Rng::gen(&mut rand::thread_rng()),
         enable_debug,
     )?;
+    let invoke_result = invoke_hf_result.invoke_result.as_ref().map_err(|e| e.clone().into());
+    let error_str = extract_error_string(&invoke_result, go_storage.as_ref());
     Ok(new_cpreflight_result_from_invoke_host_function(
         invoke_hf_result,
         None,
-        String::new(),
+        error_str,
     ))
 }
 

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -13,8 +13,9 @@
 // `crate::`.
 use super::soroban_env_host::e2e_invoke::RecordingInvocationAuthMode;
 use super::soroban_env_host::xdr::{
-    AccountId, ExtendFootprintTtlOp, InvokeHostFunctionOp, LedgerEntry, LedgerFootprint, LedgerKey,
-    OperationBody, ReadXdr, ScErrorCode, ScErrorType, SorobanTransactionData, WriteXdr, HostFunction,
+    AccountId, ExtendFootprintTtlOp, HostFunction, InvokeHostFunctionOp, LedgerEntry,
+    LedgerFootprint, LedgerKey, OperationBody, ReadXdr, ScErrorCode, ScErrorType,
+    SorobanTransactionData, WriteXdr,
 };
 use super::soroban_env_host::{LedgerInfo, DEFAULT_XDR_RW_LIMITS};
 use super::soroban_simulation::simulation::{
@@ -179,7 +180,6 @@ pub(crate) fn preflight_invoke_hf_op_or_maybe_panic(
     }
 }
 
-
 pub(crate) fn preflight_invoke_hf_op_post_autorestore_or_maybe_panic(
     go_storage: &Rc<GoLedgerStorage>,
     network_config: &NetworkConfig,
@@ -188,7 +188,8 @@ pub(crate) fn preflight_invoke_hf_op_post_autorestore_or_maybe_panic(
     hf: HostFunction,
     auth_mode: RecordingInvocationAuthMode,
     source_account: &AccountId,
-    enable_debug: bool) -> Result<CPreflightResult> {
+    enable_debug: bool,
+) -> Result<CPreflightResult> {
     // TODO: A restore preamble should be generated when network limits are surpassed.
     // The algorithm (suggested by Dima) would work as follows:
     // 1. run simulation using regular (non-auto-restore) snapshot source. the result will contain
@@ -230,8 +231,8 @@ pub(crate) fn preflight_invoke_hf_op_pre_autorestore_or_maybe_panic(
     hf: HostFunction,
     auth_mode: RecordingInvocationAuthMode,
     source_account: &AccountId,
-    enable_debug: bool) -> Result<CPreflightResult> {
-
+    enable_debug: bool,
+) -> Result<CPreflightResult> {
     // Use an autorestore wrapper to build the restore preamble
     let auto_restore_snapshot = Rc::new(AutoRestoringSnapshotSource::new(
         go_storage.clone(),

--- a/cmd/stellar-rpc/lib/preflight/src/shared.rs
+++ b/cmd/stellar-rpc/lib/preflight/src/shared.rs
@@ -190,15 +190,15 @@ pub(crate) fn preflight_invoke_hf_op_post_autorestore_or_maybe_panic(
     source_account: &AccountId,
     enable_debug: bool) -> Result<CPreflightResult> {
     // TODO: A restore preamble should be generated when network limits are surpassed.
-    // The algorithm (suggested by Dima) would work as follows: 
-    // 1. run simulation using regular (non-auto-restore) snapshot source. the result will contain 
-    //    auto-restored entries (if any) in SorobanTransactionData . the result will also have proper 
-    //    fees and limits for autorestoration. 
-    // 2. verify the output SorobanTransactionData against the network limits. 
-    //    2a. if it is below limits, return the result from step 1 
-    //    2b. if it is above limits, re-run simulation using AutoRestoringSnapshotSource and 
-    //        populate the restore preamble. now you'll have an invoke transaction without any 
-    //        auto-restored entries, and a restore transaction. 
+    // The algorithm (suggested by Dima) would work as follows:
+    // 1. run simulation using regular (non-auto-restore) snapshot source. the result will contain
+    //    auto-restored entries (if any) in SorobanTransactionData . the result will also have proper
+    //    fees and limits for autorestoration.
+    // 2. verify the output SorobanTransactionData against the network limits.
+    //    2a. if it is below limits, return the result from step 1
+    //    2b. if it is above limits, re-run simulation using AutoRestoringSnapshotSource and
+    //        populate the restore preamble. now you'll have an invoke transaction without any
+    //        auto-restored entries, and a restore transaction.
     //
     // note, that step 2b doesn't guarantee that the original transaction without autorestore, or
     // the restore transaction don't exceed the network limits. which is why I suggest to postpone


### PR DESCRIPTION
### What

Enforce autorestore for simulations in protocols > 22, by including the required `archivedEntries` vector in the `SorobanResourcesExtV0` of the `SorobanTransactionData` returned by the `simulateTransaction` method.

### Why

Autorestore wasn't working in the simulation of protocol 23

### Known limitations

The restore preamble won't be generated in the corner cases in which autorestore isn't enough. (See https://github.com/stellar/stellar-rpc/issues/464 )
