### PR TITLE
Hide diagnostic events from getTransaction(s) `events` entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 
+## Unreleased
+
+### Breaking Changes
+- The new top-level `"events"` structure to the `getTransaction` and `getTransactions` endpoint no longer has the `diagnosticEvents[Xdr|Json]`; prefer the top-level field instead as it will contain *all* of the diagnostic events that occurred in a transaction ([#455](https://github.com/stellar/stellar-rpc/pull/455)).
 
 
 ## [v23.0.0-rc.1](https://github.com/stellar/stellar-rpc/compare/v22.1.3...v23.0.0-rc.1)
@@ -12,7 +15,6 @@
 - The `inSuccessfulContractCall` field of `getEvents` is now deprecated and will be removed in the next version ([#4590](https://github.com/stellar/stellar-rpc/pull/4590)).
 
 ### Added
-
 - Added a top-level `"events"` structure to the `getTransaction` and `getTransactions` endpoint which breaks down events into disjoint `diagnosticEvents[Xdr|Json]`, `contractEvents[Xdr|Json]`, and `transactionEvents[Xdr|Json]` ([#455](https://github.com/stellar/stellar-rpc/pull/455)).
 - Added `"**"` wildcard to the `getEvents` endpoint, enabling flexible topic matching without manual padding. For example, `["X", "**"]` filter matches events with `"X"` as the first topic followed by any number of topics. The wildcard can be used only as the last or the only topic ([#419](https://github.com/stellar/stellar-rpc/pull/419)).
 - Added a field to `getLedgerEntries` results, the `extension[Xdr|Json]` field representing the `LedgerEntry`'s extension ([#388](https://github.com/stellar/stellar-rpc/pull/388)).

--- a/cmd/stellar-rpc/internal/db/transaction_test.go
+++ b/cmd/stellar-rpc/internal/db/transaction_test.go
@@ -110,10 +110,6 @@ func TestTransactionEvent(t *testing.T) {
 				},
 			},
 			expectedTx: Transaction{
-				DiagnosticEvents: [][]byte{
-					mustMarshalBinary(createDiagnosticEvent()),
-					mustMarshalBinary(createDiagnosticEvent()),
-				},
 				ContractEvents: [][][]byte{
 					{
 						mustMarshalBinary(createContractEvent()),
@@ -147,7 +143,6 @@ func TestTransactionEvent(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, tc.expectedTx.ContractEvents, tx.ContractEvents)
-		require.Equal(t, tc.expectedTx.DiagnosticEvents, tx.DiagnosticEvents)
 		require.Equal(t, tc.expectedTx.TransactionEvents, tx.TransactionEvents)
 	}
 }

--- a/cmd/stellar-rpc/internal/integrationtest/get_transactions_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/get_transactions_test.go
@@ -5,11 +5,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
-	"github.com/stellar/go/xdr"
 
 	"github.com/stellar/stellar-rpc/client"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/integrationtest/infrastructure"
@@ -105,11 +103,6 @@ func TestGetTransactionsEvents(t *testing.T) {
 	assert.NotEmpty(t, response.Events.ContractEventsXDR)
 	assert.Len(t, response.Events.ContractEventsXDR, 1)
 	assert.Empty(t, response.Events.ContractEventsXDR[0])
-	assert.NotEmpty(t, response.Events.DiagnosticEventsXDR)
-
-	var ev xdr.DiagnosticEvent
-	err := xdr.SafeUnmarshalBase64(response.Events.DiagnosticEventsXDR[0], &ev)
-	require.NoError(t, err)
 
 	assert.Len(t, response.Events.TransactionEventsXDR, 2)
 	assert.NotEmpty(t, response.DiagnosticEventsXDR)

--- a/cmd/stellar-rpc/internal/methods/get_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/get_transaction.go
@@ -144,7 +144,7 @@ func BuildEventsJSONFromTransaction(tx db.Transaction) (protocol.Events, error) 
 		return events, err
 	}
 
-	if events.TransactionEventsJSON, err = jsonifySlice(xdr.DiagnosticEvent{}, tx.TransactionEvents); err != nil {
+	if events.TransactionEventsJSON, err = jsonifySlice(xdr.TransactionEvent{}, tx.TransactionEvents); err != nil {
 		return events, err
 	}
 

--- a/cmd/stellar-rpc/internal/methods/get_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/get_transaction.go
@@ -129,7 +129,6 @@ func GetTransaction(
 // BuildEventsXDRFromTransaction encodes events into base64 xdr format
 func BuildEventsXDRFromTransaction(tx db.Transaction) protocol.Events {
 	var events protocol.Events
-	events.DiagnosticEventsXDR = base64EncodeSlice(tx.DiagnosticEvents)
 	events.TransactionEventsXDR = base64EncodeSlice(tx.TransactionEvents)
 	events.ContractEventsXDR = base64EncodeSliceOfSlices(tx.ContractEvents)
 
@@ -140,10 +139,6 @@ func BuildEventsXDRFromTransaction(tx db.Transaction) protocol.Events {
 func BuildEventsJSONFromTransaction(tx db.Transaction) (protocol.Events, error) {
 	var events protocol.Events
 	var err error
-
-	if events.DiagnosticEventsJSON, err = jsonifySlice(xdr.DiagnosticEvent{}, tx.DiagnosticEvents); err != nil {
-		return events, err
-	}
 
 	if events.ContractEventsJSON, err = jsonifySliceOfSlices(xdr.ContractEvent{}, tx.ContractEvents); err != nil {
 		return events, err

--- a/cmd/stellar-rpc/internal/methods/get_transaction_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_transaction_test.go
@@ -213,7 +213,6 @@ func TestGetTransaction(t *testing.T) {
 
 func newEventObject() protocol.Events {
 	return protocol.Events{
-		DiagnosticEventsXDR:  []string{},
 		ContractEventsXDR:    [][]string{{}},
 		TransactionEventsXDR: []string{},
 	}

--- a/cmd/stellar-rpc/internal/methods/get_transactions_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_transactions_test.go
@@ -35,7 +35,6 @@ var expectedTransactionInfo = protocol.TransactionInfo{
 		ResultXDR:           "AAAAAAAAAGQAAAAAAAAAAAAAAAA=",
 		DiagnosticEventsXDR: []string{},
 		Events: protocol.Events{
-			DiagnosticEventsXDR:  []string{},
 			ContractEventsXDR:    [][]string{{}},
 			TransactionEventsXDR: []string{},
 		},

--- a/protocol/get_transactions.go
+++ b/protocol/get_transactions.go
@@ -24,12 +24,6 @@ func (req GetTransactionsRequest) IsValid(maxLimit uint, ledgerRange LedgerSeqRa
 
 // Events contains all the events related to the transaction in both XDR and JSON formats.
 type Events struct {
-	// DiagnosticEventsXDR contains base64-encoded xdr.DiagnosticEvent objects
-	DiagnosticEventsXDR []string `json:"diagnosticEventsXdr,omitempty"`
-
-	// DiagnosticEventsJSON contains DiagnosticEvents in raw JSON format
-	DiagnosticEventsJSON []json.RawMessage `json:"diagnosticEventsJson,omitempty"`
-
 	// TransactionEventsXDR contains base64-encoded xdr.TransactionEvent objects
 	TransactionEventsXDR []string `json:"transactionEventsXdr,omitempty"`
 
@@ -66,9 +60,7 @@ type TransactionDetails struct {
 	// ResultMetaXDR is the TransactionMeta XDR value.
 	ResultMetaXDR  string          `json:"resultMetaXdr,omitempty"`
 	ResultMetaJSON json.RawMessage `json:"resultMetaJson,omitempty"`
-	// DiagnosticEventsXDR is present only if the transaction was not successful.
 	// DiagnosticEventsXDR is a base64-encoded slice of xdr.DiagnosticEvent
-	// Deprecated:Use Events.DiagnosticEventsXDR instead
 	DiagnosticEventsXDR  []string          `json:"diagnosticEventsXdr,omitempty"`
 	DiagnosticEventsJSON []json.RawMessage `json:"diagnosticEventsJson,omitempty"`
 


### PR DESCRIPTION
### What
Remove `events.diagnosticEvents[Xdr|Json]` in lieu of the top-level field.

### Why
Replaces https://github.com/stellar/stellar-rpc/pull/469, essentially this list was confusing because it filtered out data and we will decide how to reintroduce it in a future iteration. Closes https://github.com/stellar/stellar-rpc/issues/456.

### Known limitations
n/a