### PR TITLE
Fix memory leak in XDR to JSON conversions

### DIFF
--- a/cmd/stellar-rpc/internal/xdr2json/conversion.go
+++ b/cmd/stellar-rpc/internal/xdr2json/conversion.go
@@ -67,6 +67,7 @@ func convertAnyBytes(xdrTypeName string, field []byte) (json.RawMessage, error) 
 
 		result := C.xdr_to_json(b, goRawXdr)
 		C.free(unsafe.Pointer(b))
+		FreeGoXDR(goRawXdr)
 
 		jsonStr = C.GoString(result.json)
 		errStr = C.GoString(result.error)
@@ -87,4 +88,8 @@ func CXDR(xdr []byte) C.xdr_t {
 		xdr: (*C.uchar)(C.CBytes(xdr)),
 		len: C.size_t(len(xdr)),
 	}
+}
+
+func FreeGoXDR(xdr C.xdr_t) {
+	C.free(unsafe.Pointer(xdr.xdr))
 }


### PR DESCRIPTION
### What

Deallocate XDR strings passed down to Rust for JSON conversion. 

### Why

Otherwise they incur in a memory leak. It may be the culprit of #448 (or part of it at least).

### Known limitations

N/A
