### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/protocol/get_events_test.go
+++ b/protocol/get_events_test.go
@@ -367,7 +367,7 @@ func TestTopicFilterJSON(t *testing.T) {
 	scval := xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &sixtyfour}
 	scvalstr, err := xdr.MarshalBase64(scval)
 	require.NoError(t, err)
-	require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf("[%q]", scvalstr)), &got))
+	require.NoError(t, json.Unmarshal(fmt.Appendf(nil, "[%q]", scvalstr), &got))
 	assert.Equal(t, TopicFilter{{ScVal: &scval}}, got)
 }
 


### PR DESCRIPTION
### What

Optimize code using a more modern writing style. Official support by Go Team. https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
