### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/protocol/get_events_test.go
+++ b/protocol/get_events_test.go
@@ -538,7 +538,7 @@ func TestTopicFilterJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	//  valid ScVal segment
-	require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf("[%q]", scvalstr)), &got))
+	require.NoError(t, json.Unmarshal(fmt.Appendf(nil, "[%q]", scvalstr), &got))
 	require.Equal(t, TopicFilter{{ScVal: &scval}}, got)
 
 	// valid topic with multiple ScVal segments (no wildcard)


### PR DESCRIPTION
### What


Inspired by  https://github.com/stellar/stellar-rpc/pull/476  and replace all.

Optimize code using a more modern writing style. Official support by Go Team. https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
