### PR TITLE
Bump rs-soroban-env to v23.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,9 +857,9 @@ dependencies = [
  "serde_json",
  "sha2",
  "soroban-env-host 22.1.4",
- "soroban-env-host 23.0.0",
+ "soroban-env-host 23.0.1",
  "soroban-simulation 22.1.4",
- "soroban-simulation 23.0.0",
+ "soroban-simulation 23.0.1",
 ]
 
 [[package]]
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c9c4d0b09353128719087a0dfe305c7b68c618b051275f00b8cf58e8e5ec5c"
+checksum = "d9336adeabcd6f636a4e0889c8baf494658ef5a3c4e7e227569acd2ce9091e85"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1176,16 +1176,16 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b074b5b762438461128a85948e4aa687568163a6db8b97870b4b0bc4b48849c"
+checksum = "00067f52e8bbf1abf0de03fe3e2fbb06910893cfbe9a7d9093d6425658833ff3"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-traits",
- "soroban-env-macros 23.0.0",
+ "soroban-env-macros 23.0.1",
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr 23.0.0",
@@ -1230,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163d8d0f4d5aea6181b94832c2f1d12920b63d4242802a25df4859dff23b33d9"
+checksum = "b9766c5ad78e9d8ae10afbc076301f7d610c16407a1ebb230766dbe007a48725"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -1256,8 +1256,8 @@ dependencies = [
  "sec1",
  "sha2",
  "sha3",
- "soroban-builtin-sdk-macros 23.0.0",
- "soroban-env-common 23.0.0",
+ "soroban-builtin-sdk-macros 23.0.1",
+ "soroban-env-common 23.0.1",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.13",
@@ -1281,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db76da38da84eda93a5fa16092c87e01860c4e3846a6e40052fe04dbefdeb1af"
+checksum = "b0e6a1c5844257ce96f5f54ef976035d5bd0ee6edefaf9f5e0bcb8ea4b34228c"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1309,13 +1309,13 @@ dependencies = [
 
 [[package]]
 name = "soroban-simulation"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59276a17af1eacefe4c27d8f48a9571a55f4b95203c4f5d529bef32f4a8b1d68"
+checksum = "8eba67cbff663682da5a3cd68bd60016b4d38fbad5640f0f9dbe12b105127e7b"
 dependencies = [
  "anyhow",
  "rand",
- "soroban-env-host 23.0.0",
+ "soroban-env-host 23.0.1",
  "static_assertions",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "=22.1.4"
 
 [workspace.dependencies.soroban-env-host-curr]
 package = "soroban-env-host"
-version = "=23.0.0"
+version = "=23.0.1"
 
 [workspace.dependencies.soroban-simulation-prev]
 package = "soroban-simulation"
@@ -23,7 +23,7 @@ version = "=22.1.4"
 
 [workspace.dependencies.soroban-simulation-curr]
 package = "soroban-simulation"
-version = "=23.0.0"
+version = "=23.0.1"
 
 [workspace.dependencies.stellar-xdr]
 version = "=23.0.0"


### PR DESCRIPTION
### What

Bump rs-soroban-env to v23.0.1

### Why

New  rs-soroban-env release is out  with fixes for autorestore.
https://github.com/stellar/rs-soroban-env/releases/tag/v23.0.1

### Known limitations
