### PR TITLE
Optimize `getLedgers` queries by only decoding the header

### DIFF
--- a/cmd/stellar-rpc/internal/methods/get_ledgers.go
+++ b/cmd/stellar-rpc/internal/methods/get_ledgers.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"github.com/stellar/go/support/log"
-	"github.com/stellar/go/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcdatastore"
@@ -37,8 +36,10 @@ func NewGetLedgersHandler(ledgerReader db.LedgerReader, maxLimit, defaultLimit u
 	}).getLedgers)
 }
 
-// getLedgers fetch ledgers and relevant metadata from DB and falling back to the remote rpcdatastore if necessary.
-func (h ledgersHandler) getLedgers(ctx context.Context, request protocol.GetLedgersRequest,
+// getLedgers fetch ledgers and relevant metadata from DB and falling back to
+// the remote rpcdatastore if necessary.
+func (h ledgersHandler) getLedgers(
+	ctx context.Context, request protocol.GetLedgersRequest,
 ) (protocol.GetLedgersResponse, error) {
 	readTx, err := h.ledgerReader.NewTx(ctx)
 	if err != nil {
@@ -159,99 +160,113 @@ func (h ledgersHandler) parseCursor(cursor string, ledgerRange protocol.LedgerSe
 //  1. Entire range is available in local db.
 //  2. Entire range is unavailable in local db so fetch fully from datastore.
 //  3. Range partially available in the local db with the rest fetched from the datastore.
-func (h ledgersHandler) fetchLedgers(ctx context.Context, start uint32,
-	end uint32, format string, readTx db.LedgerReaderTx, localLedgerRange protocol.LedgerSeqRange,
+func (h ledgersHandler) fetchLedgers(
+	ctx context.Context,
+	start, end uint32, format string,
+	readTx db.LedgerReaderTx,
+	localLedgerRange protocol.LedgerSeqRange,
 ) ([]protocol.LedgerInfo, error) {
-	fetchFromLocalDB := func(start uint32, end uint32) ([]xdr.LedgerCloseMeta, error) {
+	limit := end - start + 1
+	result := make([]protocol.LedgerInfo, 0, limit)
+
+	addToResult := func(ledgers []db.LedgerMetadataChunk) error {
+		for _, chunk := range ledgers {
+			if len(result) >= int(limit) {
+				break
+			}
+
+			if info, err := parseLedgerInfo(chunk, format); err != nil {
+				return &jrpc2.Error{
+					Code: jrpc2.InternalError,
+					Message: fmt.Sprintf("error processing ledger %d: %v",
+						chunk.Header.Header.LedgerSeq, err),
+				}
+			} else {
+				result = append(result, info)
+			}
+		}
+		return nil
+	}
+
+	fetchFromLocalDB := func(start, end uint32) error {
 		ledgers, err := readTx.BatchGetLedgers(ctx, start, end)
 		if err != nil {
-			return nil, &jrpc2.Error{
+			return &jrpc2.Error{
 				Code:    jrpc2.InternalError,
 				Message: fmt.Sprintf("error fetching ledgers from db: %v", err),
 			}
 		}
-		return ledgers, nil
+
+		return addToResult(ledgers)
 	}
 
-	fetchFromDatastore := func(start uint32, end uint32) ([]xdr.LedgerCloseMeta, error) {
+	fetchFromDatastore := func(start, end uint32) error {
 		if h.datastoreLedgerReader == nil {
-			return nil, &jrpc2.Error{
+			return &jrpc2.Error{
 				Code:    jrpc2.InvalidParams,
 				Message: "datastore ledger reader not configured",
 			}
 		}
 		ledgers, err := h.datastoreLedgerReader.GetLedgers(ctx, start, end)
 		if err != nil {
-			return nil, &jrpc2.Error{
+			return &jrpc2.Error{
 				Code:    jrpc2.InternalError,
 				Message: fmt.Sprintf("error fetching ledgers from datastore: %v", err),
 			}
 		}
-		return ledgers, nil
+
+		for _, ledger := range ledgers {
+			raw, err := ledger.MarshalBinary()
+			if err != nil {
+				return &jrpc2.Error{
+					Code:    jrpc2.InternalError,
+					Message: fmt.Sprintf("error fetching ledgers from datastore: %v", err),
+				}
+			}
+
+			if err := addToResult([]db.LedgerMetadataChunk{
+				{Lcm: raw, Header: ledger.LedgerHeaderHistoryEntry()},
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
-	limit := end - start + 1
-	ledgers := make([]xdr.LedgerCloseMeta, 0, limit)
 	switch {
 	case start >= localLedgerRange.FirstLedger:
 		// entire range is available in local DB
-		localLedgers, err := fetchFromLocalDB(start, end)
-		if err != nil {
+		if err := fetchFromLocalDB(start, end); err != nil {
 			return nil, err
 		}
-		ledgers = append(ledgers, localLedgers...)
 
 	case end < localLedgerRange.FirstLedger:
 		// entire range is unavailable locally so fetch everything from datastore
-		dataStoreLedgers, err := fetchFromDatastore(start, end)
-		if err != nil {
+		if err := fetchFromDatastore(start, end); err != nil {
 			return nil, err
 		}
-		ledgers = append(ledgers, dataStoreLedgers...)
 
 	default:
 		// part of the ledger range is available locally so fetch local ledgers from db,
 		// and the rest from the datastore.
-
-		dataStoreLedgers, err := fetchFromDatastore(start, localLedgerRange.FirstLedger-1)
-		if err != nil {
+		if err := fetchFromDatastore(start, localLedgerRange.FirstLedger-1); err != nil {
 			return nil, err
 		}
-		ledgers = append(ledgers, dataStoreLedgers...)
-
-		localLedgers, err := fetchFromLocalDB(localLedgerRange.FirstLedger, end)
-		if err != nil {
+		if err := fetchFromLocalDB(localLedgerRange.FirstLedger, end); err != nil {
 			return nil, err
 		}
-		ledgers = append(ledgers, localLedgers...)
-	}
-
-	// convert raw lcm to protocol.LedgerInfo
-	result := make([]protocol.LedgerInfo, 0, limit)
-	for _, ledger := range ledgers {
-		if len(result) >= int(limit) {
-			break
-		}
-
-		ledgerInfo, err := h.parseLedgerInfo(ledger, format)
-		if err != nil {
-			return nil, &jrpc2.Error{
-				Code:    jrpc2.InternalError,
-				Message: fmt.Sprintf("error processing ledger %d: %v", ledger.LedgerSequence(), err),
-			}
-		}
-		result = append(result, ledgerInfo)
 	}
 
 	return result, nil
 }
 
 // parseLedgerInfo extracts and formats the ledger metadata and header information.
-func (h ledgersHandler) parseLedgerInfo(ledger xdr.LedgerCloseMeta, format string) (protocol.LedgerInfo, error) {
+func parseLedgerInfo(ledger db.LedgerMetadataChunk, format string) (protocol.LedgerInfo, error) {
+	header := ledger.Header
 	ledgerInfo := protocol.LedgerInfo{
-		Hash:            ledger.LedgerHash().HexString(),
-		Sequence:        ledger.LedgerSequence(),
-		LedgerCloseTime: ledger.LedgerCloseTime(),
+		Hash:            header.Hash.HexString(),
+		Sequence:        uint32(header.Header.LedgerSeq),
+		LedgerCloseTime: int64(header.Header.ScpValue.CloseTime),
 	}
 
 	// Format the data according to the requested format (JSON or XDR)
@@ -262,18 +277,14 @@ func (h ledgersHandler) parseLedgerInfo(ledger xdr.LedgerCloseMeta, format strin
 		if convErr != nil {
 			return ledgerInfo, convErr
 		}
-	default:
-		closeMetaB, err := ledger.MarshalBinary()
-		if err != nil {
-			return protocol.LedgerInfo{}, fmt.Errorf("error marshaling ledger close meta: %w", err)
-		}
 
-		headerB, err := ledger.LedgerHeaderHistoryEntry().MarshalBinary()
+	default:
+		headerB, err := ledger.Header.MarshalBinary()
 		if err != nil {
 			return protocol.LedgerInfo{}, fmt.Errorf("error marshaling ledger header: %w", err)
 		}
 
-		ledgerInfo.LedgerMetadata = base64.StdEncoding.EncodeToString(closeMetaB)
+		ledgerInfo.LedgerMetadata = base64.StdEncoding.EncodeToString(ledger.Lcm)
 		ledgerInfo.LedgerHeader = base64.StdEncoding.EncodeToString(headerB)
 	}
 	return ledgerInfo, nil

--- a/cmd/stellar-rpc/internal/methods/get_ledgers_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_ledgers_test.go
@@ -31,7 +31,9 @@ func setupTestDB(t *testing.T, numLedgers int) *db.DB {
 	daemon := interfaces.MakeNoOpDeamon()
 	for sequence := 1; sequence <= numLedgers; sequence++ {
 		ledgerCloseMeta := txMeta(uint32(sequence)-100, true)
-		tx, err := db.NewReadWriter(log.DefaultLogger, testDB, daemon, 150, 100, passphrase).NewTx(context.Background())
+		tx, err := db.
+			NewReadWriter(log.DefaultLogger, testDB, daemon, 150, 100, passphrase).
+			NewTx(context.Background())
 		require.NoError(t, err)
 		require.NoError(t, tx.LedgerWriter().InsertLedger(ledgerCloseMeta))
 		require.NoError(t, tx.Commit(ledgerCloseMeta, nil))
@@ -51,7 +53,7 @@ func TestGetLedgers_DefaultLimit(t *testing.T) {
 		StartLedger: 1,
 	}
 
-	response, err := handler.getLedgers(context.TODO(), request)
+	response, err := handler.getLedgers(t.Context(), request)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(50), response.LatestLedger)
@@ -80,7 +82,7 @@ func TestGetLedgers_CustomLimit(t *testing.T) {
 		},
 	}
 
-	response, err := handler.getLedgers(context.TODO(), request)
+	response, err := handler.getLedgers(t.Context(), request)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(40), response.LatestLedger)
@@ -290,6 +292,7 @@ func setupBenchmarkingDB(b *testing.B) *db.DB {
 
 func createLedgerCloseMeta(ledgerSeq uint32) xdr.LedgerCloseMeta {
 	return xdr.LedgerCloseMeta{
+		V: 0,
 		V0: &xdr.LedgerCloseMetaV0{
 			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
 				Header: xdr.LedgerHeader{
@@ -297,7 +300,6 @@ func createLedgerCloseMeta(ledgerSeq uint32) xdr.LedgerCloseMeta {
 				},
 			},
 		},
-		V1: nil,
 	}
 }
 
@@ -370,8 +372,17 @@ func TestGetLedgers(t *testing.T) {
 				FirstLedger: 2,
 			}, nil)
 			if len(tc.expectLocal) > 0 {
+				ledgerChunks := []db.LedgerMetadataChunk{}
+				for _, ledger := range getLedgerRange(tc.expectLocal) {
+					raw, err := ledger.MarshalBinary()
+					require.NoError(t, err)
+					ledgerChunks = append(ledgerChunks, db.LedgerMetadataChunk{
+						Lcm:    raw,
+						Header: ledger.LedgerHeaderHistoryEntry(),
+					})
+				}
 				mockReaderTx.On("BatchGetLedgers", ctx, tc.expectLocal[0], tc.expectLocal[len(tc.expectLocal)-1]).
-					Return(getLedgerRange(tc.expectLocal), nil)
+					Return(ledgerChunks, nil)
 			}
 
 			if len(tc.expectDatastore) > 0 {
@@ -406,7 +417,7 @@ func TestFetchLedgersErrors(t *testing.T) {
 	t.Run("DB error", func(t *testing.T) {
 		mockTx := new(MockLedgerReaderTx)
 		mockTx.On("BatchGetLedgers", ctx, uint32(150), uint32(151)).
-			Return([]xdr.LedgerCloseMeta(nil), errors.New("db error"))
+			Return([]db.LedgerMetadataChunk(nil), errors.New("db error"))
 
 		handler := ledgersHandler{}
 		_, err := handler.fetchLedgers(ctx, 150, 151, "default", mockTx, localRange)

--- a/cmd/stellar-rpc/internal/methods/json.go
+++ b/cmd/stellar-rpc/internal/methods/json.go
@@ -36,16 +36,16 @@ func transactionToJSON(tx db.Transaction) (
 	return result, envelope, resultMeta, nil
 }
 
-func ledgerToJSON(meta *xdr.LedgerCloseMeta) ([]byte, []byte, error) {
+func ledgerToJSON(chunk *db.LedgerMetadataChunk) ([]byte, []byte, error) {
 	var err error
 	var closeMetaJSON, headerJSON []byte
 
-	closeMetaJSON, err = xdr2json.ConvertInterface(*meta)
+	closeMetaJSON, err = xdr2json.ConvertBytes(xdr.LedgerCloseMeta{}, chunk.Lcm)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	headerJSON, err = xdr2json.ConvertInterface(meta.LedgerHeaderHistoryEntry())
+	headerJSON, err = xdr2json.ConvertInterface(chunk.Header)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/stellar-rpc/internal/methods/mocks.go
+++ b/cmd/stellar-rpc/internal/methods/mocks.go
@@ -64,9 +64,9 @@ func (m *MockLedgerReaderTx) GetLedgerRange(ctx context.Context) (ledgerbucketwi
 	return args.Get(0).(ledgerbucketwindow.LedgerRange), args.Error(1) //nolint:forcetypeassert
 }
 
-func (m *MockLedgerReaderTx) BatchGetLedgers(ctx context.Context, start, end uint32) ([]xdr.LedgerCloseMeta, error) {
+func (m *MockLedgerReaderTx) BatchGetLedgers(ctx context.Context, start, end uint32) ([]db.LedgerMetadataChunk, error) {
 	args := m.Called(ctx, start, end)
-	return args.Get(0).([]xdr.LedgerCloseMeta), args.Error(1) //nolint:forcetypeassert
+	return args.Get(0).([]db.LedgerMetadataChunk), args.Error(1) //nolint:forcetypeassert
 }
 
 func (m *MockLedgerReaderTx) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {


### PR DESCRIPTION
### What
Instead of decoding the raw binary data directly into an `xdr.LedgerCloseMeta`, this modifies the code to only decode the `xdr.LedgerHeaderHistoryEntry` out of the data which comes first in the layout. The rest of the meta is passed around directly as a `[]byte` until the final step, either converting it to base64 directly or to JSON.

Rudimentary benchmarks show a ~40% improvement over the baseline:

```
$ git switch main
$ go test -failfast -run=None -bench=BenchmarkBatchGetLedgers ./cmd/stellar-rpc/internal/db
goos: linux
goarch: amd64
pkg: github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db
cpu: 13th Gen Intel(R) Core(TM) i7-1360P
BenchmarkBatchGetLedgers-16    	git switch -    1788	    773248 ns/op
PASS
ok  	github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db	7.652s

$ git switch getLedgers_depthCheck
$ go test -failfast -run=None -bench=BenchmarkBatchGetLedgers ./cmd/stellar-rpc/internal/db
goos: linux
goarch: amd64
pkg: github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db
cpu: 13th Gen Intel(R) Core(TM) i7-1360P
BenchmarkBatchGetLedgers-16    	    1939	    530915 ns/op
PASS
ok  	github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db	3.325s
```

### Why
We have observed performance issues with `getLedgers` due to their density and would like to improve them.

### Known limitations
This needs to be evaluated against real load to see the improvement.
