### PR TITLE
Don't pre-create `stateChanges` to avoid empty structures for no-op changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+- `simulateTransaction` would occasionally emit state changes that did not have a `type` ([#506](https://github.com/stellar/stellar-rpc/pull/506)).
+
+
 ## [v23.0.1](https://github.com/stellar/stellar-rpc/compare/v23.0.0...v23.0.1)
- - Bump soroban-env lib to v23.0.1 ([#499](https://github.com/stellar/stellar-rpc/pull/499)).
+- Bump soroban-env lib to v23.0.1 ([#499](https://github.com/stellar/stellar-rpc/pull/499)).
 
 
 ## [v23.0.0](https://github.com/stellar/stellar-rpc/compare/v22.1.5...v23.0.0): Protocol 23 Release

--- a/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/simulate_transaction_test.go
@@ -76,7 +76,7 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 	require.Equal(t, expectedXdr, resultXdr)
 
 	// Check state diff
-	require.Len(t, result.StateChanges, 1)
+	require.Len(t, result.StateChanges, 1, "result: %+v", result)
 	require.Nil(t, result.StateChanges[0].BeforeXDR)
 	require.NotNil(t, result.StateChanges[0].AfterXDR)
 	require.Equal(t, protocol.LedgerEntryChangeTypeCreated, result.StateChanges[0].Type)

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction.go
@@ -38,6 +38,7 @@ func LedgerEntryChangeFromXDRDiff(diff preflight.XDRDiff, format string) (protoc
 
 	beforePresent := len(diff.Before) > 0
 	afterPresent := len(diff.After) > 0
+
 	switch {
 	case beforePresent:
 		entryXDR = diff.Before
@@ -55,9 +56,7 @@ func LedgerEntryChangeFromXDRDiff(diff preflight.XDRDiff, format string) (protoc
 		return protocol.LedgerEntryChange{}, errMissingDiff
 	}
 
-	var result protocol.LedgerEntryChange
-
-	result.Type = changeType
+	result := protocol.LedgerEntryChange{Type: changeType}
 
 	// We need to unmarshal the ledger entry for both b64 and json cases
 	// because we need the inner ledger key.
@@ -206,8 +205,8 @@ func formatResponse(preflight preflight.Preflight,
 	}
 
 	stateChanges := make([]protocol.LedgerEntryChange, 0, len(preflight.LedgerEntryDiff))
-	for i := range stateChanges {
-		change, err := LedgerEntryChangeFromXDRDiff(preflight.LedgerEntryDiff[i], format)
+	for _, entryDiff := range preflight.LedgerEntryDiff {
+		change, err := LedgerEntryChangeFromXDRDiff(entryDiff, format)
 		// Intentionally ignore "no before and after" entries because they're
 		// possible but shouldn't result in a full failure.
 		if errors.Is(err, errMissingDiff) {

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction.go
@@ -207,14 +207,12 @@ func formatResponse(preflight preflight.Preflight,
 
 	stateChanges := make([]protocol.LedgerEntryChange, 0, len(preflight.LedgerEntryDiff))
 	for i := range stateChanges {
-		var err error
 		change, err := LedgerEntryChangeFromXDRDiff(preflight.LedgerEntryDiff[i], format)
-		if err != nil {
-			// Intentionally ignore "no before and after" entries because
-			// they're possible but shouldn't result in a full failure.
-			if errors.Is(err, errMissingDiff) {
-				continue
-			}
+		// Intentionally ignore "no before and after" entries because they're
+		// possible but shouldn't result in a full failure.
+		if errors.Is(err, errMissingDiff) {
+			continue
+		} else if err != nil {
 			return protocol.SimulateTransactionResponse{}, err
 		}
 

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction.go
@@ -205,7 +205,7 @@ func formatResponse(preflight preflight.Preflight,
 		return protocol.SimulateTransactionResponse{}, err
 	}
 
-	stateChanges := make([]protocol.LedgerEntryChange, len(preflight.LedgerEntryDiff))
+	stateChanges := make([]protocol.LedgerEntryChange, 0, len(preflight.LedgerEntryDiff))
 	for i := range stateChanges {
 		var err error
 		change, err := LedgerEntryChangeFromXDRDiff(preflight.LedgerEntryDiff[i], format)
@@ -218,7 +218,7 @@ func formatResponse(preflight preflight.Preflight,
 			return protocol.SimulateTransactionResponse{}, err
 		}
 
-		stateChanges[i] = change
+		stateChanges = append(stateChanges, change)
 	}
 
 	simResp := protocol.SimulateTransactionResponse{

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction_test.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction_test.go
@@ -86,6 +86,14 @@ func TestLedgerEntryChange(t *testing.T) {
 				AfterXDR:  &entryB64,
 			},
 		},
+		{
+			name: "created",
+			input: preflight.XDRDiff{
+				Before: nil,
+				After:  nil,
+			},
+			expectedOutput: protocol.LedgerEntryChange{},
+		},
 	} {
 		var change protocol.LedgerEntryChange
 		change, err := LedgerEntryChangeFromXDRDiff(test.input, "")

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction_test.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction_test.go
@@ -86,14 +86,6 @@ func TestLedgerEntryChange(t *testing.T) {
 				AfterXDR:  &entryB64,
 			},
 		},
-		{
-			name: "created",
-			input: preflight.XDRDiff{
-				Before: nil,
-				After:  nil,
-			},
-			expectedOutput: protocol.LedgerEntryChange{},
-		},
 	} {
 		var change protocol.LedgerEntryChange
 		change, err := LedgerEntryChangeFromXDRDiff(test.input, "")
@@ -119,4 +111,12 @@ func TestLedgerEntryChange(t *testing.T) {
 			require.Equal(t, entryJs, changeJs.BeforeJSON)
 		}
 	}
+
+	// Check the error case
+	change, err := LedgerEntryChangeFromXDRDiff(preflight.XDRDiff{
+		Before: nil,
+		After:  nil,
+	}, "")
+	require.ErrorIs(t, err, errMissingDiff)
+	require.Equal(t, protocol.LedgerEntryChange{}, change)
 }


### PR DESCRIPTION
### What
As part of #396 we allowed pre and post to both be `nil`, but did not handle their JSON-side rendering. Since we preallocated the `stateChanges` list, it would have empty structures in those cases despite the `continue`. By using `append`, we ensure only meaningful structures get rendered.

### Why
We should conform to our API contract and never have `type = ""`.

### Known limitations
n/a