### PR TITLE
Bump protocol 26 core version to 27.0.0-3288.7696c069d

### DIFF
--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -97,8 +97,8 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '26'
-      core_deb_version: '26.0.0-3089.8e43a2d3b.jammy'
-      core_docker_img: 'stellar/stellar-core:26.0.0-3089.8e43a2d3b.jammy'
+      core_deb_version: '27.0.0-3288.7696c069d.jammy'
+      core_docker_img: 'stellar/stellar-core:27.0.0-3288.7696c069d.jammy'
 
   # integration-p25-src:
   #   name: Integration tests (p25, core from source)


### PR DESCRIPTION
Similar to #528 — bumps the core version used by the CI integration tests so we can run them against `27.0.0-3288.7696c069d`.

Only the P26 lane is bumped; P25 pins are unchanged. (Companion to stellar/stellar-horizon#188.)

Draft — for running CI integration tests only.