### PR TITLE
Bump P27 core package and image to 27.0.1-3363.3589a696b

### DIFF
--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -97,8 +97,8 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '27'
-      core_deb_version: '27.0.0-3288.7696c069d.jammy'
-      core_docker_img: 'stellar/stellar-core:27.0.0-3288.7696c069d.jammy'
+      core_deb_version: '27.0.1-3363.3589a696b.jammy'
+      core_docker_img: 'stellar/stellar-core:27.0.1-3363.3589a696b.jammy'
 
   # integration-p25-src:
   #   name: Integration tests (p25, core from source)

--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -98,7 +98,7 @@ jobs:
     with:
       protocol_version: '27'
       core_deb_version: '27.0.1-3363.3589a696b.jammy'
-      core_docker_img: 'stellar/stellar-core:27.0.1-3363.3589a696b.jammy'
+      core_docker_img: 'stellar/unsafe-stellar-core:27.0.1-3363.3589a696b.jammy'
 
   # integration-p25-src:
   #   name: Integration tests (p25, core from source)


### PR DESCRIPTION
Update the pinned P27 `core_deb_version` and `core_docker_img` to `27.0.1-3363.3589a696b.jammy`.