### PR TITLE
fullhistory: index event type and topic count for getEvents v1

### DIFF
--- a/cmd/stellar-rpc/internal/rpcv2/events/benchmark_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/events/benchmark_test.go
@@ -6,6 +6,9 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
 // BenchmarkEventIndex_10M measures heap at full chunk scale.
@@ -34,12 +37,20 @@ func BenchmarkEventIndex_10M(b *testing.B) {
 }
 
 // buildIndex10M simulates a full chunk based on real production data:
-// ~9M events, ~2M unique terms, ~35M total adds.
+// ~9M events, ~2M unique terms, ~35M adds for the contract-ID and topic
+// terms, plus the 2 adds per event the type and topic-count families
+// contribute.
+//
+// Adds are grouped by term within a ledger, the way HotStore.applyLedger
+// batches them. Feeding a chunk-wide term one event at a time instead
+// pays ConcurrentBitmaps.AddTo's COW clone per event and costs several
+// times the build time, which no production path does.
 func buildIndex10M() *ConcurrentBitmaps {
 	const (
-		totalEvents  = 9_000_000
-		numContracts = 10_000
-		numTopicVals = 3_000_000
+		totalEvents     = 9_000_000
+		numContracts    = 10_000
+		numTopicVals    = 3_000_000
+		eventsPerLedger = 900
 	)
 
 	idx := NewConcurrentBitmapsFromBitmaps(NewBitmaps())
@@ -57,13 +68,43 @@ func buildIndex10M() *ConcurrentBitmaps {
 
 	zipf := rand.NewZipf(rng, 1.01, 1.0, uint64(numTopicVals-1))
 
-	for eventID := range uint32(totalEvents) {
-		idx.AddTo(contractKeys[eventID%uint32(numContracts)], eventID)
-		numTopics := 1 + rng.Intn(4)
-		for range numTopics {
-			idx.AddTo(topicKeys[zipf.Uint64()], eventID)
+	// Type is near-degenerate in real data: system events exist only on
+	// contract upgrades, so one bitmap is near-full and the other
+	// near-empty. Topic count spreads the chunk across every bucket,
+	// including the empty-topic and overflow ones, since how that family
+	// partitions decides whether it is cheap or not.
+	const systemEventEvery = 100_000
+	contractType := EventTypeTermKey(xdr.ContractEventTypeContract)
+	systemType := EventTypeTermKey(xdr.ContractEventTypeSystem)
+
+	perKeyIDs := make(map[TermKey][]uint32, 64)
+	flush := func() {
+		for key, ids := range perKeyIDs {
+			idx.AddTo(key, ids...)
+			delete(perKeyIDs, key)
 		}
 	}
+	add := func(key TermKey, eventID uint32) {
+		perKeyIDs[key] = append(perKeyIDs[key], eventID)
+	}
+
+	for eventID := range uint32(totalEvents) {
+		add(contractKeys[eventID%uint32(numContracts)], eventID)
+		numTopics := rng.Intn(protocol.MaxTopicCount + 2)
+		for range numTopics {
+			add(topicKeys[zipf.Uint64()], eventID)
+		}
+		if eventID%systemEventEvery == 0 {
+			add(systemType, eventID)
+		} else {
+			add(contractType, eventID)
+		}
+		add(TopicCountTermKey(numTopics), eventID)
+		if (eventID+1)%eventsPerLedger == 0 {
+			flush()
+		}
+	}
+	flush()
 
 	return idx
 }

--- a/cmd/stellar-rpc/internal/rpcv2/events/index.go
+++ b/cmd/stellar-rpc/internal/rpcv2/events/index.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
@@ -21,6 +22,8 @@ const (
 	FieldTopic1     Field = 2
 	FieldTopic2     Field = 3
 	FieldTopic3     Field = 4
+	FieldEventType  Field = 5
+	FieldTopicCount Field = 6
 )
 
 // ComputeTermKey computes a 16-byte term key by hashing the field byte
@@ -50,12 +53,81 @@ func ComputeTermKey(value []byte, field Field) TermKey {
 	return key
 }
 
-// TermsForBytes returns the term keys (contract ID + topics
-// 0..MaxTopicCount-1) for a marshaled ContractEvent, navigating the raw
-// XDR via xdr.ContractEventView instead of a full UnmarshalBinary.
+// EventTypeTermKey returns the term key for eventType. Every event
+// carries one, so a query for a rare type resolves through the index
+// instead of scanning a chunk to find the few events that have it.
+func EventTypeTermKey(eventType xdr.ContractEventType) TermKey {
+	var value [4]byte
+	binary.BigEndian.PutUint32(value[:], uint32(eventType)) //nolint:gosec // enum keeps its own XDR width
+	return ComputeTermKey(value[:], FieldEventType)
+}
+
+// topicCountOverflowBucket holds every event carrying more topics than
+// a getEvents filter can name. Those events cannot be told apart by any
+// filter, and closing the bucket space keeps the union covering
+// "n or more" bounded.
+const topicCountOverflowBucket = protocol.MaxTopicCount + 1
+
+// The bucket space is written into cold chunks that are never rewritten,
+// so MaxTopicCount fixes what every bucket in an existing artifact means.
+// Growing it would silently redefine the overflow bucket: what was
+// written as "MaxTopicCount or more" would be read back as an exact
+// count. Fail the build instead, the way topicField panics when the
+// constant outgrows the topic Fields.
+const (
+	_ uint = protocol.MaxTopicCount - 4
+	_ uint = 4 - protocol.MaxTopicCount
+)
+
+// TopicCountTermKey returns the term key for the bucket holding events
+// with n topics. Every event carries one, which is what makes topic
+// arity answerable from the index: it is an absence property, and value
+// terms can only say what an event has.
+func TopicCountTermKey(n int) TermKey {
+	// n is a slice length here and a validated filter field on the query
+	// side, so it is never negative.
+	bucket := min(n, topicCountOverflowBucket)
+	return ComputeTermKey([]byte{byte(bucket)}, FieldTopicCount) //nolint:gosec // 0..overflow bucket
+}
+
+// TopicCountTermKeysAtLeast returns the buckets whose union holds every
+// event with n topics or more. The overflow bucket closes the union, so
+// an event carrying more topics than a filter can name is still in it.
+func TopicCountTermKeysAtLeast(n int) []TermKey {
+	low := min(n, topicCountOverflowBucket)
+	keys := make([]TermKey, 0, topicCountOverflowBucket-low+1)
+	for bucket := low; bucket <= topicCountOverflowBucket; bucket++ {
+		keys = append(keys, TopicCountTermKey(bucket))
+	}
+	return keys
+}
+
+// maxTermsPerEvent is what TermsForBytes emits for an event carrying
+// the most topics a filter can name: type, topic count, contract ID,
+// and one term per topic position.
+const maxTermsPerEvent = 3 + protocol.MaxTopicCount
+
+// TermsForBytes returns the term keys for a marshaled ContractEvent,
+// navigating the raw XDR via xdr.ContractEventView instead of a full
+// UnmarshalBinary: its type, its topic count, its contract ID when it
+// has one, and its topics 0..MaxTopicCount-1.
 func TermsForBytes(eventBytes []byte) ([]TermKey, error) {
 	ev := xdr.ContractEventView(eventBytes)
-	var keys []TermKey
+	keys := make([]TermKey, 0, maxTermsPerEvent)
+
+	typeView, err := ev.Type()
+	if err != nil {
+		return nil, fmt.Errorf("events: view Type: %w", err)
+	}
+	// A type outside the enum is a hard indexing error, the same call the
+	// unsupported body version below makes: the alternative is indexing
+	// the event under a bucket no filter can name, which reads as "no
+	// such events" rather than as a protocol the binary cannot serve.
+	eventType, err := typeView.Value()
+	if err != nil {
+		return nil, fmt.Errorf("events: view Type value: %w", err)
+	}
+	keys = append(keys, EventTypeTermKey(eventType))
 
 	cidOpt, err := ev.ContractId()
 	if err != nil {
@@ -100,6 +172,7 @@ func TermsForBytes(eventBytes []byte) ([]TermKey, error) {
 	if err != nil {
 		return nil, fmt.Errorf("events: view Body.V0.Topics.All: %w", err)
 	}
+	keys = append(keys, TopicCountTermKey(len(topicViews)))
 	for i, topic := range topicViews {
 		if i >= protocol.MaxTopicCount {
 			break

--- a/cmd/stellar-rpc/internal/rpcv2/events/index.go
+++ b/cmd/stellar-rpc/internal/rpcv2/events/index.go
@@ -71,9 +71,9 @@ const topicCountOverflowBucket = protocol.MaxTopicCount + 1
 // The bucket space is written into cold chunks that are never rewritten,
 // so MaxTopicCount fixes what every bucket in an existing artifact means.
 // Growing it would silently redefine the overflow bucket: what was
-// written as "MaxTopicCount or more" would be read back as an exact
-// count. Fail the build instead, the way topicField panics when the
-// constant outgrows the topic Fields.
+// written as "more topics than MaxTopicCount" would be read back as an
+// exact count. Fail the build instead, the way topicField panics when
+// the constant outgrows the topic Fields.
 const (
 	_ uint = protocol.MaxTopicCount - 4
 	_ uint = 4 - protocol.MaxTopicCount

--- a/cmd/stellar-rpc/internal/rpcv2/events/index_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/events/index_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"encoding/binary"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -182,8 +183,8 @@ func symTopicEvent(contractID *xdr.ContractId, topics ...string) xdr.ContractEve
 
 // TestTermsForBytes_ContractIDAndTopicTerms pins the full term set for the
 // common case: an event with a contract ID and one topic yields exactly the
-// contract-ID term followed by the topic-0 term, each derived with the same
-// ComputeTermKey the readers use.
+// type term, the contract-ID term, the topic-count term, and the topic-0
+// term, each derived with the same helpers the readers use.
 func TestTermsForBytes_ContractIDAndTopicTerms(t *testing.T) {
 	var cid xdr.ContractId
 	cid[0], cid[1] = 0xab, 0xcd
@@ -195,23 +196,28 @@ func TestTermsForBytes_ContractIDAndTopicTerms(t *testing.T) {
 	topicBytes, err := ev.Body.V0.Topics[0].MarshalBinary()
 	require.NoError(t, err)
 	assert.Equal(t, []TermKey{
+		EventTypeTermKey(xdr.ContractEventTypeContract),
 		ComputeTermKey(cid[:], FieldContractID),
+		TopicCountTermKey(1),
 		ComputeTermKey(topicBytes, FieldTopic0),
 	}, keys)
 }
 
 // TestTermsForBytes_NoContractIDOnlyTopicTerms exercises the nil-contract-ID
-// guard: an event without a contract ID emits only topic terms.
+// guard: an event without a contract ID emits no contract-ID term.
 func TestTermsForBytes_NoContractIDOnlyTopicTerms(t *testing.T) {
 	ev := symTopicEvent(nil, "only-topic")
 
 	keys, err := TermsForBytes(marshaledEvent(t, ev))
 	require.NoError(t, err)
-	require.Len(t, keys, 1, "no contract ID → only the topic term")
 
 	topicBytes, err := ev.Body.V0.Topics[0].MarshalBinary()
 	require.NoError(t, err)
-	assert.Equal(t, ComputeTermKey(topicBytes, FieldTopic0), keys[0])
+	assert.Equal(t, []TermKey{
+		EventTypeTermKey(xdr.ContractEventTypeContract),
+		TopicCountTermKey(1),
+		ComputeTermKey(topicBytes, FieldTopic0),
+	}, keys)
 }
 
 // TestTermsForBytes_SameTopicValueDistinctFields asserts that the SAME value
@@ -222,20 +228,21 @@ func TestTermsForBytes_SameTopicValueDistinctFields(t *testing.T) {
 
 	keys, err := TermsForBytes(marshaledEvent(t, ev))
 	require.NoError(t, err)
-	require.Len(t, keys, 2)
-	assert.NotEqual(t, keys[0], keys[1],
+	require.Len(t, keys, 4) // type, topic count, topic0, topic1
+	assert.NotEqual(t, keys[2], keys[3],
 		"same value in different topic positions must produce different term keys")
 
 	topicBytes, err := ev.Body.V0.Topics[0].MarshalBinary()
 	require.NoError(t, err)
-	assert.Equal(t, ComputeTermKey(topicBytes, FieldTopic0), keys[0])
-	assert.Equal(t, ComputeTermKey(topicBytes, FieldTopic1), keys[1])
+	assert.Equal(t, ComputeTermKey(topicBytes, FieldTopic0), keys[2])
+	assert.Equal(t, ComputeTermKey(topicBytes, FieldTopic1), keys[3])
 }
 
 // TestTermsForBytes_TopicCountClippedToMax asserts topics past
 // protocol.MaxTopicCount are not indexed (they are not queryable by a
 // getEvents filter, so indexing them would be unreachable storage): an event
-// with 6 topics and a contract ID yields 1 + MaxTopicCount terms.
+// with 6 topics and a contract ID yields the type, contract-ID and
+// topic-count terms plus MaxTopicCount topic terms.
 func TestTermsForBytes_TopicCountClippedToMax(t *testing.T) {
 	var cid xdr.ContractId
 	cid[0] = 0xfe
@@ -243,8 +250,90 @@ func TestTermsForBytes_TopicCountClippedToMax(t *testing.T) {
 
 	keys, err := TermsForBytes(marshaledEvent(t, ev))
 	require.NoError(t, err)
-	assert.Len(t, keys, 1+protocol.MaxTopicCount,
-		"1 contract-ID term + MaxTopicCount topic terms (extras dropped)")
+	assert.Len(t, keys, 3+protocol.MaxTopicCount,
+		"type + contract-ID + topic-count terms, then MaxTopicCount topic terms (extras dropped)")
+}
+
+// TestTermsForBytes_EventTypeTerm pins the type term to the event's own type:
+// a system event and a contract event must land in different buckets, or a
+// type filter would return the wrong one.
+func TestTermsForBytes_EventTypeTerm(t *testing.T) {
+	contractEv := symTopicEvent(nil, "transfer")
+	systemEv := symTopicEvent(nil, "transfer")
+	systemEv.Type = xdr.ContractEventTypeSystem
+
+	contractKeys, err := TermsForBytes(marshaledEvent(t, contractEv))
+	require.NoError(t, err)
+	systemKeys, err := TermsForBytes(marshaledEvent(t, systemEv))
+	require.NoError(t, err)
+
+	assert.Equal(t, EventTypeTermKey(xdr.ContractEventTypeContract), contractKeys[0])
+	assert.Equal(t, EventTypeTermKey(xdr.ContractEventTypeSystem), systemKeys[0])
+	assert.NotEqual(t, contractKeys[0], systemKeys[0])
+}
+
+// TestTermsForBytes_TopicCountTermBuckets covers the bucket every event
+// carries. Every count a getEvents filter can name gets its own bucket, and
+// everything above shares the overflow bucket, so a query unioning the buckets
+// from n upwards cannot miss an event that carries more topics than a filter
+// can name.
+func TestTermsForBytes_TopicCountTermBuckets(t *testing.T) {
+	topicCountTerm := func(t *testing.T, topicCount int) TermKey {
+		t.Helper()
+		topics := make([]string, topicCount)
+		for i := range topics {
+			topics[i] = fmt.Sprintf("t%d", i)
+		}
+		keys, err := TermsForBytes(marshaledEvent(t, symTopicEvent(nil, topics...)))
+		require.NoError(t, err)
+		return keys[1] // no contract ID, so the count term follows the type term
+	}
+
+	for n := range protocol.MaxTopicCount + 1 {
+		assert.Equal(t, TopicCountTermKey(n), topicCountTerm(t, n),
+			"an event with %d topics belongs in its own bucket", n)
+	}
+
+	overflow := topicCountTerm(t, protocol.MaxTopicCount+1)
+	assert.Equal(t, overflow, topicCountTerm(t, protocol.MaxTopicCount+2))
+	assert.NotEqual(t, TopicCountTermKey(protocol.MaxTopicCount), overflow,
+		"the overflow bucket must be distinct, so an exact top count is not a superset")
+
+	distinct := map[TermKey]struct{}{}
+	for n := range protocol.MaxTopicCount + 2 {
+		distinct[TopicCountTermKey(n)] = struct{}{}
+	}
+	assert.Len(t, distinct, protocol.MaxTopicCount+2,
+		"every bucket up to and including the overflow one must be its own term")
+}
+
+// TestTopicCountTermKeysAtLeast pins the union an "at least n" filter reads:
+// the buckets from n up to and including the overflow one.
+func TestTopicCountTermKeysAtLeast(t *testing.T) {
+	assert.Equal(t, []TermKey{
+		TopicCountTermKey(protocol.MaxTopicCount),
+		TopicCountTermKey(protocol.MaxTopicCount + 1),
+	}, TopicCountTermKeysAtLeast(protocol.MaxTopicCount))
+
+	assert.Len(t, TopicCountTermKeysAtLeast(0), protocol.MaxTopicCount+2)
+	assert.Equal(t,
+		[]TermKey{TopicCountTermKey(protocol.MaxTopicCount + 1)},
+		TopicCountTermKeysAtLeast(99),
+		"a count no filter can name needs only the overflow bucket")
+}
+
+// TestTermsForBytes_UnknownEventTypeHardFails pins the same decision for a
+// future ContractEventType: indexing it under a bucket no filter can name
+// would read as "no such events" rather than as a protocol this binary cannot
+// serve, so ingestion of the ledger fails instead.
+func TestTermsForBytes_UnknownEventTypeHardFails(t *testing.T) {
+	// Layout without a contract ID:
+	// ext.V (4) || contractId flag (4, =0) || type (4) || body.V (4).
+	raw := marshaledEvent(t, symTopicEvent(nil, "transfer"))
+	binary.BigEndian.PutUint32(raw[8:12], 99)
+
+	_, err := TermsForBytes(raw)
+	require.ErrorContains(t, err, "view Type value")
 }
 
 // TestTermsForBytes_UnsupportedBodyVersionHardFails pins the decision that a

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_store_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_store_test.go
@@ -452,12 +452,10 @@ func TestHotStore_IngestLedgerEvents_DuplicateLedgerErrors(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Equal(t, "a", dataSym(t, got[0]), "original event must survive the rejected re-ingest")
 
-	// The rejected payload must not reach the mirror. makePayload emits
-	// [contractID, topic0, ...]; contractID is shared across symbols
-	// (hardcoded 0xab), so we check topic0 (index 1), which is symbol-specific.
-	_, secondKeys := makePayload("b")
-	require.GreaterOrEqual(t, len(secondKeys), 2, "test fixture expected to have a topic0 term")
-	assert.Nil(t, lookupOne(t, h.store, secondKeys[1]),
+	// The rejected payload must not reach the mirror. makePayload shares
+	// its contract ID, type and topic count across symbols, so topic0 is
+	// the term that tells the two payloads apart.
+	assert.Nil(t, lookupOne(t, h.store, topic0TermKey(t, p2)),
 		"the rejected payload's topic0 term must not appear in the mirror")
 }
 

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/query.go
@@ -82,10 +82,10 @@ func (f TopicCountFilter) matches(n int) bool {
 	return n >= f.Count
 }
 
-// termKeys returns the topic-count buckets whose union covers f. An
-// exact count above what a filter can name shares the overflow bucket
-// with every other such count, so it is a superset the post-filter
-// narrows.
+// termKeys returns the topic-count buckets whose union covers f. Every
+// count validateFilters admits has a bucket of its own, and an "at
+// least" union is closed by the overflow bucket, so the union never
+// holds an event f does not match.
 func (f TopicCountFilter) termKeys() []events.TermKey {
 	if f.isWildcard() {
 		return nil
@@ -453,6 +453,17 @@ func validateFilters(filters []Filter) error {
 			return fmt.Errorf(
 				"events: filter[%d].TopicCount.Count must be non-negative, got %d",
 				fi, f.TopicCount.Count)
+		}
+		// Above MaxTopicCount the index cannot answer a count exactly: every
+		// such count shares the overflow bucket, so the terms would return a
+		// superset and the post-filter would narrow it. MaxEvents is applied
+		// before the post-filter, so that page can come back empty while
+		// matches remain, leaving no delivered position to resume from. A
+		// getEvents filter cannot name that many topics anyway.
+		if f.TopicCount.Count > protocol.MaxTopicCount {
+			return fmt.Errorf(
+				"events: filter[%d].TopicCount.Count must be at most %d, got %d",
+				fi, protocol.MaxTopicCount, f.TopicCount.Count)
 		}
 	}
 	return nil

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/query.go
@@ -7,9 +7,9 @@ package event
 //
 // Semantics:
 //
-//   - A Filter is a conjunction of equality constraints on the
-//     indexed fields (contract ID + topics 0..3). A field left
-//     nil/empty is a wildcard.
+//   - A Filter is a conjunction of constraints on the indexed fields
+//     (event type, contract ID, topics 0..3, and topic count). A field
+//     left at its zero value is a wildcard.
 //   - The query result is the union of the per-filter intersections,
 //     intersected with QueryOptions.Range, then truncated to
 //     QueryOptions.MaxEvents (when non-zero). Ascending order keeps
@@ -39,43 +39,109 @@ import (
 )
 
 // Filter is one item in the union of an events Query. Within a
-// single filter, every non-empty field is an equality constraint
-// AND-ed together against the corresponding indexed field of an
-// event. nil or empty slices are wildcards.
+// single filter, every constrained field is AND-ed together against
+// the corresponding indexed field of an event. Fields left at their
+// zero value are wildcards.
 //
 // Topics[i] constrains topic position i. Positions beyond
 // protocol.MaxTopicCount are not indexed (see events.TermsForBytes).
 type Filter struct {
 	ContractID []byte
 	Topics     [protocol.MaxTopicCount][]byte
+	// EventType constrains the event's type. A nil pointer is a
+	// wildcard. A filter accepting several types is several filters.
+	EventType *xdr.ContractEventType
+	// TopicCount constrains how many topics the event carries.
+	TopicCount TopicCountFilter
 }
 
-// isMatchAll reports whether f has no constraints (every field is a wildcard).
-func (f *Filter) isMatchAll() bool {
-	if len(f.ContractID) > 0 {
+// TopicCountFilter constrains an event's topic count to at least
+// Count, or to exactly Count when Exact is set. Its zero value, "at
+// least zero", is the wildcard.
+//
+// This is getEvents v1's topic arity: a topic filter ending in "**"
+// matches events with at least as many topics as the filter names, and
+// one that does not match events with exactly that many.
+type TopicCountFilter struct {
+	Count int
+	Exact bool
+}
+
+func (f TopicCountFilter) isWildcard() bool { return f == TopicCountFilter{} }
+
+// matches reports whether an event carrying n topics satisfies f. A
+// negative n stands for an event with no V0 body, which carries no
+// topics at all and satisfies no constraint.
+func (f TopicCountFilter) matches(n int) bool {
+	if n < 0 {
 		return false
 	}
-	for _, t := range f.Topics {
-		if len(t) > 0 {
-			return false
-		}
+	if f.Exact {
+		return n == f.Count
 	}
-	return true
+	return n >= f.Count
 }
 
-// termKeys returns the indexed (field, value) terms this filter constrains.
-func (f *Filter) termKeys() []events.TermKey {
-	var keys []events.TermKey
+// termKeys returns the topic-count buckets whose union covers f. An
+// exact count above what a filter can name shares the overflow bucket
+// with every other such count, so it is a superset the post-filter
+// narrows.
+func (f TopicCountFilter) termKeys() []events.TermKey {
+	if f.isWildcard() {
+		return nil
+	}
+	if f.Exact {
+		return []events.TermKey{events.TopicCountTermKey(f.Count)}
+	}
+	return events.TopicCountTermKeysAtLeast(f.Count)
+}
+
+// termGroups returns the indexed terms this filter constrains, grouped
+// by field: the bitmaps within a group are OR-ed and the groups are
+// AND-ed. Only the topic-count group ever holds more than one term.
+func (f *Filter) termGroups() [][]events.TermKey {
+	var groups [][]events.TermKey
 	if len(f.ContractID) > 0 {
-		keys = append(keys, events.ComputeTermKey(f.ContractID, events.FieldContractID))
+		groups = append(groups, []events.TermKey{
+			events.ComputeTermKey(f.ContractID, events.FieldContractID),
+		})
+	}
+	if f.EventType != nil {
+		groups = append(groups, []events.TermKey{events.EventTypeTermKey(*f.EventType)})
 	}
 	for tIdx, t := range f.Topics {
 		if len(t) == 0 {
 			continue
 		}
-		keys = append(keys, events.ComputeTermKey(t, topicFieldByPosition[tIdx]))
+		groups = append(groups, []events.TermKey{
+			events.ComputeTermKey(t, topicFieldByPosition[tIdx]),
+		})
 	}
-	return keys
+	// A constrained topic position already implies an "at least" count at
+	// or below it, since a topic term is only indexed for events carrying
+	// that position. Skipping the group there keeps the common
+	// ["a", "**"] shape from OR-ing chunk-sized bucket bitmaps; the
+	// post-filter enforces the count either way.
+	if !f.impliesTopicCount() {
+		if keys := f.TopicCount.termKeys(); len(keys) > 0 {
+			groups = append(groups, keys)
+		}
+	}
+	return groups
+}
+
+// impliesTopicCount reports whether f's constrained topic positions
+// already guarantee its topic-count bound.
+func (f *Filter) impliesTopicCount() bool {
+	if f.TopicCount.Exact {
+		return false
+	}
+	for i, t := range f.Topics {
+		if len(t) > 0 && i+1 >= f.TopicCount.Count {
+			return true
+		}
+	}
+	return false
 }
 
 // IDRange is a literal half-open chunk-relative event-ID window
@@ -161,13 +227,17 @@ var topicFieldByPosition = [protocol.MaxTopicCount]events.Field{
 	events.FieldTopic3,
 }
 
+// termPlan is a filter's termGroups resolved to slots in the batched
+// LookupKeys result.
+type termPlan [][]int
+
 // Query runs filters against r under opts and returns the matching
 // events in chunk-relative event-ID order.
 //
 // Semantics:
 //
-//   - Within a filter: AND of equality constraints on each non-empty
-//     field. A filter with all fields empty matches every event.
+//   - Within a filter: AND of the constraints on each constrained
+//     field. A filter with no constraints matches every event.
 //   - Across filters: union of per-filter matches.
 //   - len(filters) == 0 is treated as a single match-all filter,
 //     consistent with getEvents.
@@ -208,29 +278,41 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	start, end := opts.Range.Start, opts.Range.End
 	descending := opts.Descending
 
-	// Match-all path: empty filter slice or any all-wildcard filter.
-	// Serves without touching the index — translates the range
-	// directly to a contiguous FetchRange call. Cheaper than building
-	// the full chunk bitmap just to truncate to MaxEvents.
-	if hasMatchAllFilter(filters) {
-		return fetchAllInRange(ctx, r, start, end, opts.MaxEvents, descending)
-	}
-
 	// ───── 1. Dedupe terms across filters ─────
 	//
-	// filterPlans[i] holds the indices into uniqueKeys that filter i
-	// requires intersected. Empty plans were handled by the match-all
-	// short-circuit above.
-	filterPlans := make([][]int, len(filters))
+	// filterPlans[i] holds the slots filter i needs out of the batched
+	// lookup.
+	//
+	// A filter that asks the index for no terms constrains nothing, and
+	// so does an empty filter slice: both take the match-all path, which
+	// serves without touching the index by translating the range
+	// directly to a contiguous FetchRange call. That is cheaper than
+	// building the full chunk bitmap just to truncate to MaxEvents, and
+	// reading the condition off the term groups themselves is what keeps
+	// an unconstrained filter from intersecting nothing and coming back
+	// empty instead.
+	filterPlans := make([]termPlan, len(filters))
 	var uniqueKeys []events.TermKey
 
+	matchAll := len(filters) == 0
 	for i := range filters {
-		keys := filters[i].termKeys()
-		slots := make([]int, len(keys))
-		for j, key := range keys {
-			slots[j] = indexOfOrAddTerm(&uniqueKeys, key)
+		groups := filters[i].termGroups()
+		if len(groups) == 0 {
+			matchAll = true
+			break
 		}
-		filterPlans[i] = slots
+		plan := make(termPlan, len(groups))
+		for g, keys := range groups {
+			slots := make([]int, len(keys))
+			for j, key := range keys {
+				slots[j] = indexOfOrAddTerm(&uniqueKeys, key)
+			}
+			plan[g] = slots
+		}
+		filterPlans[i] = plan
+	}
+	if matchAll {
+		return fetchAllInRange(ctx, r, start, end, opts.MaxEvents, descending)
 	}
 
 	// ───── 2. Single batched lookup for all unique terms ─────
@@ -241,7 +323,7 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 
 	// ───── 3. Per-filter intersect ─────
 	//
-	// If any term in a filter is absent from the index (bitmaps[s] is
+	// If a whole group is absent from the index (every bitmap in it is
 	// nil), that filter's intersection is empty — skip it without
 	// contributing to the union.
 	//
@@ -255,15 +337,16 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	// either, so the same bitmap may appear across multiple filters
 	// safely.
 	perFilter := make([]*roaring.Bitmap, 0, len(filterPlans))
-	for _, slots := range filterPlans {
-		inputs := make([]*roaring.Bitmap, 0, len(slots))
+	for _, plan := range filterPlans {
+		inputs := make([]*roaring.Bitmap, 0, len(plan))
 		missed := false
-		for _, s := range slots {
-			if bitmaps[s] == nil {
+		for _, slots := range plan {
+			group := unionSlots(bitmaps, slots)
+			if group == nil {
 				missed = true
 				break
 			}
-			inputs = append(inputs, bitmaps[s])
+			inputs = append(inputs, group)
 		}
 		if missed {
 			continue
@@ -305,6 +388,11 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	// publishes entries before offsets, so LookupKeys can briefly
 	// surface IDs past EventCount. The AND keeps Query's result
 	// strictly within the snapshot the caller pinned at request entry.
+	//
+	// This covers the multi-term group too. Its bitmaps are separate
+	// mirror snapshots taken at different instants, but an event never
+	// moves between the terms of one group once ingested, so a torn read
+	// across them can only surface IDs past the pinned End.
 	rangeBM := roaring.New()
 	rangeBM.AddRange(uint64(start), uint64(end))
 	if singleFilter {
@@ -347,7 +435,9 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 // because of a malformed value. ContractId must be the canonical
 // 32-byte xdr.Hash form (or absent); a short ContractId would
 // bytes.Equal-mismatch every event without surfacing the bug to the
-// caller. Empty/wildcard fields are allowed.
+// caller. A negative topic count is meaningless, and an event type
+// outside the enum is one no event can carry: both key a term nothing
+// is indexed under. Empty/wildcard fields are allowed.
 func validateFilters(filters []Filter) error {
 	for fi := range filters {
 		f := &filters[fi]
@@ -355,23 +445,40 @@ func validateFilters(filters []Filter) error {
 			return fmt.Errorf(
 				"events: filter[%d].ContractID must be 0 or 32 bytes, got %d", fi, l)
 		}
+		if f.EventType != nil && !f.EventType.ValidEnum(int32(*f.EventType)) {
+			return fmt.Errorf(
+				"events: filter[%d].EventType %d is not a known event type", fi, *f.EventType)
+		}
+		if f.TopicCount.Count < 0 {
+			return fmt.Errorf(
+				"events: filter[%d].TopicCount.Count must be non-negative, got %d",
+				fi, f.TopicCount.Count)
+		}
 	}
 	return nil
 }
 
-// hasMatchAllFilter reports whether any filter in filters is the
-// match-all filter (no contract ID, no topics). An empty filters
-// slice also counts (consistent with getEvents).
-func hasMatchAllFilter(filters []Filter) bool {
-	if len(filters) == 0 {
-		return true
+// unionSlots ORs the bitmaps at slots, and returns nil when every one
+// of them is absent from the index. A lone present bitmap is borrowed
+// rather than cloned, like the single-constraint path in Query.
+func unionSlots(bitmaps []*roaring.Bitmap, slots []int) *roaring.Bitmap {
+	if len(slots) == 1 {
+		return bitmaps[slots[0]]
 	}
-	for i := range filters {
-		if filters[i].isMatchAll() {
-			return true
+	present := make([]*roaring.Bitmap, 0, len(slots))
+	for _, s := range slots {
+		if bitmaps[s] != nil {
+			present = append(present, bitmaps[s])
 		}
 	}
-	return false
+	switch len(present) {
+	case 0:
+		return nil
+	case 1:
+		return present[0]
+	default:
+		return roaring.FastOr(present...)
+	}
 }
 
 // indexOfOrAddTerm returns the index of key inside *keys, appending
@@ -525,42 +632,76 @@ func planFilters(filters []Filter) filterPlan {
 	return plan
 }
 
+// eventFields holds the decoded fields matchesAnyFilterView pulls out
+// of one event, each resolved at most once and only when some clause
+// asks for it.
+type eventFields struct {
+	contractID     []byte
+	contractIDDone bool
+
+	eventType     xdr.ContractEventType
+	eventTypeDone bool
+
+	topicCount     int
+	topicCountDone bool
+
+	topics     [protocol.MaxTopicCount][]byte
+	topicsDone bool
+}
+
 // matchesAnyFilterView reports whether the event encoded in raw
-// satisfies at least one filter clause. It lazily resolves
-// ContractId and each constrained topic position via
-// xdr.ContractEventView navigation, byte-comparing aliased .Raw()
-// slices against the filter clauses. Zero per-event allocation —
-// every byte slice involved aliases into raw.
+// satisfies at least one filter clause. It resolves each field a
+// clause constrains via xdr.ContractEventView navigation,
+// byte-comparing aliased .Raw() slices against the filter clauses.
+// Zero per-event allocation — every byte slice involved aliases into
+// raw.
 //
-// Lazy resolution: events that fail every clause's ContractId check
-// never trigger the topic walk; events that pass do exactly one
-// linear walk over Topics up to the highest constrained position
-// (single-call cache, multi-clause queries reuse).
+// Fields are resolved at most once and only when a clause asks for
+// them, cheapest first: events that fail every clause's type or
+// ContractId check never trigger the topic walk, and events that pass
+// do exactly one linear walk over Topics up to the highest constrained
+// position.
 //
-//nolint:gocognit // linear clause loop with two-level lazy cache; splitting helpers fragments the lazy invariant
+//nolint:gocognit,cyclop // linear clause loop with per-field lazy caches; helpers would fragment the invariant
 func matchesAnyFilterView(raw []byte, filters []Filter, plan *filterPlan) (bool, error) {
 	ev := xdr.ContractEventView(raw)
-	var (
-		cidBytes     []byte
-		cidPresent   bool
-		cidResolved  bool
-		topicRaw     [protocol.MaxTopicCount][]byte
-		topicsWalked bool
-	)
+	var got eventFields
 
 	for fi := range filters {
 		f := &filters[fi]
-		if len(f.ContractID) > 0 {
-			if !cidResolved {
-				present, b, err := resolveViewContractID(ev)
+		if f.EventType != nil {
+			if !got.eventTypeDone {
+				eventType, err := resolveViewEventType(ev)
 				if err != nil {
 					return false, err
 				}
-				cidResolved = true
-				cidPresent = present
-				cidBytes = b
+				got.eventType, got.eventTypeDone = eventType, true
 			}
-			if !cidPresent || !bytes.Equal(cidBytes, f.ContractID) {
+			if got.eventType != *f.EventType {
+				continue
+			}
+		}
+		if len(f.ContractID) > 0 {
+			if !got.contractIDDone {
+				cid, err := resolveViewContractID(ev)
+				if err != nil {
+					return false, err
+				}
+				got.contractID, got.contractIDDone = cid, true
+			}
+			if !bytes.Equal(got.contractID, f.ContractID) {
+				continue
+			}
+		}
+		if !f.TopicCount.isWildcard() {
+			if !got.topicCountDone {
+				n, err := resolveViewTopicCount(ev)
+				if err != nil {
+					return false, err
+				}
+				got.topicCount, got.topicCountDone = n, true
+			}
+			if !f.TopicCount.matches(got.topicCount) {
 				continue
 			}
 		}
@@ -569,13 +710,13 @@ func matchesAnyFilterView(raw []byte, filters []Filter, plan *filterPlan) (bool,
 			if len(want) == 0 {
 				continue
 			}
-			if !topicsWalked {
-				if err := collectTopicViewBytes(ev, plan, &topicRaw); err != nil {
+			if !got.topicsDone {
+				if err := collectTopicViewBytes(ev, plan, &got.topics); err != nil {
 					return false, err
 				}
-				topicsWalked = true
+				got.topicsDone = true
 			}
-			g := topicRaw[i]
+			g := got.topics[i]
 			if g == nil || !bytes.Equal(g, want) {
 				matched = false
 				break
@@ -588,26 +729,77 @@ func matchesAnyFilterView(raw []byte, filters []Filter, plan *filterPlan) (bool,
 	return false, nil
 }
 
-// resolveViewContractID extracts the optional ContractId from a
-// ContractEventView. Returns (present, bytes, err); when present is
-// false, bytes is nil.
-func resolveViewContractID(ev xdr.ContractEventView) (bool, []byte, error) {
+func resolveViewEventType(ev xdr.ContractEventView) (xdr.ContractEventType, error) {
+	typeView, err := ev.Type()
+	if err != nil {
+		return 0, fmt.Errorf("events: post-filter view Type: %w", err)
+	}
+	eventType, err := typeView.Value()
+	if err != nil {
+		return 0, fmt.Errorf("events: post-filter view Type value: %w", err)
+	}
+	return eventType, nil
+}
+
+// resolveViewTopics returns the event's Body.V0.Topics. ok is false for
+// a body version that carries no topics at all.
+func resolveViewTopics(ev xdr.ContractEventView) (xdr.ContractEventV0TopicsView, bool, error) {
+	body, err := ev.Body()
+	if err != nil {
+		return nil, false, fmt.Errorf("events: post-filter view Body: %w", err)
+	}
+	bodyV, err := body.V()
+	if err != nil {
+		return nil, false, fmt.Errorf("events: post-filter view Body.V: %w", err)
+	}
+	if bodyV != 0 {
+		return nil, false, nil
+	}
+	v0, err := body.V0()
+	if err != nil {
+		return nil, false, fmt.Errorf("events: post-filter view Body.V0: %w", err)
+	}
+	topics, err := v0.Topics()
+	if err != nil {
+		return nil, false, fmt.Errorf("events: post-filter view Body.V0.Topics: %w", err)
+	}
+	return topics, true, nil
+}
+
+// resolveViewTopicCount returns how many topics the event carries, or
+// -1 when it has no V0 body, which TopicCountFilter.matches rejects for
+// every constraint.
+func resolveViewTopicCount(ev xdr.ContractEventView) (int, error) {
+	topics, ok, err := resolveViewTopics(ev)
+	if err != nil || !ok {
+		return -1, err
+	}
+	count, err := topics.Count()
+	if err != nil {
+		return 0, fmt.Errorf("events: post-filter view Body.V0.Topics.Count: %w", err)
+	}
+	return count, nil
+}
+
+// resolveViewContractID returns the event's ContractId aliased into the
+// raw buffer, or nil when it has none.
+func resolveViewContractID(ev xdr.ContractEventView) ([]byte, error) {
 	cidOpt, err := ev.ContractId()
 	if err != nil {
-		return false, nil, fmt.Errorf("events: post-filter view ContractId opt: %w", err)
+		return nil, fmt.Errorf("events: post-filter view ContractId opt: %w", err)
 	}
 	cidView, present, err := cidOpt.Unwrap()
 	if err != nil {
-		return false, nil, fmt.Errorf("events: post-filter view ContractId unwrap: %w", err)
+		return nil, fmt.Errorf("events: post-filter view ContractId unwrap: %w", err)
 	}
 	if !present {
-		return false, nil, nil
+		return nil, nil
 	}
-	cid, err := cidView.Value()
+	cid, err := cidView.Raw()
 	if err != nil {
-		return false, nil, fmt.Errorf("events: post-filter view ContractId value: %w", err)
+		return nil, fmt.Errorf("events: post-filter view ContractId raw: %w", err)
 	}
-	return true, cid[:], nil
+	return cid, nil
 }
 
 // collectTopicViewBytes walks the ContractEventView's Body.V0.Topics
@@ -625,24 +817,9 @@ func collectTopicViewBytes(
 	if !plan.anyTopic {
 		return nil
 	}
-	body, err := ev.Body()
-	if err != nil {
-		return fmt.Errorf("events: post-filter view Body: %w", err)
-	}
-	bodyV, err := body.V()
-	if err != nil {
-		return fmt.Errorf("events: post-filter view Body.V: %w", err)
-	}
-	if bodyV != 0 {
-		return nil
-	}
-	v0, err := body.V0()
-	if err != nil {
-		return fmt.Errorf("events: post-filter view Body.V0: %w", err)
-	}
-	topicsArr, err := v0.Topics()
-	if err != nil {
-		return fmt.Errorf("events: post-filter view Body.V0.Topics: %w", err)
+	topicsArr, ok, err := resolveViewTopics(ev)
+	if err != nil || !ok {
+		return err
 	}
 	i := 0
 	for topic, ierr := range topicsArr.Iter() {

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/query_test.go
@@ -61,11 +61,21 @@ type queryFixture struct {
 // dataSym labels the event so tests can match against the layout above.
 func payloadFor(t *testing.T, cid xdr.ContractId, dataSym string, topics ...xdr.ScVal) events.Payload {
 	t.Helper()
+	return typedPayloadFor(t, cid, xdr.ContractEventTypeContract, dataSym, topics...)
+}
+
+// typedPayloadFor is payloadFor with the event type spelled out, for
+// the tests that filter on it.
+func typedPayloadFor(
+	t *testing.T, cid xdr.ContractId, eventType xdr.ContractEventType,
+	dataSym string, topics ...xdr.ScVal,
+) events.Payload {
+	t.Helper()
 	sym := xdr.ScSymbol(dataSym)
 	cidCopy := cid
 	ev := xdr.ContractEvent{
 		ContractId: &cidCopy,
-		Type:       xdr.ContractEventTypeContract,
+		Type:       eventType,
 		Body: xdr.ContractEventBody{
 			V: 0,
 			V0: &xdr.ContractEventV0{
@@ -760,6 +770,324 @@ func makeSimplePayload(t *testing.T, dataSymbol string) events.Payload {
 	}
 }
 
+// ─── Event type and topic count ─────────────────────────────────────────
+
+// typeArityFixture seeds a hot chunk with events that differ in type
+// and in how many topics they carry, including one that carries more
+// than a filter can name.
+//
+// Layout:
+//
+//	id 0: contract, topics [alpha]                             → "c-1"
+//	id 1: system,   topics [alpha]                             → "s-1"
+//	id 2: contract, topics [alpha, beta]                       → "c-2"
+//	id 3: contract, topics []                                  → "c-0"
+//	id 4: contract, topics [alpha, beta, gamma, delta, epslon] → "c-5"
+//	id 5: contract, topics [alpha, beta, gamma, delta]         → "c-4"
+//	id 6: contract, topics [alpha .. zeta]                     → "c-6"
+//
+// "c-5" and "c-6" share the overflow bucket, so an exact count there is a
+// superset the post-filter has to narrow.
+type typeArityFixture struct {
+	store    *HotStore
+	contract xdr.ContractId
+	alphaRaw []byte
+}
+
+func newTypeArityFixture(t *testing.T) *typeArityFixture {
+	t.Helper()
+	const chunkID = chunk.ID(0)
+	h := openHotStoreForTest(t, chunkID)
+	fx := &typeArityFixture{store: h.store}
+	fx.contract[0] = 0x07
+
+	topic := func(name string) xdr.ScVal {
+		sym := xdr.ScSymbol(name)
+		return xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym}
+	}
+	alpha, beta := topic("alpha"), topic("beta")
+	gamma, delta, epsilon, zeta := topic("gamma"), topic("delta"), topic("epsilon"), topic("zeta")
+	var err error
+	fx.alphaRaw, err = alpha.MarshalBinary()
+	require.NoError(t, err)
+
+	require.NoError(t, ingestLedgerEvents(fx.store, chunkID.FirstLedger(), []events.Payload{
+		payloadFor(t, fx.contract, "c-1", alpha),
+		typedPayloadFor(t, fx.contract, xdr.ContractEventTypeSystem, "s-1", alpha),
+		payloadFor(t, fx.contract, "c-2", alpha, beta),
+		payloadFor(t, fx.contract, "c-0"),
+		payloadFor(t, fx.contract, "c-5", alpha, beta, gamma, delta, epsilon),
+		payloadFor(t, fx.contract, "c-4", alpha, beta, gamma, delta),
+		payloadFor(t, fx.contract, "c-6", alpha, beta, gamma, delta, epsilon, zeta),
+	}))
+	return fx
+}
+
+// query runs filters over the whole chunk and returns the matched
+// events by label.
+func (fx *typeArityFixture) query(t *testing.T, filters ...Filter) []string {
+	t.Helper()
+	got, err := Query(context.Background(), fx.store, filters,
+		QueryOptions{Range: wholeChunk(t, fx.store)})
+	require.NoError(t, err)
+	return dataSyms(t, got)
+}
+
+func TestQuery_EventTypeFilter(t *testing.T) {
+	fx := newTypeArityFixture(t)
+	system, contract := xdr.ContractEventTypeSystem, xdr.ContractEventTypeContract
+	diagnostic := xdr.ContractEventTypeDiagnostic
+
+	for name, tc := range map[string]struct {
+		filter Filter
+		want   []string
+	}{
+		"system": {
+			Filter{EventType: &system},
+			[]string{"s-1"},
+		},
+		"contract": {
+			Filter{EventType: &contract},
+			[]string{"c-1", "c-2", "c-0", "c-5", "c-4", "c-6"},
+		},
+		"type and topic value": {
+			Filter{EventType: &system, Topics: [protocol.MaxTopicCount][]byte{fx.alphaRaw}},
+			[]string{"s-1"},
+		},
+		// A type nobody emitted is missing from the index, which empties
+		// the filter rather than widening it.
+		"type absent from the chunk": {
+			Filter{EventType: &diagnostic},
+			[]string{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, fx.query(t, tc.filter))
+		})
+	}
+}
+
+// TestQuery_TopicCountFilter covers getEvents v1's topic arity. Every count a
+// filter can name has its own bucket and the overflow bucket holds the rest,
+// so "at least n" reaches "c-5", which carries more topics than a filter can
+// name, while an exact count never returns it.
+func TestQuery_TopicCountFilter(t *testing.T) {
+	fx := newTypeArityFixture(t)
+	contract := xdr.ContractEventTypeContract
+	const top = protocol.MaxTopicCount
+
+	for name, tc := range map[string]struct {
+		filter Filter
+		want   []string
+	}{
+		"exactly 0":                   {Filter{TopicCount: TopicCountFilter{Count: 0, Exact: true}}, []string{"c-0"}},
+		"exactly 1":                   {Filter{TopicCount: TopicCountFilter{Count: 1, Exact: true}}, []string{"c-1", "s-1"}},
+		"exactly 2":                   {Filter{TopicCount: TopicCountFilter{Count: 2, Exact: true}}, []string{"c-2"}},
+		"exactly 3":                   {Filter{TopicCount: TopicCountFilter{Count: 3, Exact: true}}, []string{}},
+		"exactly the top count":       {Filter{TopicCount: TopicCountFilter{Count: top, Exact: true}}, []string{"c-4"}},
+		"exactly above the top count": {Filter{TopicCount: TopicCountFilter{Count: top + 1, Exact: true}}, []string{"c-5"}},
+
+		"at least 1": {
+			Filter{TopicCount: TopicCountFilter{Count: 1}},
+			[]string{"c-1", "s-1", "c-2", "c-5", "c-4", "c-6"},
+		},
+		"at least 2": {
+			Filter{TopicCount: TopicCountFilter{Count: 2}},
+			[]string{"c-2", "c-5", "c-4", "c-6"},
+		},
+		"at least 3":                   {Filter{TopicCount: TopicCountFilter{Count: 3}}, []string{"c-5", "c-4", "c-6"}},
+		"at least the top count":       {Filter{TopicCount: TopicCountFilter{Count: top}}, []string{"c-5", "c-4", "c-6"}},
+		"at least above the top count": {Filter{TopicCount: TopicCountFilter{Count: top + 1}}, []string{"c-5", "c-6"}},
+		"at least two above the top":   {Filter{TopicCount: TopicCountFilter{Count: top + 2}}, []string{"c-6"}},
+		"at least beyond every event":  {Filter{TopicCount: TopicCountFilter{Count: top + 3}}, []string{}},
+
+		"count alongside every other field": {
+			Filter{
+				EventType:  &contract,
+				ContractID: fx.contract[:],
+				Topics:     [protocol.MaxTopicCount][]byte{fx.alphaRaw},
+				TopicCount: TopicCountFilter{Count: 2},
+			},
+			[]string{"c-2", "c-5", "c-4", "c-6"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, fx.query(t, tc.filter))
+		})
+	}
+}
+
+// TestQuery_TypeAndCountIndexTerms pins what each filter shape asks the index
+// for. A wildcard topic count constrains nothing and keeps the match-all
+// short-circuit; every other shape resolves through the index. An "at least"
+// count already implied by a constrained topic position fetches no bucket at
+// all, since the buckets are chunk-sized bitmaps.
+func TestQuery_TypeAndCountIndexTerms(t *testing.T) {
+	fx := newTypeArityFixture(t)
+	system := xdr.ContractEventTypeSystem
+	const top = protocol.MaxTopicCount
+
+	for name, tc := range map[string]struct {
+		filter    Filter
+		wantCalls int
+		wantKeys  int
+	}{
+		"wildcard count stays match-all":      {Filter{}, 0, 0},
+		"type alone":                          {Filter{EventType: &system}, 1, 1},
+		"exact count alone":                   {Filter{TopicCount: TopicCountFilter{Count: 1, Exact: true}}, 1, 1},
+		"at least 1 unions every bucket":      {Filter{TopicCount: TopicCountFilter{Count: 1}}, 1, top + 1},
+		"at least the top count":              {Filter{TopicCount: TopicCountFilter{Count: top}}, 1, 2},
+		"at least beyond what a filter names": {Filter{TopicCount: TopicCountFilter{Count: 9}}, 1, 1},
+		"count on top of a contract": {
+			Filter{ContractID: fx.contract[:], TopicCount: TopicCountFilter{Count: 3}},
+			1, 1 + 3,
+		},
+		"count implied by a topic position": {
+			Filter{
+				Topics:     [protocol.MaxTopicCount][]byte{fx.alphaRaw},
+				TopicCount: TopicCountFilter{Count: 1},
+			},
+			1, 1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cr := &countingReader{Reader: fx.store}
+			_, err := Query(context.Background(), cr, []Filter{tc.filter},
+				QueryOptions{Range: wholeChunk(t, fx.store)})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantCalls, cr.lookupKeysCalls)
+			assert.Equal(t, tc.wantKeys, cr.totalKeys)
+		})
+	}
+}
+
+// TestQuery_TopicCountImpliedByTopicChangesNothing pins that eliding an
+// implied bucket group is a no-op in both directions: a filter returns the
+// same events whether or not it carries the count its topic position already
+// guarantees.
+func TestQuery_TopicCountImpliedByTopicChangesNothing(t *testing.T) {
+	fx := newTypeArityFixture(t)
+	topics := [protocol.MaxTopicCount][]byte{fx.alphaRaw}
+
+	withCount := fx.query(t, Filter{Topics: topics, TopicCount: TopicCountFilter{Count: 1}})
+	assert.Equal(t, fx.query(t, Filter{Topics: topics}), withCount)
+	assert.Equal(t, []string{"c-1", "s-1", "c-2", "c-5", "c-4", "c-6"}, withCount)
+}
+
+// TestQuery_TopicCountWithRangeAndOrder puts the bucket union and the elided
+// group through the rest of the query contract, which the whole-chunk
+// ascending cases above never exercise: the caller's pinned window, descending
+// order, and MaxEvents.
+func TestQuery_TopicCountWithRangeAndOrder(t *testing.T) {
+	fx := newTypeArityFixture(t)
+	atLeast2 := Filter{TopicCount: TopicCountFilter{Count: 2}}
+	// Count 1 is implied by topic0, so this filter's bucket group is elided.
+	implied := Filter{
+		Topics:     [protocol.MaxTopicCount][]byte{fx.alphaRaw},
+		TopicCount: TopicCountFilter{Count: 1},
+	}
+	// Ids 2..5: drops "c-6" (id 6) and the single-topic events at 0 and 1.
+	window := IDRange{Start: 2, End: 6}
+
+	for name, tc := range map[string]struct {
+		filter Filter
+		opts   QueryOptions
+		want   []string
+	}{
+		"descending": {
+			atLeast2,
+			QueryOptions{Range: wholeChunk(t, fx.store), Descending: true},
+			[]string{"c-6", "c-4", "c-5", "c-2"},
+		},
+		"narrower window": {
+			atLeast2,
+			QueryOptions{Range: window},
+			[]string{"c-2", "c-5", "c-4"},
+		},
+		"narrower window, elided group": {
+			implied,
+			QueryOptions{Range: window},
+			[]string{"c-2", "c-5", "c-4"},
+		},
+		"max events keeps the lowest ids": {
+			atLeast2,
+			QueryOptions{Range: wholeChunk(t, fx.store), MaxEvents: 2},
+			[]string{"c-2", "c-5"},
+		},
+		"max events descending keeps the highest ids": {
+			atLeast2,
+			QueryOptions{Range: wholeChunk(t, fx.store), MaxEvents: 2, Descending: true},
+			[]string{"c-6", "c-4"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := Query(context.Background(), fx.store, []Filter{tc.filter}, tc.opts)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, dataSyms(t, got))
+		})
+	}
+}
+
+// TestQuery_UnionOfTypeAndCountFilters covers the two new fields across the
+// union rather than within one filter: each filter narrows on its own and the
+// results merge in event-ID order.
+func TestQuery_UnionOfTypeAndCountFilters(t *testing.T) {
+	fx := newTypeArityFixture(t)
+	system := xdr.ContractEventTypeSystem
+
+	assert.Equal(t, []string{"s-1", "c-0"}, fx.query(t,
+		Filter{EventType: &system},
+		Filter{TopicCount: TopicCountFilter{Count: 0, Exact: true}}))
+}
+
+// TestQuery_InvalidFilterRejected covers the values that would key a term no
+// event is indexed under, which would otherwise return nothing with no signal.
+func TestQuery_InvalidFilterRejected(t *testing.T) {
+	fx := newTypeArityFixture(t)
+	unknownType := xdr.ContractEventType(99)
+
+	for name, tc := range map[string]struct {
+		filter  Filter
+		wantErr string
+	}{
+		"negative topic count": {
+			Filter{TopicCount: TopicCountFilter{Count: -1}},
+			"TopicCount.Count must be non-negative",
+		},
+		"unknown event type": {
+			Filter{EventType: &unknownType},
+			"not a known event type",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := Query(context.Background(), fx.store, []Filter{tc.filter},
+				QueryOptions{Range: wholeChunk(t, fx.store)})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestUnionSlots covers the OR-within-a-group step directly, including the
+// all-absent case a fixture cannot reach: the topic-count buckets are the only
+// multi-term group, and the overflow bucket is populated in any chunk holding
+// an event with topics.
+func TestUnionSlots(t *testing.T) {
+	first := roaring.BitmapOf(1, 2)
+	second := roaring.BitmapOf(3)
+	bitmaps := []*roaring.Bitmap{first, nil, second, nil}
+
+	assert.Same(t, first, unionSlots(bitmaps, []int{0}),
+		"a lone bitmap is borrowed, not cloned")
+	assert.Nil(t, unionSlots(bitmaps, []int{1}))
+	assert.Nil(t, unionSlots(bitmaps, []int{1, 3}),
+		"a group absent from the index empties the filter")
+	assert.Same(t, second, unionSlots(bitmaps, []int{1, 2}),
+		"the one present bitmap in a group is borrowed too")
+	assert.Equal(t, []uint32{1, 2, 3}, unionSlots(bitmaps, []int{0, 2}).ToArray())
+	assert.Equal(t, []uint32{1, 2}, first.ToArray(), "inputs must not be mutated")
+}
+
 // ─── Cold-reader parity coverage ────────────────────────────────────────
 //
 // The hot tests above prove Query works against *HotStore. The whole
@@ -803,7 +1131,7 @@ func makeSimplePayload(t *testing.T, dataSymbol string) events.Payload {
 // can't be used to recover ledger boundaries.
 //
 //nolint:unparam // chunkID is conceptually a fixture knob even though tests use chunk.ID(0) today
-func freezeFixtureToColdReader(t *testing.T, fx *queryFixture, chunkID chunk.ID) *ColdReader {
+func freezeFixtureToColdReader(t *testing.T, hot *HotStore, chunkID chunk.ID) *ColdReader {
 	t.Helper()
 	dir := t.TempDir()
 
@@ -817,7 +1145,7 @@ func freezeFixtureToColdReader(t *testing.T, fx *queryFixture, chunkID chunk.ID)
 	// Read the hot store's offsets snapshot so we know exactly how many
 	// events sit in each ledger. Walking per-ledger via FetchRange lets
 	// us drive the cold writer in the same shape the freeze loop would.
-	hotOffsets, err := fx.store.Offsets()
+	hotOffsets, err := hot.Offsets()
 	require.NoError(t, err)
 
 	eventID := uint32(0)
@@ -837,7 +1165,7 @@ func freezeFixtureToColdReader(t *testing.T, fx *queryFixture, chunkID chunk.ID)
 		// Pull this ledger's events in order. FetchRange yields borrowed
 		// bytes — clone before handing to the cold writer and the term
 		// indexer.
-		for p, err := range fx.store.FetchRange(context.Background(), eventID, count) {
+		for p, err := range hot.FetchRange(context.Background(), eventID, count) {
 			require.NoError(t, err)
 			p.ContractEventBytes = bytes.Clone(p.ContractEventBytes)
 			require.NoError(t, cw.Append(p))
@@ -861,7 +1189,7 @@ func freezeFixtureToColdReader(t *testing.T, fx *queryFixture, chunkID chunk.ID)
 
 func TestQuery_ColdReaderParity_MatchAllAscending(t *testing.T) {
 	hotFx := newQueryFixture(t)
-	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+	cr := freezeFixtureToColdReader(t, hotFx.store, chunk.ID(0))
 
 	got, err := Query(context.Background(), cr, nil,
 		QueryOptions{Range: wholeChunk(t, cr)})
@@ -873,7 +1201,7 @@ func TestQuery_ColdReaderParity_MatchAllAscending(t *testing.T) {
 
 func TestQuery_ColdReaderParity_MatchAllDescendingWithCap(t *testing.T) {
 	hotFx := newQueryFixture(t)
-	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+	cr := freezeFixtureToColdReader(t, hotFx.store, chunk.ID(0))
 
 	got, err := Query(context.Background(), cr, nil,
 		QueryOptions{Descending: true, MaxEvents: 2, Range: wholeChunk(t, cr)})
@@ -883,7 +1211,7 @@ func TestQuery_ColdReaderParity_MatchAllDescendingWithCap(t *testing.T) {
 
 func TestQuery_ColdReaderParity_ContractIDOnly(t *testing.T) {
 	hotFx := newQueryFixture(t)
-	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+	cr := freezeFixtureToColdReader(t, hotFx.store, chunk.ID(0))
 
 	got, err := Query(context.Background(), cr,
 		[]Filter{{ContractID: hotFx.contractA[:]}},
@@ -894,7 +1222,7 @@ func TestQuery_ColdReaderParity_ContractIDOnly(t *testing.T) {
 
 func TestQuery_ColdReaderParity_ContractAndTopicAnd(t *testing.T) {
 	hotFx := newQueryFixture(t)
-	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+	cr := freezeFixtureToColdReader(t, hotFx.store, chunk.ID(0))
 
 	// contract A AND topic0 == alpha → ids 0, 1. Exercises FastAnd
 	// over two cold-loaded bitmaps.
@@ -907,7 +1235,7 @@ func TestQuery_ColdReaderParity_ContractAndTopicAnd(t *testing.T) {
 
 func TestQuery_ColdReaderParity_UnionOfTwoFilters(t *testing.T) {
 	hotFx := newQueryFixture(t)
-	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+	cr := freezeFixtureToColdReader(t, hotFx.store, chunk.ID(0))
 
 	// A∩topic1=gamma → id 1; B∩topic1=beta → id 2.
 	got, err := Query(context.Background(), cr, []Filter{
@@ -920,7 +1248,7 @@ func TestQuery_ColdReaderParity_UnionOfTwoFilters(t *testing.T) {
 
 func TestQuery_ColdReaderParity_RangeAndFilter(t *testing.T) {
 	hotFx := newMultiLedgerQueryFixture(t)
-	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+	cr := freezeFixtureToColdReader(t, hotFx.store, chunk.ID(0))
 	first := chunk.ID(0).FirstLedger()
 
 	// contractA filtered, second ledger only → 2 extra events.
@@ -933,7 +1261,7 @@ func TestQuery_ColdReaderParity_RangeAndFilter(t *testing.T) {
 
 func TestQuery_ColdReaderParity_DescendingRangeWithCap(t *testing.T) {
 	hotFx := newMultiLedgerQueryFixture(t)
-	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+	cr := freezeFixtureToColdReader(t, hotFx.store, chunk.ID(0))
 	first := chunk.ID(0).FirstLedger()
 
 	// contractA, whole chunk, descending capped to 2 → highest two A's = ids 6, 5.
@@ -990,7 +1318,7 @@ func TestIDRangeForLedgers_OutOfRangeLedgerErrors(t *testing.T) {
 
 func TestQuery_ColdReaderParity_FilterWithUnknownContract(t *testing.T) {
 	hotFx := newQueryFixture(t)
-	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+	cr := freezeFixtureToColdReader(t, hotFx.store, chunk.ID(0))
 
 	// Cold path: LookupKeys returns nil for the missing term (no panic,
 	// no error — same as hot). The filter contributes nothing, union is
@@ -1002,4 +1330,42 @@ func TestQuery_ColdReaderParity_FilterWithUnknownContract(t *testing.T) {
 		QueryOptions{Range: wholeChunk(t, cr)})
 	require.NoError(t, err)
 	assert.Empty(t, got)
+}
+
+// TestQuery_ColdReaderParity_EventType checks the type term through the
+// MPHF, where a term the chunk never saw resolves to some other term's
+// slot and is caught by the fingerprint.
+func TestQuery_ColdReaderParity_EventType(t *testing.T) {
+	hotFx := newTypeArityFixture(t)
+	cr := freezeFixtureToColdReader(t, hotFx.store, chunk.ID(0))
+	system, diagnostic := xdr.ContractEventTypeSystem, xdr.ContractEventTypeDiagnostic
+
+	got, err := Query(context.Background(), cr, []Filter{{EventType: &system}},
+		QueryOptions{Range: wholeChunk(t, cr)})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"s-1"}, dataSyms(t, got))
+
+	got, err = Query(context.Background(), cr, []Filter{{EventType: &diagnostic}},
+		QueryOptions{Range: wholeChunk(t, cr)})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestQuery_ColdReaderParity_TopicCount runs the bucket union and the
+// exact-count narrowing against the cold index.
+func TestQuery_ColdReaderParity_TopicCount(t *testing.T) {
+	hotFx := newTypeArityFixture(t)
+	cr := freezeFixtureToColdReader(t, hotFx.store, chunk.ID(0))
+
+	got, err := Query(context.Background(), cr,
+		[]Filter{{TopicCount: TopicCountFilter{Count: 2}}},
+		QueryOptions{Range: wholeChunk(t, cr)})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"c-2", "c-5", "c-4", "c-6"}, dataSyms(t, got))
+
+	got, err = Query(context.Background(), cr,
+		[]Filter{{TopicCount: TopicCountFilter{Count: protocol.MaxTopicCount, Exact: true}}},
+		QueryOptions{Range: wholeChunk(t, cr)})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"c-4"}, dataSyms(t, got))
 }

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/query_test.go
@@ -945,6 +945,23 @@ func TestQuery_TypeAndCountIndexTerms(t *testing.T) {
 			},
 			1, 1,
 		},
+		// The two shapes a topic position does not imply. A position proves a
+		// lower bound only, so it can never establish an exact count; and
+		// topic0 proves only that the event carries one topic.
+		"exact count is never implied by a topic position": {
+			Filter{
+				Topics:     [protocol.MaxTopicCount][]byte{fx.alphaRaw},
+				TopicCount: TopicCountFilter{Count: 1, Exact: true},
+			},
+			1, 1 + 1,
+		},
+		"topic0 does not imply at least 2": {
+			Filter{
+				Topics:     [protocol.MaxTopicCount][]byte{fx.alphaRaw},
+				TopicCount: TopicCountFilter{Count: 2},
+			},
+			1, 1 + 4,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			cr := &countingReader{Reader: fx.store}
@@ -1034,6 +1051,47 @@ func TestQuery_UnionOfTypeAndCountFilters(t *testing.T) {
 	assert.Equal(t, []string{"s-1", "c-0"}, fx.query(t,
 		Filter{EventType: &system},
 		Filter{TopicCount: TopicCountFilter{Count: 0, Exact: true}}))
+}
+
+// TestMatchesAnyFilterView_TypeAndCount covers the post-filter's type and
+// topic-count checks. Both index families are exact, so a single-clause query
+// never reaches them with a mismatch: they fire only when a union clause falls
+// through to the next one, or when a term hash collides. Nothing else in the
+// package covers them, and every other test passes with either check disabled.
+func TestMatchesAnyFilterView_TypeAndCount(t *testing.T) {
+	// Only arity matters here, so both events carry the same topic value.
+	var cid xdr.ContractId
+	sym := xdr.ScSymbol("alpha")
+	topic := xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym}
+	oneTopic := payloadFor(t, cid, "one-topic", topic).ContractEventBytes
+	twoTopics := payloadFor(t, cid, "two-topics", topic, topic).ContractEventBytes
+
+	system, contract := xdr.ContractEventTypeSystem, xdr.ContractEventTypeContract
+	exactly1 := Filter{TopicCount: TopicCountFilter{Count: 1, Exact: true}}
+	exactly2 := Filter{TopicCount: TopicCountFilter{Count: 2, Exact: true}}
+	atLeast2 := Filter{TopicCount: TopicCountFilter{Count: 2}}
+
+	for name, tc := range map[string]struct {
+		raw    []byte
+		filter Filter
+		want   bool
+	}{
+		"wrong type rejected":     {oneTopic, Filter{EventType: &system}, false},
+		"right type accepted":     {oneTopic, Filter{EventType: &contract}, true},
+		"count above exact":       {twoTopics, exactly1, false},
+		"count below exact":       {oneTopic, exactly2, false},
+		"exact count accepted":    {twoTopics, exactly2, true},
+		"count below the minimum": {oneTopic, atLeast2, false},
+		"at least count accepted": {twoTopics, atLeast2, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			filters := []Filter{tc.filter}
+			plan := planFilters(filters)
+			got, err := matchesAnyFilterView(tc.raw, filters, &plan)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // TestQuery_InvalidFilterRejected covers the values that would key a term no

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/query_test.go
@@ -782,12 +782,13 @@ func makeSimplePayload(t *testing.T, dataSymbol string) events.Payload {
 //	id 1: system,   topics [alpha]                             → "s-1"
 //	id 2: contract, topics [alpha, beta]                       → "c-2"
 //	id 3: contract, topics []                                  → "c-0"
-//	id 4: contract, topics [alpha, beta, gamma, delta, epslon] → "c-5"
+//	id 4: contract, topics [alpha, beta, gamma, delta, epsilon] → "c-5"
 //	id 5: contract, topics [alpha, beta, gamma, delta]         → "c-4"
 //	id 6: contract, topics [alpha .. zeta]                     → "c-6"
 //
-// "c-5" and "c-6" share the overflow bucket, so an exact count there is a
-// superset the post-filter has to narrow.
+// "c-5" and "c-6" both carry more topics than a filter can name, so they
+// share the overflow bucket: they are what an "at least" union has to reach
+// and what an exact count must not return.
 type typeArityFixture struct {
 	store    *HotStore
 	contract xdr.ContractId
@@ -880,12 +881,11 @@ func TestQuery_TopicCountFilter(t *testing.T) {
 		filter Filter
 		want   []string
 	}{
-		"exactly 0":                   {Filter{TopicCount: TopicCountFilter{Count: 0, Exact: true}}, []string{"c-0"}},
-		"exactly 1":                   {Filter{TopicCount: TopicCountFilter{Count: 1, Exact: true}}, []string{"c-1", "s-1"}},
-		"exactly 2":                   {Filter{TopicCount: TopicCountFilter{Count: 2, Exact: true}}, []string{"c-2"}},
-		"exactly 3":                   {Filter{TopicCount: TopicCountFilter{Count: 3, Exact: true}}, []string{}},
-		"exactly the top count":       {Filter{TopicCount: TopicCountFilter{Count: top, Exact: true}}, []string{"c-4"}},
-		"exactly above the top count": {Filter{TopicCount: TopicCountFilter{Count: top + 1, Exact: true}}, []string{"c-5"}},
+		"exactly 0":             {Filter{TopicCount: TopicCountFilter{Count: 0, Exact: true}}, []string{"c-0"}},
+		"exactly 1":             {Filter{TopicCount: TopicCountFilter{Count: 1, Exact: true}}, []string{"c-1", "s-1"}},
+		"exactly 2":             {Filter{TopicCount: TopicCountFilter{Count: 2, Exact: true}}, []string{"c-2"}},
+		"exactly 3":             {Filter{TopicCount: TopicCountFilter{Count: 3, Exact: true}}, []string{}},
+		"exactly the top count": {Filter{TopicCount: TopicCountFilter{Count: top, Exact: true}}, []string{"c-4"}},
 
 		"at least 1": {
 			Filter{TopicCount: TopicCountFilter{Count: 1}},
@@ -895,11 +895,8 @@ func TestQuery_TopicCountFilter(t *testing.T) {
 			Filter{TopicCount: TopicCountFilter{Count: 2}},
 			[]string{"c-2", "c-5", "c-4", "c-6"},
 		},
-		"at least 3":                   {Filter{TopicCount: TopicCountFilter{Count: 3}}, []string{"c-5", "c-4", "c-6"}},
-		"at least the top count":       {Filter{TopicCount: TopicCountFilter{Count: top}}, []string{"c-5", "c-4", "c-6"}},
-		"at least above the top count": {Filter{TopicCount: TopicCountFilter{Count: top + 1}}, []string{"c-5", "c-6"}},
-		"at least two above the top":   {Filter{TopicCount: TopicCountFilter{Count: top + 2}}, []string{"c-6"}},
-		"at least beyond every event":  {Filter{TopicCount: TopicCountFilter{Count: top + 3}}, []string{}},
+		"at least 3":             {Filter{TopicCount: TopicCountFilter{Count: 3}}, []string{"c-5", "c-4", "c-6"}},
+		"at least the top count": {Filter{TopicCount: TopicCountFilter{Count: top}}, []string{"c-5", "c-4", "c-6"}},
 
 		"count alongside every other field": {
 			Filter{
@@ -932,12 +929,11 @@ func TestQuery_TypeAndCountIndexTerms(t *testing.T) {
 		wantCalls int
 		wantKeys  int
 	}{
-		"wildcard count stays match-all":      {Filter{}, 0, 0},
-		"type alone":                          {Filter{EventType: &system}, 1, 1},
-		"exact count alone":                   {Filter{TopicCount: TopicCountFilter{Count: 1, Exact: true}}, 1, 1},
-		"at least 1 unions every bucket":      {Filter{TopicCount: TopicCountFilter{Count: 1}}, 1, top + 1},
-		"at least the top count":              {Filter{TopicCount: TopicCountFilter{Count: top}}, 1, 2},
-		"at least beyond what a filter names": {Filter{TopicCount: TopicCountFilter{Count: 9}}, 1, 1},
+		"wildcard count stays match-all": {Filter{}, 0, 0},
+		"type alone":                     {Filter{EventType: &system}, 1, 1},
+		"exact count alone":              {Filter{TopicCount: TopicCountFilter{Count: 1, Exact: true}}, 1, 1},
+		"at least 1 unions every bucket": {Filter{TopicCount: TopicCountFilter{Count: 1}}, 1, top + 1},
+		"at least the top count":         {Filter{TopicCount: TopicCountFilter{Count: top}}, 1, 2},
 		"count on top of a contract": {
 			Filter{ContractID: fx.contract[:], TopicCount: TopicCountFilter{Count: 3}},
 			1, 1 + 3,
@@ -1057,6 +1053,18 @@ func TestQuery_InvalidFilterRejected(t *testing.T) {
 		"unknown event type": {
 			Filter{EventType: &unknownType},
 			"not a known event type",
+		},
+		// The index shares one bucket across every count above what a filter
+		// can name, so serving these would mean returning a superset and
+		// letting the post-filter narrow it, which MaxEvents can turn into an
+		// empty page with matches still ahead.
+		"topic count above what a filter can name": {
+			Filter{TopicCount: TopicCountFilter{Count: protocol.MaxTopicCount + 1}},
+			"must be at most 4",
+		},
+		"exact topic count above what a filter can name": {
+			Filter{TopicCount: TopicCountFilter{Count: protocol.MaxTopicCount + 1, Exact: true}},
+			"must be at most 4",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## What

Adds two index term families to the event store: one keyed on an event's type, one keyed on how many topics it carries.

Both come out of the storage analysis in #774. getEvents v1 filters on event type, and its topic filters carry arity semantics: a filter ending in `**` matches events with at least as many topics as it names, and one that does not matches events with exactly that many. Neither is answerable from an index over contract IDs and topic values, so today a type-only query degenerates to a full scan over exactly the rarest data. Arity is worse than a missing value term, because it is an absence property and a value term can only say what an event has.

Completed chunks are immutable, so adding a term family later means reingesting the events store. That is why this lands before the initial backfill rather than alongside the v1 shim that will use it.

## The overflow bucket

Topic-count buckets are exact for every count a filter can name, plus one overflow bucket shared by every event carrying more.

The overflow bucket is load bearing. Events can carry more than four topics: `ContractEventV0.topics` is an unbounded XDR vector and the Soroban host records topics without a count check. The design doc already notes this on the value side ("Additional topics beyond 4 are stored but not indexed"). With a bucket per exact count and nothing above, a five-topic event would fall outside every bucket an "at least n" union can reach and would silently drop out of results it belongs in. The post-filter cannot undo that, since it only removes candidates.

Keeping the top bucket exact rather than saturating also matters for pagination. A saturating top bucket would make the index return a superset for any exact count a v1 filter can express, and because `MaxEvents` is applied before the post-filter, a page could come back empty with matches still ahead and no cursor to resume from. With the overflow bucket, the only superset left is an exact count above what any filter can name, which neither API can produce.

## Query side

`Filter` grows an `EventType` pointer and a `TopicCount` field whose zero value is the wildcard. `TopicCountFilter{Count, Exact}` maps directly onto v1's two shapes.

Terms are now grouped by field: bitmaps within a group are OR-ed and the groups are AND-ed. Only the topic-count group ever holds more than one term, and every other field is a single-element group, so the old flat plan is the degenerate case. The match-all short-circuit is now read off the term groups themselves rather than a separate predicate, so the two cannot drift.

One planner shortcut: an "at least" count already implied by a constrained topic position fetches no bucket at all, since a topic term is only indexed for events that carry that position. That covers the standard `["transfer", "**"]` shape, and skips OR-ing chunk-sized bitmaps for a constraint that was a no-op. The post-filter enforces the count either way.

## Cost

Measured with `BenchmarkEventIndex_10M` at 9M events, with adds grouped per ledger the way `HotStore.applyLedger` batches them: the two families add roughly 7% build time and 1% heap. The type bitmaps are near-degenerate and compress away; the topic-count buckets are the real cost and are still small against the ~57MB of bitmap data per chunk. Including them is the low-regret call, since an unused term costs disk and nothing else, while a missing one costs a reingest.

## Notes for review

- No format identifier bump. Chunks built before this have no bitmaps for either family, so they need reingesting; that is consistent with how this branch treats pre-release storage changes.
- `TermsForBytes` now rejects an event type outside the enum, which fails ingestion of that ledger. This matches the existing hard-fail on an unsupported `ContractEvent` body version, and is now commented and tested rather than implicit.
- `protocol.MaxTopicCount` is pinned by a compile-time assertion. The bucket space is written into artifacts that are never rewritten, so growing that constant would silently redefine what the overflow bucket in every existing chunk means.
- The v1 shim itself is not here. This is the storage and query support it needs.

## Follow-ups, not in this PR

- Nothing detects an under-indexed chunk: a query against one reads the missing bitmaps as "no matching events" rather than failing. Both new families are universal, one term per event, so per-chunk bucket cardinalities must sum to the event count. That is a cheap open-time tripwire if we want one.
- `indexPackItemsPerRecord = 128` was tuned assuming every bitmap is small. The topic-count buckets are around a megabyte each, so a handful of records per chunk become large and an unrelated term landing in one pays that read. Worth measuring.
- A type-only filter no longer takes the sequential match-all path; it resolves through a near-full term and does point gets. Nothing detects "this group covers essentially the whole range" and falls back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GGKYLKf29KsdFRtvWXVNf
