### PR TITLE
bench(full-history): run benchmark campaigns from GitHub Actions (#868)

### DIFF
--- a/.github/workflows/bench-campaign.yml
+++ b/.github/workflows/bench-campaign.yml
@@ -10,8 +10,7 @@ name: Bench campaign (EC2)
 
 on:
   # Dispatch only. No cron in v1: a campaign occupies one box for most of a day
-  # and nothing here decides which phase is worth running unattended. The
-  # rpc-bench concurrency group is the lane the whole campaign chain runs in.
+  # and nothing here decides which phase is worth running unattended.
   workflow_dispatch:
     # Ten inputs is the workflow_dispatch ceiling, so this list is full: further
     # knobs have to become overrides inside render-campaign-toml.sh.
@@ -70,11 +69,16 @@ on:
         type: string
         default: main
 
-# One campaign at a time across the whole repo: a campaign owns a box for hours
-# and two of them would only measure each other. Queue, never cancel — a
-# cancelled chain leaves the box to its self-terminate ceiling.
+# Campaigns run in parallel: every run launches its own box, writes under its
+# own runs/<run_id>/ S3 prefix, and the relay ignores other runs' result
+# objects, so two campaigns never measure each other. The one shared resource,
+# the results-site push in notify, is race-safe on its own (ingest.sh
+# --push-main rebuilds and retries when main moves). The group is therefore
+# per run: it exists only so a re-run of the same run_id queues behind the
+# original rather than racing it. Never cancel — a cancelled chain leaves the
+# box to its self-terminate ceiling.
 concurrency:
-  group: rpc-bench
+  group: rpc-bench-${{ github.run_id }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/bench-campaign.yml
+++ b/.github/workflows/bench-campaign.yml
@@ -1,0 +1,801 @@
+name: Bench campaign (EC2)
+# Runs one stellar-rpc-benchmarks campaign on one ephemeral EC2 box: renders the
+# campaign TOML from the dispatch inputs, launches the box with that config in
+# its user-data, then relays the wait across four poll jobs until the box
+# publishes a verdict object to S3.
+# Box bootstrap: perf-eval/bootstrap-common.sh + perf-eval/bench-campaign/run-campaign.sh;
+# runner-side waiting: perf-eval/relay.
+# The campaign itself lives in stellar-experimental/stellar-rpc-benchmarks; this
+# workflow only drives it and reports the verdict.
+
+on:
+  # Dispatch only. No cron in v1: a campaign occupies one box for most of a day
+  # and nothing here decides which phase is worth running unattended. The
+  # rpc-bench concurrency group is the lane the whole campaign chain runs in.
+  workflow_dispatch:
+    # Ten inputs is the workflow_dispatch ceiling, so this list is full: further
+    # knobs have to become overrides inside render-campaign-toml.sh.
+    inputs:
+      phase:
+        description: 'Pacing phase (selects close_interval + the dataset profiles)'
+        required: true
+        type: choice
+        options: ['1', '2', '3']
+      ingest:
+        description: 'Which ingest benchmarks to run'
+        required: false
+        type: choice
+        default: both
+        options: [both, cold, hot, none]
+      query:
+        description: 'Run the query suites after ingest'
+        required: false
+        type: choice
+        default: 'no'
+        options: ['no', 'yes']
+      runs:
+        description: 'Repetitions per (dataset, chunk) cell'
+        required: false
+        type: string
+        default: '1'
+      workers:
+        description: 'bench-ingest cold --workers (empty = the per-machine default)'
+        required: false
+        type: string
+        default: ''
+      machine:
+        description: 'Box size: 2x = m6id.2xlarge, 8x = c6id.8xlarge'
+        required: false
+        type: choice
+        default: 2x
+        options: [2x, 8x]
+      ref:
+        description: 'stellar-rpc ref to benchmark (resolved on the box, not here)'
+        required: false
+        type: string
+        default: feature/full-history
+      hot_num_ledgers:
+        description: 'Cap the hot ingest at N ledgers (0 = the whole chunk); shortens a smoke run'
+        required: false
+        type: string
+        default: '0'
+      run_name:
+        description: 'Campaign name (empty = phase<N>-<machine>)'
+        required: false
+        type: string
+        default: ''
+      benchmarks_ref:
+        description: 'stellar-rpc-benchmarks ref the box runs the campaign from'
+        required: false
+        type: string
+        default: main
+
+# One campaign at a time across the whole repo: a campaign owns a box for hours
+# and two of them would only measure each other. Queue, never cancel — a
+# cancelled chain leaves the box to its self-terminate ceiling.
+concurrency:
+  group: rpc-bench
+  cancel-in-progress: false
+
+permissions:
+  id-token: write   # OIDC AssumeRole into the GHA role
+  contents: read    # checkout
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  AWS_REGION: us-east-1
+  BUCKET: stellar-rpc-ci-load-test
+  PERF_EVAL_DIR: cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval
+  RESULT_KEY: runs/${{ github.run_id }}/campaign/result.json # deterministic per run
+
+jobs:
+  validate:
+    name: Validate inputs + render campaign config
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      toml_b64: ${{ steps.render.outputs.toml_b64 }}
+      budget_minutes: ${{ steps.render.outputs.budget_minutes }}
+      deadline_epoch: ${{ steps.render.outputs.deadline_epoch }}
+      instance_type: ${{ steps.render.outputs.instance_type }}
+      workers: ${{ steps.render.outputs.workers }}
+      self_terminate_minutes: ${{ steps.render.outputs.self_terminate_minutes }}
+      campaign_name: ${{ steps.render.outputs.campaign_name }}
+    steps:
+      # Default checkout (github.sha): the harness — this workflow, the render
+      # script, the leg script, the relay — always runs at the version it was
+      # dispatched from. The benchmarked ref travels in the TOML and is resolved
+      # on the box. This deliberately differs from ec2-leg.yml, which checks out
+      # its target_ref and so also runs that ref's harness.
+      - uses: actions/checkout@v4
+
+      # Every input check and the wall-clock estimate live in the script so they
+      # can be exercised off GHA; a rejection here costs no EC2 time.
+      - name: Render campaign config
+        id: render
+        env:
+          PHASE: ${{ inputs.phase }}
+          INGEST: ${{ inputs.ingest }}
+          QUERY: ${{ inputs.query }}
+          RUNS: ${{ inputs.runs }}
+          WORKERS: ${{ inputs.workers }}
+          MACHINE: ${{ inputs.machine }}
+          TARGET_REF: ${{ inputs.ref }}
+          HOT_NUM_LEDGERS: ${{ inputs.hot_num_ledgers }}
+          RUN_NAME: ${{ inputs.run_name }}
+          # Gated here even though it never enters the TOML: the launch job
+          # interpolates it into the box user-data, which runs as root.
+          BENCHMARKS_REF: ${{ inputs.benchmarks_ref }}
+        run: ./"$PERF_EVAL_DIR"/bench-campaign/render-campaign-toml.sh
+
+      - name: Summarize the plan
+        env:
+          CAMPAIGN_NAME: ${{ steps.render.outputs.campaign_name }}
+          BUDGET_MINUTES: ${{ steps.render.outputs.budget_minutes }}
+          DEADLINE_EPOCH: ${{ steps.render.outputs.deadline_epoch }}
+          INSTANCE_TYPE: ${{ steps.render.outputs.instance_type }}
+          RESOLVED_WORKERS: ${{ steps.render.outputs.workers }}
+          PHASE: ${{ inputs.phase }}
+          INGEST: ${{ inputs.ingest }}
+          QUERY: ${{ inputs.query }}
+          RUNS: ${{ inputs.runs }}
+          TARGET_REF: ${{ inputs.ref }}
+          HOT_NUM_LEDGERS: ${{ inputs.hot_num_ledgers }}
+          BENCHMARKS_REF: ${{ inputs.benchmarks_ref }}
+        run: |
+          # shellcheck disable=SC2016 # the backticks below are markdown, not command substitution
+          {
+            printf '### Bench campaign `%s`\n\n' "$CAMPAIGN_NAME"
+            printf '| field | value |\n|---|---|\n'
+            printf '| phase | %s |\n' "$PHASE"
+            printf '| ingest / query | %s / %s |\n' "$INGEST" "$QUERY"
+            printf '| runs / workers / hot_num_ledgers | %s / %s / %s |\n' \
+              "$RUNS" "$RESOLVED_WORKERS" "$HOT_NUM_LEDGERS"
+            printf '| stellar-rpc ref | `%s` |\n' "$TARGET_REF"
+            printf '| benchmarks ref | `%s` |\n' "$BENCHMARKS_REF"
+            printf '| instance type | %s |\n' "$INSTANCE_TYPE"
+            printf '| estimated budget | %dh%02dm |\n' \
+              "$((BUDGET_MINUTES / 60))" "$((BUDGET_MINUTES % 60))"
+            printf '| deadline (UTC) | %s |\n' "$(date -u -d "@$DEADLINE_EPOCH" +%FT%TZ)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  launch:
+    name: Launch campaign box
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      instance_id: ${{ steps.launch.outputs.instance_id }}
+    env:
+      INSTANCE_TYPE: ${{ needs.validate.outputs.instance_type }}
+      SELF_TERMINATE_MINUTES: ${{ needs.validate.outputs.self_terminate_minutes }}
+      BUDGET_MINUTES: ${{ needs.validate.outputs.budget_minutes }}
+      CAMPAIGN_NAME: ${{ needs.validate.outputs.campaign_name }}
+      BENCH_TOML_B64: ${{ needs.validate.outputs.toml_b64 }}
+      BENCH_REPO_REF: ${{ inputs.benchmarks_ref }}
+      SSM_REGISTRATION_TIMEOUT: 240
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GHA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 1800
+
+      # Seed RESULT_KEY with a pending marker so the key exists from launch
+      # onward: the relay reads "pending" as still-running and can treat fetch
+      # errors as genuine faults (an absent key surfaces as 403, not 404,
+      # because the role has no s3:ListBucket on this bucket). A re-run attempt
+      # also overwrites the previous attempt's leftover verdict here.
+      - name: Seed the pending result marker
+        env:
+          RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          jq -n --arg run "$RUN_ID" \
+                '{schemaVersion: 1, verdict: "pending", markdown: "", runId: $run}' > /tmp/pending.json
+          aws s3api put-object --bucket "$BUCKET" --key "$RESULT_KEY" \
+                --content-type application/json --body /tmp/pending.json >/dev/null
+          echo "seeded pending marker at s3://$BUCKET/$RESULT_KEY"
+
+      - name: Render user-data
+        # The scripts ship verbatim; parameters travel in a preamble so the bytes
+        # that run on the box match the bytes in git. Order is:
+        #   preamble exports -> bootstrap-common.sh -> run-campaign.sh.
+        # BENCH_TOML_B64 is one base64 line, so it survives quoting as-is.
+        run: |
+          {
+            echo '#!/usr/bin/env bash'
+            echo "export RUN_ID=${{ github.run_id }}-${{ github.run_attempt }}"
+            echo "export BUCKET=$BUCKET RESULT_KEY=$RESULT_KEY"
+            echo "export SELF_TERMINATE_MINUTES=$SELF_TERMINATE_MINUTES BUDGET_MINUTES=$BUDGET_MINUTES"
+            echo "export BENCH_TOML_B64=\"$BENCH_TOML_B64\""
+            echo "export BENCH_REPO_REF=\"$BENCH_REPO_REF\""
+            cat "$PERF_EVAL_DIR/bootstrap-common.sh"
+            cat "$PERF_EVAL_DIR/bench-campaign/run-campaign.sh"
+          } > /tmp/user-data.sh
+          # EC2 refuses user-data above 16 KB; fail here rather than on launch.
+          SIZE=$(wc -c < /tmp/user-data.sh)
+          echo "user-data is $SIZE bytes"
+          [ "$SIZE" -le 16384 ] || { echo "::error::user-data is $SIZE bytes, over the 16384-byte EC2 limit"; exit 1; }
+
+      - name: Launch EC2 instance
+        id: launch
+        run: |
+          # rpc-bench + deadline are what bench-reaper.yml sweeps on; the test tag
+          # is what the GHA role's terminate permission is conditioned on. The
+          # deadline tag is the reaper's backstop, not the campaign budget: it is
+          # set past the box's self-terminate ceiling so a failed campaign keeps
+          # its rescue window instead of being reaped out from under an operator.
+          # It is computed here rather than at render time so runner queue delay
+          # cannot shrink it; the 30-minute margin covers launch-to-boot lag,
+          # because the box's shutdown clock only starts at boot.
+          REAPER_DEADLINE_EPOCH=$(( $(date +%s) + (SELF_TERMINATE_MINUTES + 30) * 60 ))
+          COMMON_TAGS="{Key=test,Value=stellar-rpc-ci-load-test},
+            {Key=rpc-bench,Value=true},
+            {Key=run-id,Value=${{ github.run_id }}},
+            {Key=deadline,Value=$REAPER_DEADLINE_EPOCH}"
+          # AMI: Canonical Ubuntu 24.04 LTS (Noble) amd64, us-east-1, gp3, serial
+          # 20260714. The benchmarks runner's bootstrap.sh requires 24.04, so
+          # ec2-leg.yml's 22.04 AMI is deliberately not reused here.
+          # Root gp3 stays small (toolchain + build clone only) because the
+          # datasets, RocksDB and packfiles all live on the NVMe instance store
+          # both machine types carry.
+          RUN_INSTANCES_JSON=$(aws ec2 run-instances \
+            --image-id ami-052355af2a014bd2c \
+            --instance-type "$INSTANCE_TYPE" \
+            --iam-instance-profile Name=stellar-rpc-ci-load-test \
+            --user-data file:///tmp/user-data.sh \
+            --instance-initiated-shutdown-behavior terminate \
+            --block-device-mappings '[{
+              "DeviceName":"/dev/sda1",
+              "Ebs":{"VolumeSize":50,"VolumeType":"gp3","Iops":3000,"Throughput":125,"DeleteOnTermination":true}
+            }]' \
+            --tag-specifications \
+              "ResourceType=instance,Tags=[
+                {Key=Name,Value=bench-campaign-$CAMPAIGN_NAME},
+                $COMMON_TAGS
+              ]" \
+              "ResourceType=volume,Tags=[
+                {Key=Name,Value=bench-campaign-$CAMPAIGN_NAME-root},
+                $COMMON_TAGS
+              ]" \
+            --count 1 \
+            --output json)
+
+          INSTANCE_ID=$(printf '%s' "$RUN_INSTANCES_JSON" | jq -r '.Instances[0].InstanceId')
+          echo "instance_id=$INSTANCE_ID" >> "$GITHUB_OUTPUT"
+          echo "launched $INSTANCE_ID ($INSTANCE_TYPE) for campaign $CAMPAIGN_NAME"
+
+      # The relay's periodic debug tail reads the box log over SSM, so a box that
+      # never registers is a blind run: fail fast instead.
+      - name: Wait for SSM agent to register
+        env:
+          INSTANCE_ID: ${{ steps.launch.outputs.instance_id }}
+        run: |
+          DEADLINE=$(( $(date +%s) + SSM_REGISTRATION_TIMEOUT ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            PING=$(aws ssm describe-instance-information \
+                     --filters "Key=InstanceIds,Values=$INSTANCE_ID" \
+                     --query 'InstanceInformationList[0].PingStatus' \
+                     --output text 2>/dev/null || echo "")
+            echo "[$(date -u +%FT%TZ)] ssm ping=$PING"
+            if [ "$PING" = "Online" ]; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::SSM agent never registered for $INSTANCE_ID — verify AmazonSSMManagedInstanceCore is attached to the stellar-rpc-ci-load-test role"
+          exit 1
+
+  # A campaign outlives any single GHA job (6 h hard ceiling), and Actions has no
+  # way to loop a job, so the wait is relayed across four copied jobs. Each one
+  # polls its ~5.3 h window and reports state=ok|fail|running; `running` hands
+  # off to the next. 4 x 19200 s covers the 21 h capacity ceiling the render
+  # script enforces.
+  poll1:
+    name: Await campaign (window 1/4)
+    needs: [validate, launch]
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    outputs:
+      state: ${{ steps.relay.outputs.state }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go
+      - name: Configure AWS via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GHA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 21600
+      # RUN_ID must match the box preamble's: the relay ignores result objects
+      # from other attempts, which share RESULT_KEY with this one.
+      - name: Relay
+        id: relay
+        env:
+          INSTANCE_ID: ${{ needs.launch.outputs.instance_id }}
+          DEADLINE_EPOCH: ${{ needs.validate.outputs.deadline_epoch }}
+          RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          WINDOW_SECONDS: 19200
+          POLL_INTERVAL: 30
+          DEBUG_LOG_LINES: 40
+          DEBUG_LOG_EVERY_POLLS: 10
+        run: go run "./$PERF_EVAL_DIR/relay"
+      - name: Write relay summary
+        if: always()
+        run: |
+          if [ -f /tmp/results.md ]; then
+            cat /tmp/results.md >> "$GITHUB_STEP_SUMMARY"
+          elif [ -f /tmp/timeout-comment.md ]; then
+            cat /tmp/timeout-comment.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      # The relay exits 0 for every state; the job verdict is decided here.
+      - name: Gate on relay state
+        env:
+          STATE: ${{ steps.relay.outputs.state }}
+        run: |
+          case "$STATE" in
+            ok) echo "campaign passed inside this window" ;;
+            running) echo "window closed with the campaign still running; handing off to window 2/4" ;;
+            fail)
+              cat /tmp/results.md /tmp/timeout-comment.md 2>/dev/null || true
+              echo "::error::campaign failed"
+              exit 1
+              ;;
+            *)
+              echo "::error::relay reported no state"
+              exit 1
+              ;;
+          esac
+
+  poll2:
+    name: Await campaign (window 2/4)
+    needs: [validate, launch, poll1]
+    if: needs.poll1.outputs.state == 'running'
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    outputs:
+      state: ${{ steps.relay.outputs.state }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go
+      - name: Configure AWS via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GHA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 21600
+      - name: Relay
+        id: relay
+        env:
+          INSTANCE_ID: ${{ needs.launch.outputs.instance_id }}
+          DEADLINE_EPOCH: ${{ needs.validate.outputs.deadline_epoch }}
+          RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          WINDOW_SECONDS: 19200
+          POLL_INTERVAL: 30
+          DEBUG_LOG_LINES: 40
+          DEBUG_LOG_EVERY_POLLS: 10
+        run: go run "./$PERF_EVAL_DIR/relay"
+      - name: Write relay summary
+        if: always()
+        run: |
+          if [ -f /tmp/results.md ]; then
+            cat /tmp/results.md >> "$GITHUB_STEP_SUMMARY"
+          elif [ -f /tmp/timeout-comment.md ]; then
+            cat /tmp/timeout-comment.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Gate on relay state
+        env:
+          STATE: ${{ steps.relay.outputs.state }}
+        run: |
+          case "$STATE" in
+            ok) echo "campaign passed inside this window" ;;
+            running) echo "window closed with the campaign still running; handing off to window 3/4" ;;
+            fail)
+              cat /tmp/results.md /tmp/timeout-comment.md 2>/dev/null || true
+              echo "::error::campaign failed"
+              exit 1
+              ;;
+            *)
+              echo "::error::relay reported no state"
+              exit 1
+              ;;
+          esac
+
+  poll3:
+    name: Await campaign (window 3/4)
+    needs: [validate, launch, poll2]
+    if: needs.poll2.outputs.state == 'running'
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    outputs:
+      state: ${{ steps.relay.outputs.state }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go
+      - name: Configure AWS via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GHA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 21600
+      - name: Relay
+        id: relay
+        env:
+          INSTANCE_ID: ${{ needs.launch.outputs.instance_id }}
+          DEADLINE_EPOCH: ${{ needs.validate.outputs.deadline_epoch }}
+          RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          WINDOW_SECONDS: 19200
+          POLL_INTERVAL: 30
+          DEBUG_LOG_LINES: 40
+          DEBUG_LOG_EVERY_POLLS: 10
+        run: go run "./$PERF_EVAL_DIR/relay"
+      - name: Write relay summary
+        if: always()
+        run: |
+          if [ -f /tmp/results.md ]; then
+            cat /tmp/results.md >> "$GITHUB_STEP_SUMMARY"
+          elif [ -f /tmp/timeout-comment.md ]; then
+            cat /tmp/timeout-comment.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Gate on relay state
+        env:
+          STATE: ${{ steps.relay.outputs.state }}
+        run: |
+          case "$STATE" in
+            ok) echo "campaign passed inside this window" ;;
+            running) echo "window closed with the campaign still running; handing off to window 4/4" ;;
+            fail)
+              cat /tmp/results.md /tmp/timeout-comment.md 2>/dev/null || true
+              echo "::error::campaign failed"
+              exit 1
+              ;;
+            *)
+              echo "::error::relay reported no state"
+              exit 1
+              ;;
+          esac
+
+  poll4:
+    name: Await campaign (window 4/4)
+    needs: [validate, launch, poll3]
+    if: needs.poll3.outputs.state == 'running'
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    outputs:
+      state: ${{ steps.relay.outputs.state }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go
+      - name: Configure AWS via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GHA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 21600
+      - name: Relay
+        id: relay
+        env:
+          INSTANCE_ID: ${{ needs.launch.outputs.instance_id }}
+          DEADLINE_EPOCH: ${{ needs.validate.outputs.deadline_epoch }}
+          RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          WINDOW_SECONDS: 19200
+          POLL_INTERVAL: 30
+          DEBUG_LOG_LINES: 40
+          DEBUG_LOG_EVERY_POLLS: 10
+        run: go run "./$PERF_EVAL_DIR/relay"
+      - name: Write relay summary
+        if: always()
+        run: |
+          if [ -f /tmp/results.md ]; then
+            cat /tmp/results.md >> "$GITHUB_STEP_SUMMARY"
+          elif [ -f /tmp/timeout-comment.md ]; then
+            cat /tmp/timeout-comment.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      # The last window: `running` here means the chain ran out before the
+      # campaign deadline. The box's own ceiling and the reaper still kill it.
+      - name: Gate on relay state
+        env:
+          STATE: ${{ steps.relay.outputs.state }}
+        run: |
+          case "$STATE" in
+            ok) echo "campaign passed inside this window" ;;
+            running) echo "::warning::relay chain exhausted; the campaign is still running on the box" ;;
+            fail)
+              cat /tmp/results.md /tmp/timeout-comment.md 2>/dev/null || true
+              echo "::error::campaign failed"
+              exit 1
+              ;;
+            *)
+              echo "::error::relay reported no state"
+              exit 1
+              ;;
+          esac
+
+  notify:
+    name: Notify
+    needs: [validate, launch, poll1, poll2, poll3, poll4]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    # The results-site ingest (bundle download, converter, viewer smoke test,
+    # push) dominates this budget; the notification itself takes seconds.
+    timeout-minutes: 20
+    steps:
+      # For scripts/bench-campaign's slack-payload.sh; same harness-version rule
+      # as validate (github.sha, not the benchmarked ref).
+      - uses: actions/checkout@v4
+
+      # The chain's shape carries the verdict: exactly one poll job sees the
+      # result object, the rest are skipped (empty state) or handed off.
+      # `rescued` mirrors the cleanup job's box-left-up condition (a poll saw
+      # a fail verdict) so the notification only claims a rescuable box when
+      # cleanup actually left one running.
+      - name: Decide the campaign verdict
+        id: verdict
+        env:
+          S1: ${{ needs.poll1.outputs.state }}
+          S2: ${{ needs.poll2.outputs.state }}
+          S3: ${{ needs.poll3.outputs.state }}
+          S4: ${{ needs.poll4.outputs.state }}
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+          LAUNCH_RESULT: ${{ needs.launch.result }}
+        run: |
+          STATE=fail
+          REASON=""
+          RESCUED=false
+          for S in "$S1" "$S2" "$S3" "$S4"; do
+            if [ "$S" = "ok" ]; then STATE=ok; fi
+          done
+          if [ "$STATE" != "ok" ]; then
+            if [ "$VALIDATE_RESULT" != "success" ]; then
+              REASON="input validation failed"
+            elif [ "$LAUNCH_RESULT" != "success" ]; then
+              REASON="box launch failed"
+            elif [ "$S1" = "fail" ] || [ "$S2" = "fail" ] || [ "$S3" = "fail" ] || [ "$S4" = "fail" ]; then
+              REASON="the campaign reported a failing verdict"
+              RESCUED=true
+            else
+              REASON="the relay chain was exhausted without a verdict"
+            fi
+          fi
+          {
+            echo "state=$STATE"
+            echo "reason=$REASON"
+            echo "rescued=$RESCUED"
+          } >> "$GITHUB_OUTPUT"
+          echo "verdict: $STATE ${REASON:+($REASON)}"
+
+      # Unconditional: the ok path reads the sidecar and ingests, the fail path
+      # reads the result object for the notification's verdict excerpt.
+      - name: Configure AWS via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GHA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 1800
+
+      # The box writes this sidecar next to the result object so the bundle's run
+      # id, published location, and uploaded tarball can be named without parsing
+      # the markdown. Its runId must match this attempt's, the way the relay
+      # checks the result object: attempts of the same run share this key, so a
+      # re-run whose own sidecar upload failed would otherwise report the
+      # previous attempt's bundle.
+      - name: Read the run-info sidecar
+        id: runinfo
+        if: steps.verdict.outputs.state == 'ok'
+        env:
+          RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          if aws s3 cp "s3://$BUCKET/${RESULT_KEY%/*}/run-info.json" /tmp/run-info.json >/dev/null 2>&1; then
+            SIDECAR_RUN_ID=$(jq -r '.runId // ""' /tmp/run-info.json)
+            if [ "$SIDECAR_RUN_ID" = "$RUN_ID" ]; then
+              {
+                echo "bench_run_id=$(jq -r '.benchRunId // ""' /tmp/run-info.json)"
+                echo "results_uri=$(jq -r '.resultsUri // ""' /tmp/run-info.json)"
+                echo "tarball_key=$(jq -r '.tarballKey // ""' /tmp/run-info.json)"
+              } >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::run-info.json is from run ${SIDECAR_RUN_ID:-<none>}, not $RUN_ID; the notification falls back to the result key"
+            fi
+          else
+            echo "::warning::no run-info.json sidecar; the notification falls back to the result key"
+          fi
+
+      # On failure the result object's markdown is the closest thing to a cause
+      # (the box wrote the last campaign-console lines into it), so pull a short
+      # excerpt for the notification: the first grep-worthy lines, else the last
+      # three. Guarded by the same runId check as the sidecar; the seeded
+      # pending marker (relay exhausted, launch failed) has no markdown and
+      # yields nothing. Best-effort throughout.
+      - name: Read the failure excerpt from the result object
+        id: result
+        if: steps.verdict.outputs.state == 'fail'
+        env:
+          RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          aws s3 cp "s3://$BUCKET/$RESULT_KEY" /tmp/result.json >/dev/null 2>&1 || exit 0
+          [ "$(jq -r '.runId // ""' /tmp/result.json)" = "$RUN_ID" ] || exit 0
+          [ "$(jq -r '.verdict // ""' /tmp/result.json)" = "fail" ] || exit 0
+          # Drop the fences, blank lines, and the ✅/❌ headline (the Slack
+          # header already carries the verdict).
+          jq -r '.markdown // ""' /tmp/result.json | grep -v '^```' | grep -v '^\s*$' | grep -v '^[✅❌]' > /tmp/verdict-lines.txt || true
+          EXCERPT=$(grep -m3 -iE 'fail|error|regression|gate|exceed|panic' /tmp/verdict-lines.txt || tail -n 3 /tmp/verdict-lines.txt)
+          [ -n "$EXCERPT" ] || exit 0
+          {
+            echo "excerpt<<VERDICT_EXCERPT_EOF"
+            echo "$EXCERPT"
+            echo "VERDICT_EXCERPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # Fold the run into the results site: fetch the tarball the box uploaded,
+      # clone stellar-rpc-benchmarks, and run its own ingest script, which
+      # converts the bundle, gates on the repo's tests, and pushes
+      # docs/runs/<id>.json to main — that push IS the site deploy. The push
+      # authenticates with BENCHMARKS_PUSH_TOKEN, a token with write access to
+      # that one repo; until the secret holds a working token this degrades to
+      # a warning. Best-effort throughout: an ingest failure must never turn a
+      # passing campaign red — the notification just falls back to the raw
+      # results URI, and the run can be ingested later from a laptop with the
+      # same script.
+      - name: Ingest the run into the results site
+        id: ingest
+        if: steps.verdict.outputs.state == 'ok' && steps.runinfo.outputs.tarball_key != ''
+        env:
+          TARBALL_KEY: ${{ steps.runinfo.outputs.tarball_key }}
+          RESULTS_URI: ${{ steps.runinfo.outputs.results_uri }}
+          PUSH_TOKEN: ${{ secrets.BENCHMARKS_PUSH_TOKEN }}
+        run: |
+          if [ -z "$PUSH_TOKEN" ]; then
+            echo "::warning::BENCHMARKS_PUSH_TOKEN is unset; run not ingested into the results site"
+            exit 0
+          fi
+          if ! aws s3 cp "s3://$BUCKET/$TARBALL_KEY" /tmp/bench-bundle.tgz; then
+            echo "::warning::tarball download failed; run not ingested into the results site"
+            exit 0
+          fi
+          # Full clone: the ingest script pushes HEAD:main, which a shallow
+          # clone's server-side check can reject. The token rides in the remote
+          # URL; the runner is ephemeral and Actions masks the secret in logs.
+          if ! git clone "https://x-access-token:${PUSH_TOKEN}@github.com/stellar-experimental/stellar-rpc-benchmarks.git" /tmp/benchmarks; then
+            echo "::warning::benchmarks repo clone failed; run not ingested into the results site"
+            exit 0
+          fi
+          git -C /tmp/benchmarks config user.name "github-actions[bot]"
+          git -C /tmp/benchmarks config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Campaign datasets are the synthetic apply-load packs, hence the
+          # hard-coded kind — revisit if a pubnet campaign ever runs through
+          # this workflow.
+          if (cd /tmp/benchmarks && scripts/ingest.sh /tmp/bench-bundle.tgz \
+                --dataset-kind synthetic --push-main \
+                -- --source-uri "$RESULTS_URI") 2>&1 | tee /tmp/ingest.log; then
+            VIEWER=$(grep '^viewer: ' /tmp/ingest.log | tail -1 | cut -d' ' -f2)
+            echo "viewer_url=$VIEWER" >> "$GITHUB_OUTPUT"
+            # The converted run JSON the ingest just committed; the notification
+            # reads the per-profile ingestion p99s and the build commit from it.
+            SITE_RUN_ID="${VIEWER##*run=}"
+            if [ -n "$SITE_RUN_ID" ] && [ -f "/tmp/benchmarks/docs/runs/$SITE_RUN_ID.json" ]; then
+              echo "run_json=/tmp/benchmarks/docs/runs/$SITE_RUN_ID.json" >> "$GITHUB_OUTPUT"
+            fi
+            echo "ingested; viewer: $VIEWER"
+          else
+            echo "::warning::results-site ingest failed; the notification falls back to the raw results URI"
+          fi
+
+      # The Block Kit payload comes from slack-payload.sh so its layout is
+      # testable off GHA. A missing or broken webhook must never turn a passing
+      # campaign red: it degrades to a warning plus the message in the log.
+      - name: Post the campaign notification
+        env:
+          MODE: campaign
+          STATE: ${{ steps.verdict.outputs.state }}
+          REASON: ${{ steps.verdict.outputs.reason }}
+          BOX_RESCUED: ${{ steps.verdict.outputs.rescued }}
+          CAMPAIGN_NAME: ${{ needs.validate.outputs.campaign_name }}
+          PHASE: ${{ inputs.phase }}
+          INGEST: ${{ inputs.ingest }}
+          QUERY: ${{ inputs.query }}
+          RUNS: ${{ inputs.runs }}
+          HOT_NUM_LEDGERS: ${{ inputs.hot_num_ledgers }}
+          TARGET_REF: ${{ inputs.ref }}
+          WORKERS: ${{ needs.validate.outputs.workers }}
+          INSTANCE_TYPE: ${{ needs.validate.outputs.instance_type }}
+          BUDGET_MINUTES: ${{ needs.validate.outputs.budget_minutes }}
+          DEADLINE_EPOCH: ${{ needs.validate.outputs.deadline_epoch }}
+          BOX_ID: ${{ needs.launch.outputs.instance_id }}
+          RUN_ID_TAG: ${{ github.run_id }}
+          BENCH_RUN_ID: ${{ steps.runinfo.outputs.bench_run_id }}
+          RESULTS_URI: ${{ steps.runinfo.outputs.results_uri }}
+          VIEWER_URL: ${{ steps.ingest.outputs.viewer_url }}
+          RUN_JSON: ${{ steps.ingest.outputs.run_json }}
+          EXCERPT: ${{ steps.result.outputs.excerpt }}
+          HARNESS_SHA: ${{ github.sha }}
+          WEBHOOK: ${{ secrets.SLACK_BENCH_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          # Elapsed since the config was rendered: the render script pins
+          # deadline_epoch = render time + budget.
+          ELAPSED_MINUTES=""
+          if [ -n "$DEADLINE_EPOCH" ] && [ -n "$BUDGET_MINUTES" ]; then
+            case "$DEADLINE_EPOCH$BUDGET_MINUTES" in
+              *[!0-9]*) : ;;
+              *)
+                E=$(( ($(date +%s) - (DEADLINE_EPOCH - BUDGET_MINUTES * 60)) / 60 ))
+                if [ "$E" -ge 0 ]; then ELAPSED_MINUTES=$E; fi
+                ;;
+            esac
+          fi
+          # The benchmarked commit, for the ref link: the converted run JSON
+          # records what the box actually built (campaign boxes leave the
+          # result object's targetSha empty).
+          TARGET_SHA=""
+          if [ -n "$RUN_JSON" ] && [ -r "$RUN_JSON" ]; then
+            TARGET_SHA=$(jq -r '.build.commit // ""' "$RUN_JSON" 2>/dev/null || true)
+          fi
+          export ELAPSED_MINUTES TARGET_SHA
+          # Degrade, never fail: a payload bug must not turn a campaign verdict
+          # red at the last step.
+          if ! ./"$PERF_EVAL_DIR"/bench-campaign/slack-payload.sh > /tmp/slack.json; then
+            echo "::warning::slack-payload.sh failed; notification not delivered"
+            exit 0
+          fi
+          TEXT=$(jq -r '.attachments[0].fallback' /tmp/slack.json)
+          echo "$TEXT"
+          echo "$TEXT" >> "$GITHUB_STEP_SUMMARY"
+          if [ -z "$WEBHOOK" ]; then
+            echo "::warning::SLACK_BENCH_WEBHOOK_URL is unset; notification not delivered"
+            exit 0
+          fi
+          if curl -fsS -X POST -H 'Content-Type: application/json' \
+               --data @/tmp/slack.json "$WEBHOOK" >/dev/null; then
+            echo "slack notified"
+          else
+            echo "::warning::slack notification failed"
+          fi
+
+  cleanup:
+    name: Terminate campaign box
+    needs: [launch, poll1, poll2, poll3, poll4]
+    if: always() && needs.launch.outputs.instance_id != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Configure AWS via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GHA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 900
+
+      # A failing campaign is the one worth rescuing: its bundle tarball is still
+      # on the box under /tmp, so the box is left up to its self-terminate
+      # ceiling for an operator to SSM in and pull it. The deadline tag plus
+      # bench-reaper.yml guarantee it dies regardless.
+      - name: Terminate unless the campaign failed
+        env:
+          INSTANCE_ID: ${{ needs.launch.outputs.instance_id }}
+          S1: ${{ needs.poll1.outputs.state }}
+          S2: ${{ needs.poll2.outputs.state }}
+          S3: ${{ needs.poll3.outputs.state }}
+          S4: ${{ needs.poll4.outputs.state }}
+        run: |
+          FAILED=false
+          for S in "$S1" "$S2" "$S3" "$S4"; do
+            if [ "$S" = "fail" ]; then FAILED=true; fi
+          done
+          if [ "$FAILED" = "true" ]; then
+            echo "::warning::campaign failed — leaving $INSTANCE_ID up to its self-terminate ceiling so /tmp/bench-results-*.tgz can be rescued over SSM"
+            exit 0
+          fi
+          # Tolerates an already-terminated box (terminate is idempotent, and a
+          # passing campaign powers itself off) but surfaces real failures —
+          # a bare `|| true` here masked a missing ec2:TerminateInstances
+          # permission for weeks.
+          if ! OUT=$(aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" 2>&1); then
+            echo "::warning::terminate-instances failed; the box falls to its self-terminate ceiling / the reaper: $OUT"
+          fi

--- a/.github/workflows/bench-campaign.yml
+++ b/.github/workflows/bench-campaign.yml
@@ -637,15 +637,25 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # Fold the run into the results site: fetch the tarball the box uploaded,
-      # clone stellar-rpc-benchmarks, and run its own ingest script, which
-      # converts the bundle, gates on the repo's tests, and pushes
-      # docs/runs/<id>.json to main — that push IS the site deploy. The push
-      # authenticates with BENCHMARKS_PUSH_TOKEN, a token with write access to
-      # that one repo; until the secret holds a working token this degrades to
-      # a warning. Best-effort throughout: an ingest failure must never turn a
-      # passing campaign red — the notification just falls back to the raw
-      # results URI, and the run can be ingested later from a laptop with the
-      # same script.
+      # clone stellar-rpc-benchmarks at the same ref the box ran the campaign
+      # from, and run its own ingest script, which converts the bundle, gates on
+      # the repo's tests, and pushes docs/runs/<id>.json to main — that push IS
+      # the site deploy. Producer and consumer must run the same benchmarks
+      # code: a bundle produced by a feature ref and converted by main's older
+      # converter loses whatever sections that ref added, silently.
+      #
+      # The site publishes from main only (ingest.sh --push-main refuses a HEAD
+      # that is not origin/main, because it pushes HEAD:main), so a campaign run
+      # from a feature ref converts with --local instead — committed on a local
+      # run/<id> branch, nothing pushed — which still leaves the run JSON for
+      # the notification's recap. Re-ingest by hand once the ref merges.
+      #
+      # The push authenticates with BENCHMARKS_PUSH_TOKEN, a token with write
+      # access to that one repo; until the secret holds a working token this
+      # degrades to a warning. Best-effort throughout: an ingest failure must
+      # never turn a passing campaign red — the step exits 0 on every path and
+      # reports what happened through ingest_state / ingest_reason, which the
+      # notification puts on the card.
       - name: Ingest the run into the results site
         id: ingest
         if: steps.verdict.outputs.state == 'ok' && steps.runinfo.outputs.tarball_key != ''
@@ -653,13 +663,46 @@ jobs:
           TARBALL_KEY: ${{ steps.runinfo.outputs.tarball_key }}
           RESULTS_URI: ${{ steps.runinfo.outputs.results_uri }}
           PUSH_TOKEN: ${{ secrets.BENCHMARKS_PUSH_TOKEN }}
+          BENCH_REPO_REF: ${{ inputs.benchmarks_ref }}
         run: |
+          BENCH_REPO_REF="${BENCH_REPO_REF:-main}"
+          # ingested | skipped | failed, plus a one-line human reason for the
+          # Slack card. Written on every path, always before the exit.
+          emit() {
+            {
+              echo "ingest_state=$1"
+              echo "ingest_reason=$(printf '%s' "${2:-}" | tr -d '\r\n')"
+            } >> "$GITHUB_OUTPUT"
+          }
+          # Name the gate that rejected the run, from the ingest log, so the
+          # card says what broke instead of "see the run".
+          classify_failure() {
+            FAIL_LINE=""
+            if grep -q 'SMOKE SUMMARY' /tmp/ingest.log 2>/dev/null \
+               && ! grep -q 'SMOKE SUMMARY: [0-9]* passed, 0 failed' /tmp/ingest.log 2>/dev/null; then
+              FAIL_LINE=$( (grep -m1 'FAIL \[' /tmp/ingest.log | sed 's/^[[:space:]]*//') || true )
+              [ -n "$FAIL_LINE" ] || FAIL_LINE="no FAIL line in the log"
+              # Bash substring, not cut -c: GNU cut counts bytes and would
+              # split the em dash the smoke test prints.
+              echo "viewer smoke gate failed (${FAIL_LINE:0:120})"
+            elif grep -q 'make: \*\*\* \[Makefile:.*test\]' /tmp/ingest.log 2>/dev/null; then
+              echo "converter tests failed"
+            elif grep -q 'converter failed' /tmp/ingest.log 2>/dev/null; then
+              echo "converter failed"
+            elif grep -q 'already exists (run already ingested)' /tmp/ingest.log 2>/dev/null; then
+              echo "run already ingested"
+            else
+              echo "ingest.sh exited non-zero (see step log)"
+            fi
+          }
           if [ -z "$PUSH_TOKEN" ]; then
             echo "::warning::BENCHMARKS_PUSH_TOKEN is unset; run not ingested into the results site"
+            emit skipped "BENCHMARKS_PUSH_TOKEN unset"
             exit 0
           fi
           if ! aws s3 cp "s3://$BUCKET/$TARBALL_KEY" /tmp/bench-bundle.tgz; then
             echo "::warning::tarball download failed; run not ingested into the results site"
+            emit failed "tarball download failed"
             exit 0
           fi
           # Full clone: the ingest script pushes HEAD:main, which a shallow
@@ -667,27 +710,58 @@ jobs:
           # URL; the runner is ephemeral and Actions masks the secret in logs.
           if ! git clone "https://x-access-token:${PUSH_TOKEN}@github.com/stellar-experimental/stellar-rpc-benchmarks.git" /tmp/benchmarks; then
             echo "::warning::benchmarks repo clone failed; run not ingested into the results site"
+            emit failed "benchmarks clone failed (ref $BENCH_REPO_REF)"
+            exit 0
+          fi
+          # Checkout, not clone --branch: benchmarks_ref takes any ref the box
+          # takes, and --branch rejects a commit SHA. From a fresh clone
+          # `checkout main` still leaves HEAD at origin/main for --push-main,
+          # and --local branches off a detached HEAD fine.
+          if ! git -C /tmp/benchmarks checkout --quiet "$BENCH_REPO_REF"; then
+            echo "::warning::benchmarks ref $BENCH_REPO_REF not found; run not ingested into the results site"
+            emit failed "benchmarks ref $BENCH_REPO_REF not found"
             exit 0
           fi
           git -C /tmp/benchmarks config user.name "github-actions[bot]"
           git -C /tmp/benchmarks config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          MODE_FLAG=--push-main
+          if [ "$BENCH_REPO_REF" != "main" ]; then
+            MODE_FLAG=--local
+          fi
           # Campaign datasets are the synthetic apply-load packs, hence the
           # hard-coded kind — revisit if a pubnet campaign ever runs through
           # this workflow.
           if (cd /tmp/benchmarks && scripts/ingest.sh /tmp/bench-bundle.tgz \
-                --dataset-kind synthetic --push-main \
+                --dataset-kind synthetic "$MODE_FLAG" \
                 -- --source-uri "$RESULTS_URI") 2>&1 | tee /tmp/ingest.log; then
-            VIEWER=$(grep '^viewer: ' /tmp/ingest.log | tail -1 | cut -d' ' -f2)
-            echo "viewer_url=$VIEWER" >> "$GITHUB_OUTPUT"
             # The converted run JSON the ingest just committed; the notification
             # reads the per-profile ingestion p99s and the build commit from it.
-            SITE_RUN_ID="${VIEWER##*run=}"
+            # --push-main names the live run in a `viewer:` line; --local
+            # publishes nothing and prints none, so read the id off the commit
+            # subject (`runs: add <id>`) instead.
+            VIEWER=""
+            SITE_RUN_ID=""
+            if [ "$MODE_FLAG" = "--push-main" ]; then
+              VIEWER=$( (grep '^viewer: ' /tmp/ingest.log | tail -1 | cut -d' ' -f2) || true )
+              echo "viewer_url=$VIEWER" >> "$GITHUB_OUTPUT"
+              SITE_RUN_ID="${VIEWER##*run=}"
+            else
+              SITE_RUN_ID=$( (sed -n 's/^.*runs: add \(.*\)$/\1/p' /tmp/ingest.log | tail -1) || true )
+            fi
             if [ -n "$SITE_RUN_ID" ] && [ -f "/tmp/benchmarks/docs/runs/$SITE_RUN_ID.json" ]; then
               echo "run_json=/tmp/benchmarks/docs/runs/$SITE_RUN_ID.json" >> "$GITHUB_OUTPUT"
             fi
-            echo "ingested; viewer: $VIEWER"
+            if [ "$MODE_FLAG" = "--push-main" ]; then
+              emit ingested "published to the results site"
+              echo "ingested; viewer: $VIEWER"
+            else
+              echo "::warning::benchmarks_ref $BENCH_REPO_REF is not main; the run was converted on a local run/ branch but not published to the results site"
+              emit skipped "benchmarks_ref $BENCH_REPO_REF is not main — site publishes from main only; merge it, then re-ingest by hand"
+            fi
           else
-            echo "::warning::results-site ingest failed; the notification falls back to the raw results URI"
+            INGEST_REASON=$(classify_failure)
+            echo "::warning::results-site ingest failed: $INGEST_REASON; the notification falls back to the raw results URI"
+            emit failed "$INGEST_REASON"
           fi
 
       # The Block Kit payload comes from slack-payload.sh so its layout is
@@ -716,6 +790,10 @@ jobs:
           RESULTS_URI: ${{ steps.runinfo.outputs.results_uri }}
           VIEWER_URL: ${{ steps.ingest.outputs.viewer_url }}
           RUN_JSON: ${{ steps.ingest.outputs.run_json }}
+          # Empty when the ingest step was skipped by its `if:` — a failed
+          # campaign, or no tarball — i.e. the ingest was never attempted.
+          INGEST_STATE: ${{ steps.ingest.outputs.ingest_state }}
+          INGEST_REASON: ${{ steps.ingest.outputs.ingest_reason }}
           EXCERPT: ${{ steps.result.outputs.excerpt }}
           HARNESS_SHA: ${{ github.sha }}
           WEBHOOK: ${{ secrets.SLACK_BENCH_WEBHOOK_URL }}

--- a/.github/workflows/bench-campaign.yml
+++ b/.github/workflows/bench-campaign.yml
@@ -207,6 +207,8 @@ jobs:
         # that run on the box match the bytes in git. Order is:
         #   preamble exports -> bootstrap-common.sh -> run-campaign.sh.
         # BENCH_TOML_B64 is one base64 line, so it survives quoting as-is.
+        # The whole script is gzipped for launch: cloud-init gunzips user-data
+        # transparently, and the raw script outgrew EC2's 16 KB user-data cap.
         run: |
           {
             echo '#!/usr/bin/env bash'
@@ -218,10 +220,12 @@ jobs:
             cat "$PERF_EVAL_DIR/bootstrap-common.sh"
             cat "$PERF_EVAL_DIR/bench-campaign/run-campaign.sh"
           } > /tmp/user-data.sh
+          gzip -9 -c /tmp/user-data.sh > /tmp/user-data.sh.gz
           # EC2 refuses user-data above 16 KB; fail here rather than on launch.
-          SIZE=$(wc -c < /tmp/user-data.sh)
-          echo "user-data is $SIZE bytes"
-          [ "$SIZE" -le 16384 ] || { echo "::error::user-data is $SIZE bytes, over the 16384-byte EC2 limit"; exit 1; }
+          RAW=$(wc -c < /tmp/user-data.sh)
+          SIZE=$(wc -c < /tmp/user-data.sh.gz)
+          echo "user-data is $RAW bytes raw, $SIZE bytes gzipped"
+          [ "$SIZE" -le 16384 ] || { echo "::error::gzipped user-data is $SIZE bytes, over the 16384-byte EC2 limit"; exit 1; }
 
       - name: Launch EC2 instance
         id: launch
@@ -249,7 +253,7 @@ jobs:
             --image-id ami-052355af2a014bd2c \
             --instance-type "$INSTANCE_TYPE" \
             --iam-instance-profile Name=stellar-rpc-ci-load-test \
-            --user-data file:///tmp/user-data.sh \
+            --user-data fileb:///tmp/user-data.sh.gz \
             --instance-initiated-shutdown-behavior terminate \
             --block-device-mappings '[{
               "DeviceName":"/dev/sda1",

--- a/.github/workflows/bench-reaper.yml
+++ b/.github/workflows/bench-reaper.yml
@@ -1,0 +1,116 @@
+name: Bench box reaper
+# Terminates bench-campaign boxes whose deadline tag has passed. It is the
+# backstop behind bench-campaign.yml's cleanup job and the box's own
+# self-terminate ceiling: those cover a cancelled or crashed workflow and a
+# healthy box respectively, but neither covers a box whose shutdown was never
+# scheduled (e.g. user-data died before bootstrap-common.sh ran).
+# bench-campaign.yml sets the deadline tag at launch to the box's self-terminate
+# ceiling plus a margin, so it always expires after that shutdown would have
+# fired.
+
+on:
+  # Schedules only fire from the default branch, so this is inert until it lands
+  # on main; workflow_dispatch is how it gets tested before then.
+  schedule:
+    - cron: '17,47 * * * *'
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # OIDC AssumeRole into the GHA role
+  contents: read
+
+concurrency:
+  group: bench-reaper
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  reap:
+    name: Reap expired bench boxes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      AWS_REGION: us-east-1
+      PERF_EVAL_DIR: cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval
+    steps:
+      # For the Slack payload script.
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GHA_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 900
+
+      - name: Terminate boxes past their deadline
+        id: reap
+        run: |
+          NOW=$(date +%s)
+          # shellcheck disable=SC2016 # the backticks in the JMESPath query are literals, not command substitution
+          BOXES=$(aws ec2 describe-instances \
+            --filters "Name=tag:rpc-bench,Values=true" \
+                      "Name=instance-state-name,Values=pending,running" \
+            --query 'Reservations[].Instances[].{id:InstanceId,deadline:Tags[?Key==`deadline`]|[0].Value,runId:Tags[?Key==`run-id`]|[0].Value}' \
+            --output json)
+
+          # An untagged box is not this workflow's business to kill — it may be a
+          # hand-launched debugging box. Report it instead (log + the alert).
+          UNTAGGED=$(jq -r '[.[] | select(.deadline == null or .deadline == "" or (.deadline | test("^[0-9]+$") | not)) | .id] | join(" ")' <<<"$BOXES")
+          [ -z "$UNTAGGED" ] || echo "::warning::rpc-bench boxes without a usable deadline tag, left alone: $UNTAGGED"
+          echo "untagged=$UNTAGGED" >> "$GITHUB_OUTPUT"
+
+          # The alert names each box with its campaign run and how far past the
+          # deadline it was.
+          REAPED_JSON=$(jq -c --argjson now "$NOW" \
+            '[.[] | select(.deadline != null and (.deadline | test("^[0-9]+$")) and (.deadline | tonumber) < $now)
+              | {id, runId: (.runId // ""), overdueMin: ((($now - (.deadline | tonumber)) / 60) | floor)}]' \
+            <<<"$BOXES")
+          EXPIRED=$(jq -r 'map(.id) | join(" ")' <<<"$REAPED_JSON")
+          echo "reaped_json=$REAPED_JSON" >> "$GITHUB_OUTPUT"
+          if [ -z "$EXPIRED" ]; then
+            echo "no expired rpc-bench boxes"
+            echo "terminated=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "terminating past-deadline boxes: $EXPIRED"
+          # shellcheck disable=SC2086 # EXPIRED is a space-separated id list by construction
+          aws ec2 terminate-instances --instance-ids $EXPIRED >/dev/null
+          echo "terminated=$EXPIRED" >> "$GITHUB_OUTPUT"
+
+      # A reap means a campaign box outlived every in-band ceiling, which is worth
+      # a human look. The Block Kit payload comes from slack-payload.sh (shared
+      # with bench-campaign.yml). Same degrade-to-warning rule: a missing or
+      # broken webhook must not fail this job.
+      - name: Alert on reaped boxes
+        if: steps.reap.outputs.terminated != ''
+        env:
+          MODE: reaper
+          REAPED_JSON: ${{ steps.reap.outputs.reaped_json }}
+          UNTAGGED: ${{ steps.reap.outputs.untagged }}
+          WEBHOOK: ${{ secrets.SLACK_BENCH_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          # Degrade, never fail: a payload bug must not fail the reap itself.
+          if ! ./"$PERF_EVAL_DIR"/bench-campaign/slack-payload.sh > /tmp/slack.json; then
+            echo "::warning::slack-payload.sh failed; alert not delivered"
+            exit 0
+          fi
+          TEXT=$(jq -r '.attachments[0].fallback' /tmp/slack.json)
+          echo "$TEXT"
+          echo "$TEXT" >> "$GITHUB_STEP_SUMMARY"
+          if [ -z "$WEBHOOK" ]; then
+            echo "::warning::SLACK_BENCH_WEBHOOK_URL is unset; alert not delivered"
+            exit 0
+          fi
+          if curl -fsS -X POST -H 'Content-Type: application/json' \
+               --data @/tmp/slack.json "$WEBHOOK" >/dev/null; then
+            echo "slack notified"
+          else
+            echo "::warning::slack alert failed"
+          fi

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/render-campaign-toml.sh
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/render-campaign-toml.sh
@@ -100,6 +100,14 @@ fi
 if [ "$INGEST" = none ] && [ "$QUERY" = no ]; then
   die "ingest=none with query=no is an empty campaign; pick an ingest mode or set query=yes"
 fi
+# The hot query legs read the hot database the hot ingest leg leaves behind: the
+# runner wipes that dir before each rep and keeps it after the last one for
+# exactly this reason. Without a hot ingest the dir never exists, and the leg
+# fails on the box — after the toolchain install, the build and the dataset sync,
+# an hour into a paid run. Fail here instead.
+if [ "$QUERY" = yes ] && [ "$INGEST" != both ] && [ "$INGEST" != hot ]; then
+  die "query legs need a hot DB: use ingest=both or ingest=hot, got ingest=$INGEST"
+fi
 
 # A leading `-` is rejected everywhere below: these values are passed as
 # arguments to commands on the box (`git checkout "$ref"`, the runner CLI, the

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/render-campaign-toml.sh
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/render-campaign-toml.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Renders a stellar-rpc-benchmarks campaign config from the bench-campaign.yml
+# dispatch inputs, plus the launch parameters derived from it (budget, deadline,
+# instance type). bench-campaign.yml renders its campaign config through this
+# script rather than inline, so the phase matrix, the wall-clock estimate and
+# every rejection are exercisable on a laptop:
+#
+#   PHASE=1 INGEST=both QUERY=no MACHINE=2x ./render-campaign-toml.sh
+#
+# Env in: PHASE INGEST QUERY RUNS WORKERS MACHINE TARGET_REF HOT_NUM_LEDGERS
+# RUN_NAME BENCHMARKS_REF, with PUBLISH_URI / INPUTS_PREFIX / CAPACITY_MINUTES /
+# SETUP_MARGIN_MINUTES / NOW_EPOCH available as overrides for tests.
+# BENCHMARKS_REF produces no output key: it is validated here and consumed by the
+# workflow's launch job straight from the dispatch input.
+# Out: key=value lines appended to $GITHUB_OUTPUT (stdout when unset); the
+# human-readable estimate goes to stderr so it never lands in the outputs.
+#
+# Also runs on developer macOS, i.e. bash 3.2: no associative arrays, no
+# `base64 -w0`.
+set -euo pipefail
+
+die() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+# Empty string is not an integer, which is what the WORKERS default relies on.
+is_uint() {
+  case "${1:-}" in
+    '' | *[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# require_uint <name> <value> <min> <max>
+require_uint() {
+  is_uint "$2" || die "$1 must be an integer, got '$2'"
+  if [ "$2" -lt "$3" ] || [ "$2" -gt "$4" ]; then
+    die "$1 must be between $3 and $4, got '$2'"
+  fi
+}
+
+# GNU date wants -d @epoch, BSD date wants -r epoch.
+fmt_epoch() {
+  date -u -r "$1" +%FT%TZ 2>/dev/null || date -u -d "@$1" +%FT%TZ 2>/dev/null || echo "epoch $1"
+}
+
+PHASE="${PHASE:-}"
+INGEST="${INGEST:-both}"
+QUERY="${QUERY:-no}"
+RUNS="${RUNS:-1}"
+WORKERS="${WORKERS:-}"
+MACHINE="${MACHINE:-2x}"
+TARGET_REF="${TARGET_REF:-feature/full-history}"
+HOT_NUM_LEDGERS="${HOT_NUM_LEDGERS:-0}"
+RUN_NAME="${RUN_NAME:-}"
+BENCHMARKS_REF="${BENCHMARKS_REF:-main}"
+
+PUBLISH_URI="${PUBLISH_URI:-s3://stellar-rpc-bench/results}"
+INPUTS_PREFIX="${INPUTS_PREFIX:-s3://stellar-rpc-bench/inputs/synthetic-ledgers/2026-07-18-apply-load-20k}"
+# 21 h: four 5.3 h poller windows, the most the relay chain can cover.
+CAPACITY_MINUTES="${CAPACITY_MINUTES:-1260}"
+# Toolchain install, build, dataset sync, cold legs, query legs, bundle upload.
+SETUP_MARGIN_MINUTES="${SETUP_MARGIN_MINUTES:-120}"
+NOW_EPOCH="${NOW_EPOCH:-$(date +%s)}"
+
+case "$INGEST" in
+  both | cold | hot | none) ;;
+  *) die "ingest must be one of both|cold|hot|none, got '$INGEST'" ;;
+esac
+case "$QUERY" in
+  yes | no) ;;
+  *) die "query must be yes|no, got '$QUERY'" ;;
+esac
+case "$MACHINE" in
+  2x) instance_type=m6id.2xlarge; default_workers=8 ;;
+  8x) instance_type=c6id.8xlarge; default_workers=32 ;;
+  *) die "machine must be 2x|8x, got '$MACHINE'" ;;
+esac
+
+# Phase = the pacing campaign each dataset was generated for. The profile names
+# are the dataset names and the S3 directory names under INPUTS_PREFIX.
+case "$PHASE" in
+  1) close_interval=2s;    interval_ms=2000; profiles="sac-6000 custom_token-4000 soroswap-1500" ;;
+  2) close_interval=1s;    interval_ms=1000; profiles="sac-5000 custom_token-4000 soroswap-1500" ;;
+  3) close_interval=600ms; interval_ms=600;  profiles="sac-6000 custom_token-3600 soroswap-1800" ;;
+  *) die "phase must be 1|2|3, got '$PHASE'" ;;
+esac
+
+require_uint runs "$RUNS" 1 20
+# A campaign runs chunk 1 only, so a cap above the 10,000-ledger chunk is a typo.
+require_uint hot_num_ledgers "$HOT_NUM_LEDGERS" 0 10000
+if [ -n "$WORKERS" ]; then
+  require_uint workers "$WORKERS" 1 128
+  workers="$WORKERS"
+else
+  workers="$default_workers"
+fi
+
+if [ "$INGEST" = none ] && [ "$QUERY" = no ]; then
+  die "ingest=none with query=no is an empty campaign; pick an ingest mode or set query=yes"
+fi
+
+# A leading `-` is rejected everywhere below: these values are passed as
+# arguments to commands on the box (`git checkout "$ref"`, the runner CLI, the
+# instance Name tag), where a value like `-f` is read as an option instead of a
+# name and the campaign silently runs the wrong thing.
+campaign_name="${RUN_NAME:-phase${PHASE}-${MACHINE}}"
+case "$campaign_name" in
+  -*) die "run_name must not start with '-' (it is read as a command option), got '$campaign_name'" ;;
+  *[!A-Za-z0-9._-]*) die "run_name must match [A-Za-z0-9._-]+ (the runner rejects anything else), got '$campaign_name'" ;;
+esac
+# The ref is interpolated into the TOML, so keep it to git-ref characters.
+case "$TARGET_REF" in
+  -*) die "ref must not start with '-' (it is read as a command option), got '$TARGET_REF'" ;;
+  *[!A-Za-z0-9._/-]*) die "ref must match [A-Za-z0-9._/-]+, got '$TARGET_REF'" ;;
+esac
+# The benchmarks ref never reaches the TOML: it is interpolated into the box
+# user-data, which runs as root, so it is gated here rather than only quoted.
+case "$BENCHMARKS_REF" in
+  -*) die "benchmarks_ref must not start with '-' (it is read as a command option), got '$BENCHMARKS_REF'" ;;
+  *[!A-Za-z0-9._/-]*) die "benchmarks_ref must match [A-Za-z0-9._/-]+, got '$BENCHMARKS_REF'" ;;
+esac
+
+# Wall clock is dominated by the paced hot legs: one per dataset per run, each
+# replaying `ledgers` ledgers at the phase close interval. Cold and query legs
+# are unpaced and fall inside the setup margin.
+if [ "$INGEST" = hot ] || [ "$INGEST" = both ]; then
+  if [ "$HOT_NUM_LEDGERS" -gt 0 ]; then
+    ledgers="$HOT_NUM_LEDGERS"
+  else
+    ledgers=10000
+  fi
+  dataset_count=0
+  for _p in $profiles; do
+    dataset_count=$((dataset_count + 1))
+  done
+  hot_secs=$(((dataset_count * RUNS * ledgers * interval_ms + 999) / 1000))
+else
+  hot_secs=0
+fi
+budget_minutes=$(((hot_secs + 59) / 60 + SETUP_MARGIN_MINUTES))
+
+if [ "$budget_minutes" -gt "$CAPACITY_MINUTES" ]; then
+  die "estimated budget ${budget_minutes}m exceeds the ${CAPACITY_MINUTES}m relay-chain ceiling;" \
+    "shrink runs (${RUNS}), cap hot_num_ledgers (${HOT_NUM_LEDGERS}), or split the phase into separate dispatches"
+fi
+
+deadline_epoch=$((NOW_EPOCH + budget_minutes * 60))
+# The box outlives the relay chain so a stuck run still uploads its log.
+self_terminate_minutes=$((budget_minutes + 30))
+
+query_bool=false
+[ "$QUERY" = yes ] && query_bool=true
+
+toml_file="$(mktemp "${TMPDIR:-/tmp}/campaign-XXXXXX")"
+{
+  printf 'name = "%s"\n' "$campaign_name"
+  printf 'ref = "%s"\n' "$TARGET_REF"
+  printf 'ingest = "%s"\n' "$INGEST"
+  printf 'query = %s\n' "$query_bool"
+  printf 'close_interval = "%s"\n' "$close_interval"
+  printf 'runs = %s\n' "$RUNS"
+  printf 'workers = %s\n' "$workers"
+  printf 'hot_num_ledgers = %s\n' "$HOT_NUM_LEDGERS"
+  printf 'publish_uri = "%s"\n' "$PUBLISH_URI"
+  for profile in $profiles; do
+    printf '\n[[dataset]]\n'
+    printf 'name = "%s"\n' "$profile"
+    printf 'kind = "packs-s3"\n'
+    printf 'location = "%s/%s/packs/cold"\n' "$INPUTS_PREFIX" "$profile"
+    printf 'chunks = [1]\n'
+  done
+} > "$toml_file"
+
+{
+  echo "toml_b64=$(base64 < "$toml_file" | tr -d '\n')"
+  echo "budget_minutes=$budget_minutes"
+  echo "deadline_epoch=$deadline_epoch"
+  echo "instance_type=$instance_type"
+  echo "workers=$workers"
+  echo "self_terminate_minutes=$self_terminate_minutes"
+  echo "campaign_name=$campaign_name"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"
+
+{
+  echo "campaign $campaign_name: phase $PHASE (close_interval $close_interval), ingest=$INGEST query=$QUERY"
+  echo "datasets: $profiles"
+  echo "machine $MACHINE = $instance_type, workers $workers, runs $RUNS, hot_num_ledgers $HOT_NUM_LEDGERS"
+  echo "paced hot legs ~$((hot_secs / 60))m; budget ${budget_minutes}m of ${CAPACITY_MINUTES}m capacity"
+  echo "deadline $(fmt_epoch "$deadline_epoch"); box self-terminates after ${self_terminate_minutes}m"
+  echo "rendered config: $toml_file"
+} >&2

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/render-campaign-toml.sh
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/render-campaign-toml.sh
@@ -215,7 +215,7 @@ toml_file="$(mktemp "${TMPDIR:-/tmp}/campaign-XXXXXX")"
     printf '\n[[dataset]]\n'
     printf 'name = "%s"\n' "$profile"
     printf 'kind = "packs-s3"\n'
-    printf 'location = "%s/%s/packs/cold"\n' "$INPUTS_PREFIX" "$profile"
+    printf 'location = "%s/%s/packs-v2/cold"\n' "$INPUTS_PREFIX" "$profile"
     printf 'chunks = [1]\n'
   done
 } > "$toml_file"

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/render-campaign-toml.sh
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/render-campaign-toml.sh
@@ -9,7 +9,8 @@
 #
 # Env in: PHASE INGEST QUERY RUNS WORKERS MACHINE TARGET_REF HOT_NUM_LEDGERS
 # RUN_NAME BENCHMARKS_REF, with PUBLISH_URI / INPUTS_PREFIX / CAPACITY_MINUTES /
-# SETUP_MARGIN_MINUTES / NOW_EPOCH available as overrides for tests.
+# SETUP_MARGIN_MINUTES / QUERY_LEG_DURATION_SECONDS / NOW_EPOCH available as
+# overrides for tests.
 # BENCHMARKS_REF produces no output key: it is validated here and consumed by the
 # workflow's launch job straight from the dispatch input.
 # Out: key=value lines appended to $GITHUB_OUTPUT (stdout when unset); the
@@ -60,9 +61,29 @@ PUBLISH_URI="${PUBLISH_URI:-s3://stellar-rpc-bench/results}"
 INPUTS_PREFIX="${INPUTS_PREFIX:-s3://stellar-rpc-bench/inputs/synthetic-ledgers/2026-07-18-apply-load-20k}"
 # 21 h: four 5.3 h poller windows, the most the relay chain can cover.
 CAPACITY_MINUTES="${CAPACITY_MINUTES:-1260}"
-# Toolchain install, build, dataset sync, cold legs, query legs, bundle upload.
+# Toolchain install, build, dataset sync, cold ingest legs, bundle upload.
 SETUP_MARGIN_MINUTES="${SETUP_MARGIN_MINUTES:-120}"
 NOW_EPOCH="${NOW_EPOCH:-$(date +%s)}"
+
+# How long one bench-query leg holds each rate of its ladder. The runner's
+# default is 60s (DefaultQueryDuration in runner/internal/config/config.go) and
+# the rendered TOML cannot set query_duration, because the runner rejects TOML
+# keys it does not know. The override exists so the estimate can follow the
+# runner's default if that default moves.
+QUERY_LEG_DURATION_SECONDS="${QUERY_LEG_DURATION_SECONDS:-60}"
+# The query grid the runner builds (runner/internal/plan/plan.go): one leg per
+# dataset, per run, per tier (cold and hot), per query type, and the four types
+# are ledgers, txpage, txhash and events.
+query_tiers=2
+query_type_count=4
+# Every leg sweeps the ladder in the benchmarks repo's docs/targets.json, which
+# holds three multipliers (0.5x, 1x, 2x of the phase floor), and it holds each
+# one for QUERY_LEG_DURATION_SECONDS.
+query_rate_steps=3
+# Time a leg spends outside its paced windows: building the query corpus,
+# dropping the page cache for a cold leg, and the warmup. A minute per leg
+# covers that on both box sizes.
+query_leg_overhead_secs=60
 
 case "$INGEST" in
   both | cold | hot | none) ;;
@@ -88,6 +109,7 @@ case "$PHASE" in
 esac
 
 require_uint runs "$RUNS" 1 20
+require_uint query_leg_duration_seconds "$QUERY_LEG_DURATION_SECONDS" 1 3600
 # A campaign runs chunk 1 only, so a cap above the 10,000-ledger chunk is a typo.
 require_uint hot_num_ledgers "$HOT_NUM_LEDGERS" 0 10000
 if [ -n "$WORKERS" ]; then
@@ -132,28 +154,43 @@ case "$BENCHMARKS_REF" in
   *[!A-Za-z0-9._/-]*) die "benchmarks_ref must match [A-Za-z0-9._/-]+, got '$BENCHMARKS_REF'" ;;
 esac
 
-# Wall clock is dominated by the paced hot legs: one per dataset per run, each
-# replaying `ledgers` ledgers at the phase close interval. Cold and query legs
-# are unpaced and fall inside the setup margin.
+# Two parts of the campaign run at a rate the campaign chooses, so their wall
+# clock is known here. The hot ingest legs replay `ledgers` ledgers at the phase
+# close interval, one leg per dataset per run. The query legs each hold a fixed
+# arrival rate for a fixed duration, once per rate on the ladder. The cold
+# ingest legs run as fast as the box allows, so they stay in the setup margin
+# together with the toolchain install, the build and the dataset sync.
+dataset_count=0
+for _p in $profiles; do
+  dataset_count=$((dataset_count + 1))
+done
+
 if [ "$INGEST" = hot ] || [ "$INGEST" = both ]; then
   if [ "$HOT_NUM_LEDGERS" -gt 0 ]; then
     ledgers="$HOT_NUM_LEDGERS"
   else
     ledgers=10000
   fi
-  dataset_count=0
-  for _p in $profiles; do
-    dataset_count=$((dataset_count + 1))
-  done
   hot_secs=$(((dataset_count * RUNS * ledgers * interval_ms + 999) / 1000))
 else
   hot_secs=0
 fi
-budget_minutes=$(((hot_secs + 59) / 60 + SETUP_MARGIN_MINUTES))
+
+if [ "$QUERY" = yes ]; then
+  query_legs=$((dataset_count * RUNS * query_tiers * query_type_count))
+  query_secs=$((query_legs * (query_rate_steps * QUERY_LEG_DURATION_SECONDS + query_leg_overhead_secs)))
+else
+  query_legs=0
+  query_secs=0
+fi
+budget_minutes=$(((hot_secs + query_secs + 59) / 60 + SETUP_MARGIN_MINUTES))
 
 if [ "$budget_minutes" -gt "$CAPACITY_MINUTES" ]; then
-  die "estimated budget ${budget_minutes}m exceeds the ${CAPACITY_MINUTES}m relay-chain ceiling;" \
-    "shrink runs (${RUNS}), cap hot_num_ledgers (${HOT_NUM_LEDGERS}), or split the phase into separate dispatches"
+  hint="shrink runs (${RUNS}), cap hot_num_ledgers (${HOT_NUM_LEDGERS}), or split the phase into separate dispatches"
+  if [ "$QUERY" = yes ]; then
+    hint="$hint; the ${query_legs} query legs (${query_rate_steps} rates of ${QUERY_LEG_DURATION_SECONDS}s each) cost ~$((query_secs / 60))m of it, so query=no is the other lever"
+  fi
+  die "estimated budget ${budget_minutes}m exceeds the ${CAPACITY_MINUTES}m relay-chain ceiling;" "$hint"
 fi
 
 deadline_epoch=$((NOW_EPOCH + budget_minutes * 60))
@@ -197,7 +234,7 @@ toml_file="$(mktemp "${TMPDIR:-/tmp}/campaign-XXXXXX")"
   echo "campaign $campaign_name: phase $PHASE (close_interval $close_interval), ingest=$INGEST query=$QUERY"
   echo "datasets: $profiles"
   echo "machine $MACHINE = $instance_type, workers $workers, runs $RUNS, hot_num_ledgers $HOT_NUM_LEDGERS"
-  echo "paced hot legs ~$((hot_secs / 60))m; budget ${budget_minutes}m of ${CAPACITY_MINUTES}m capacity"
+  echo "paced hot legs ~$((hot_secs / 60))m; ${query_legs} query legs ~$((query_secs / 60))m; budget ${budget_minutes}m of ${CAPACITY_MINUTES}m capacity"
   echo "deadline $(fmt_epoch "$deadline_epoch"); box self-terminates after ${self_terminate_minutes}m"
   echo "rendered config: $toml_file"
 } >&2

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/render-campaign-toml.sh
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/render-campaign-toml.sh
@@ -100,13 +100,15 @@ fi
 if [ "$INGEST" = none ] && [ "$QUERY" = no ]; then
   die "ingest=none with query=no is an empty campaign; pick an ingest mode or set query=yes"
 fi
-# The hot query legs read the hot database the hot ingest leg leaves behind: the
-# runner wipes that dir before each rep and keeps it after the last one for
-# exactly this reason. Without a hot ingest the dir never exists, and the leg
-# fails on the box — after the toolchain install, the build and the dataset sync,
-# an hour into a paid run. Fail here instead.
-if [ "$QUERY" = yes ] && [ "$INGEST" != both ] && [ "$INGEST" != hot ]; then
-  die "query legs need a hot DB: use ingest=both or ingest=hot, got ingest=$INGEST"
+# Both query suites read a database this campaign builds: the hot legs read the
+# hot DB the hot ingest leaves behind, and the cold legs read the cold store the
+# cold ingest builds (the golden dataset's banked cold tree is not read — it was
+# frozen by an older binary, and #932 changed the cold-index format under it).
+# Without both ingests a query leg fails on the box — after the toolchain
+# install, the build and the dataset sync, an hour into a paid run. Fail here
+# instead.
+if [ "$QUERY" = yes ] && [ "$INGEST" != both ]; then
+  die "query=yes needs both databases: use ingest=both (cold legs read the cold ingest's store, hot legs the hot ingest's DB), got ingest=$INGEST"
 fi
 
 # A leading `-` is rejected everywhere below: these values are passed as

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/run-campaign.sh
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/run-campaign.sh
@@ -59,6 +59,62 @@ export CGO_CFLAGS="-I$HOME/.zstd/include -I$HOME/.rocksdb/include"
 export CGO_LDFLAGS="-L$HOME/.zstd/lib -L$HOME/.rocksdb/lib"
 export LD_LIBRARY_PATH="$HOME/.zstd/lib:$HOME/.rocksdb/lib"
 
+# upload_bundle copies a results tarball and a run-info.json sidecar to the run's
+# own prefix in S3, next to the result object. The verdict object carries only
+# markdown, so the notify job reads the sidecar for the bundle's run id and
+# destination as data, and it ingests the tarball into the results site from this
+# bucket because its role can read this bucket but not the results bucket.
+#
+# Every step is best-effort: a failed upload must not change the campaign's
+# verdict, so each command is either an `if` condition or is followed by `|| log`
+# and so cannot reach the ERR trap. The notify job falls back to the result key
+# when the sidecar is missing, and skips the site ingest when tarballKey is empty.
+#
+# It sets TARBALL_KEY to the key it wrote, or to an empty string when no tarball
+# reached S3, for the caller's verdict markdown.
+#
+# usage: upload_bundle <tarball> <bench_run_id> <results_uri>
+upload_bundle() {
+  local tarball="$1" bench_run_id="$2" results_uri="$3"
+  TARBALL_KEY=""
+  if [ -z "$BUCKET" ] || [ -z "$RESULT_KEY" ]; then
+    log "WARN: BUCKET/RESULT_KEY unset; skipping the tarball and run-info.json"
+    return 0
+  fi
+  local prefix="${RESULT_KEY%/*}"
+  TARBALL_KEY="$prefix/$(basename "$tarball")"
+  if ! aws s3api put-object --bucket "$BUCKET" --key "$TARBALL_KEY" \
+         --content-type application/gzip --body "$tarball" >/dev/null; then
+    log "WARN: tarball upload failed; notify skips the results-site ingest"
+    TARBALL_KEY=""
+  fi
+  if ! jq -n --arg run "$RUN_ID" --arg bench "$bench_run_id" \
+        --arg uri "$results_uri" --arg tar "$tarball" --arg tarkey "$TARBALL_KEY" \
+        '{schemaVersion: 1, runId: $run, benchRunId: $bench, resultsUri: $uri, tarball: $tar, tarballKey: $tarkey}' \
+        > /tmp/run-info.json; then
+    log "WARN: could not write run-info.json; notify falls back to the result key"
+    return 0
+  fi
+  aws s3api put-object --bucket "$BUCKET" --key "$prefix/run-info.json" \
+        --content-type application/json --body /tmp/run-info.json >/dev/null \
+    || log "WARN: run-info.json upload failed; notify falls back to the result key"
+}
+
+# newest_bundle_tarball prints the path of the most recently modified
+# /tmp/bench-results-*.tgz, or nothing when the runner produced none. The runner
+# names one tarball per campaign run id, and a resumed or retried campaign on the
+# same box can leave more than one behind.
+newest_bundle_tarball() {
+  local newest="" candidate
+  for candidate in /tmp/bench-results-*.tgz; do
+    [ -f "$candidate" ] || continue
+    if [ -z "$newest" ] || [ "$candidate" -nt "$newest" ]; then
+      newest="$candidate"
+    fi
+  done
+  printf '%s' "$newest"
+}
+
 # The runner keeps its own campaign.log inside the bundle; this tee is for the
 # lines this fragment parses (`published:`) and the tail it puts in a failure
 # comment. pipefail is active so the `if` sees the runner's exit code, and the
@@ -79,30 +135,9 @@ if (cd /root/stellar-rpc-benchmarks/runner \
   TARBALL="/tmp/bench-results-${BENCH_RUN_ID}.tgz"
   log "published bundle $BENCH_RUN_ID to $RESULTS_URI"
 
-  # Sidecar for the notify job: the verdict object carries only markdown, and the
-  # workflow needs the run id and destination as data. The tarball rides along to
-  # the run's own prefix because the notify job's role can read this bucket but
-  # not the results bucket — it is what the job ingests into the results site.
-  # All best-effort: the notify job already falls back to the result key, so a
-  # failed upload must not turn a passed campaign into a fail verdict via the
-  # ERR trap; a missing tarballKey just skips the site ingest.
-  if [ -n "$BUCKET" ] && [ -n "$RESULT_KEY" ]; then
-    TARBALL_KEY="${RESULT_KEY%/*}/$(basename "$TARBALL")"
-    if ! aws s3api put-object --bucket "$BUCKET" --key "$TARBALL_KEY" \
-           --content-type application/gzip --body "$TARBALL" >/dev/null; then
-      log "WARN: tarball upload failed; notify skips the results-site ingest"
-      TARBALL_KEY=""
-    fi
-    jq -n --arg run "$RUN_ID" --arg bench "$BENCH_RUN_ID" \
-          --arg uri "$RESULTS_URI" --arg tar "$TARBALL" --arg tarkey "$TARBALL_KEY" \
-          '{schemaVersion: 1, runId: $run, benchRunId: $bench, resultsUri: $uri, tarball: $tar, tarballKey: $tarkey}' \
-          > /tmp/run-info.json
-    aws s3api put-object --bucket "$BUCKET" --key "${RESULT_KEY%/*}/run-info.json" \
-          --content-type application/json --body /tmp/run-info.json >/dev/null \
-      || log "WARN: run-info.json upload failed; notify falls back to the result key"
-  else
-    log "WARN: BUCKET/RESULT_KEY unset; skipping run-info.json"
-  fi
+  # The complete bundle and its sidecar, for the notify job to ingest into the
+  # results site.
+  upload_bundle "$TARBALL" "$BENCH_RUN_ID" "$RESULTS_URI"
 
   # shellcheck disable=SC2016  # the backticks below are markdown code spans, not shell expansion
   {
@@ -124,15 +159,42 @@ if (cd /root/stellar-rpc-benchmarks/runner \
   poweroff
 
 else
-  # Non-zero: a leg failed, the tarball failed, or the publish failed. The bundle
-  # itself is still complete (the runner's epilogue always runs), so name where it
-  # is rather than only that it broke.
+  # Non-zero: a leg failed, the tarball failed, or the publish failed. The
+  # runner's epilogue runs after a failed leg — it writes the bundle's metadata,
+  # tars /mnt/nvme/bench/results/<run id> into /tmp/bench-results-<run id>.tgz,
+  # and publishes it when the campaign config names a publish URI — so a bundle
+  # holding every leg that did finish usually exists here.
+  #
+  # Upload it before the verdict: the box self-terminates at its ceiling, and
+  # without this the good legs die with it and only an SSM rescue can recover
+  # them. A campaign that failed before the tarball step leaves no tarball, and
+  # a campaign whose publish step failed leaves no `published:` line, so both
+  # are treated as missing rather than as errors.
+  TARBALL=$(newest_bundle_tarball)
+  TARBALL_KEY=""
+  if [ -n "$TARBALL" ]; then
+    BENCH_RUN_ID=$(basename "$TARBALL" .tgz)
+    BENCH_RUN_ID="${BENCH_RUN_ID#bench-results-}"
+    PUBLISHED_LINE=$(grep '^published: ' /tmp/campaign-console.log | tail -1 || true)
+    RESULTS_URI="${PUBLISHED_LINE#published: }"
+    RESULTS_URI="${RESULTS_URI%/}"
+    log "uploading the bundle a failed campaign left behind: $BENCH_RUN_ID"
+    upload_bundle "$TARBALL" "$BENCH_RUN_ID" "$RESULTS_URI"
+  else
+    log "WARN: no /tmp/bench-results-*.tgz on the box; there is no bundle to upload"
+  fi
+
   # shellcheck disable=SC2016  # the backticks below are markdown code spans, not shell expansion
   {
     printf '❌ **%s failed** (run `%s`)\n\n' "$LEG_TITLE" "$RUN_ID"
     printf 'Last 60 lines of the campaign console:\n\n```\n'
     tail -n 60 /tmp/campaign-console.log
     printf '```\n\n'
+    if [ -n "$TARBALL_KEY" ]; then
+      printf 'Uploaded bundle: `s3://%s/%s`, holding the legs that finished before the failure.\n' "$BUCKET" "$TARBALL_KEY"
+    else
+      printf 'No bundle uploaded: an SSM rescue is the only way to reach the results.\n'
+    fi
     printf 'Rescue: the bundle is under `/mnt/nvme/bench/results/`, the tarball at `/tmp/bench-results-*.tgz`.\n'
     printf 'The box is left running until its self-terminate ceiling (%s minutes after boot), so an operator can SSM in.\n' "$SELF_TERMINATE_MINUTES"
   } > "$RESULTS_FILE"

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/run-campaign.sh
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/run-campaign.sh
@@ -1,0 +1,147 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2154  # env + helpers (log, bail, upload_result, upload_box_log,
+# RUN_ID, BUCKET, RESULT_KEY, RESULTS_FILE, ...) come from bootstrap-common.sh, which
+# the workflow concatenates ABOVE this fragment.
+#
+# Bench-campaign leg. Concatenated after bootstrap-common.sh in the rendered EC2
+# user-data, so it inherits that file's env, helpers, and the already-active
+# `set -euo pipefail` + ERR-trap-that-bails. Runs as root.
+#
+# It hands the whole campaign to the benchmarks repo's campaign CLI: this box
+# clones stellar-rpc-benchmarks, lets its runner/bootstrap.sh provision the
+# machine, and runs `campaign run` against the TOML the workflow rendered. The
+# runner owns the legs, the bundle, the tarball, and the publish; this fragment
+# only translates its exit code into the verdict object the poller reads.
+LEG_TITLE="Bench campaign"
+
+[ -n "${BENCH_TOML_B64:-}" ] || bail "BENCH_TOML_B64 unset; the workflow must render the campaign TOML into the user-data preamble"
+BENCH_REPO_REF="${BENCH_REPO_REF:-main}"
+
+# runner/bootstrap.sh uses sudo, $USER, and $HOME under `set -u`, and cloud-init
+# user-data has none of them: root's shell here is not a login shell.
+export HOME=/root USER=root
+
+# bootstrap-common only installs awscli/jq/curl, and the benchmarks clone needs
+# git. We deliberately do NOT call bootstrap_box: this box never builds
+# stellar-rpc itself — the campaign CLI clones and builds it from the ref in the
+# TOML, into its own build clone under $BENCH_ROOT/src.
+log "installing git (for the benchmarks clone)"
+apt-get install -y -qq --no-install-recommends git
+
+# The basename lands verbatim in the bundle (the runner copies the config it was
+# given), so keep it descriptive.
+log "decoding campaign config"
+printf '%s' "$BENCH_TOML_B64" | base64 -d > /root/bench-campaign.toml
+log "campaign config:"
+cat /root/bench-campaign.toml
+
+# Full clone, not shallow: BENCH_REPO_REF may be a SHA.
+log "cloning stellar-rpc-benchmarks at $BENCH_REPO_REF"
+rm -rf /root/stellar-rpc-benchmarks
+git clone https://github.com/stellar-experimental/stellar-rpc-benchmarks.git /root/stellar-rpc-benchmarks
+git -C /root/stellar-rpc-benchmarks checkout "$BENCH_REPO_REF"
+
+# The benchmarks bootstrap is authoritative for this machine: NVMe discovery and
+# mount, the fsync-honesty probe (it exits non-zero on absorbed fsync rather than
+# letting the box produce fiction), the AWS CLI, the pinned Go/Rust, and the
+# native libs. A non-zero exit hits our still-active ERR trap -> bail -> fail
+# verdict, which is what we want: none of those failures are recoverable here.
+# SRC_REF points its native-lib install scripts (and their version pins) at the
+# ref this campaign benchmarks, taken from the TOML the workflow rendered.
+SRC_REF=$(sed -n 's/^ref = "\(.*\)"$/\1/p' /root/bench-campaign.toml | head -1)
+log "running runner/bootstrap.sh (SRC_REF=${SRC_REF:-unset})"
+SRC_REF="$SRC_REF" bash /root/stellar-rpc-benchmarks/runner/bootstrap.sh
+
+# bootstrap.sh appends these to .bashrc for future shells; this shell is not one,
+# so mirror them exactly as it writes them.
+export PATH=/usr/local/go/bin:$HOME/go/bin:$HOME/.cargo/bin:$PATH
+export CGO_CFLAGS="-I$HOME/.zstd/include -I$HOME/.rocksdb/include"
+export CGO_LDFLAGS="-L$HOME/.zstd/lib -L$HOME/.rocksdb/lib"
+export LD_LIBRARY_PATH="$HOME/.zstd/lib:$HOME/.rocksdb/lib"
+
+# The runner keeps its own campaign.log inside the bundle; this tee is for the
+# lines this fragment parses (`published:`) and the tail it puts in a failure
+# comment. pipefail is active so the `if` sees the runner's exit code, and the
+# `if` keeps the ERR trap off a failed campaign — the failure path below is more
+# useful than bail's.
+log "running campaign"
+if (cd /root/stellar-rpc-benchmarks/runner \
+    && BENCH_ROOT=/mnt/nvme/bench go run ./cmd/campaign run /root/bench-campaign.toml) \
+    2>&1 | tee /tmp/campaign-console.log; then
+
+  # Exit 0 means every leg, the tarball, and the publish all succeeded, so the
+  # runner printed `published: <dest>`. A missing line is defensive only.
+  PUBLISHED_LINE=$(grep '^published: ' /tmp/campaign-console.log | tail -1 || true)
+  [ -n "$PUBLISHED_LINE" ] || bail "campaign exited 0 but printed no 'published:' line; cannot locate the published bundle"
+  RESULTS_URI="${PUBLISHED_LINE#published: }"
+  RESULTS_URI="${RESULTS_URI%/}"
+  BENCH_RUN_ID="${RESULTS_URI##*/}"
+  TARBALL="/tmp/bench-results-${BENCH_RUN_ID}.tgz"
+  log "published bundle $BENCH_RUN_ID to $RESULTS_URI"
+
+  # Sidecar for the notify job: the verdict object carries only markdown, and the
+  # workflow needs the run id and destination as data. The tarball rides along to
+  # the run's own prefix because the notify job's role can read this bucket but
+  # not the results bucket — it is what the job ingests into the results site.
+  # All best-effort: the notify job already falls back to the result key, so a
+  # failed upload must not turn a passed campaign into a fail verdict via the
+  # ERR trap; a missing tarballKey just skips the site ingest.
+  if [ -n "$BUCKET" ] && [ -n "$RESULT_KEY" ]; then
+    TARBALL_KEY="${RESULT_KEY%/*}/$(basename "$TARBALL")"
+    if ! aws s3api put-object --bucket "$BUCKET" --key "$TARBALL_KEY" \
+           --content-type application/gzip --body "$TARBALL" >/dev/null; then
+      log "WARN: tarball upload failed; notify skips the results-site ingest"
+      TARBALL_KEY=""
+    fi
+    jq -n --arg run "$RUN_ID" --arg bench "$BENCH_RUN_ID" \
+          --arg uri "$RESULTS_URI" --arg tar "$TARBALL" --arg tarkey "$TARBALL_KEY" \
+          '{schemaVersion: 1, runId: $run, benchRunId: $bench, resultsUri: $uri, tarball: $tar, tarballKey: $tarkey}' \
+          > /tmp/run-info.json
+    aws s3api put-object --bucket "$BUCKET" --key "${RESULT_KEY%/*}/run-info.json" \
+          --content-type application/json --body /tmp/run-info.json >/dev/null \
+      || log "WARN: run-info.json upload failed; notify falls back to the result key"
+  else
+    log "WARN: BUCKET/RESULT_KEY unset; skipping run-info.json"
+  fi
+
+  # shellcheck disable=SC2016  # the backticks below are markdown code spans, not shell expansion
+  {
+    printf '✅ **%s passed** (run `%s`)\n\n' "$LEG_TITLE" "$RUN_ID"
+    printf -- '- bench run id: `%s`\n' "$BENCH_RUN_ID"
+    printf -- '- results: `%s`\n' "$RESULTS_URI"
+    printf -- '- tarball on the box: `%s`\n' "$TARBALL"
+    printf -- '- benchmarks ref: `%s`\n' "$BENCH_REPO_REF"
+    printf -- '- campaign config: `%s`\n' /root/bench-campaign.toml
+  } > "$RESULTS_FILE"
+  upload_result ok "$RESULTS_FILE"
+
+  # The EXIT trap would do this, but poweroff can outrun a normal script exit, so
+  # push the box log first. shutdown-behavior=terminate turns this poweroff into
+  # a terminate, which is how a passing campaign releases the instance without
+  # waiting for the GHA runner (the poll chain may still be between windows).
+  upload_box_log
+  log "campaign complete: $BENCH_RUN_ID — powering off (terminates the instance)"
+  poweroff
+
+else
+  # Non-zero: a leg failed, the tarball failed, or the publish failed. The bundle
+  # itself is still complete (the runner's epilogue always runs), so name where it
+  # is rather than only that it broke.
+  # shellcheck disable=SC2016  # the backticks below are markdown code spans, not shell expansion
+  {
+    printf '❌ **%s failed** (run `%s`)\n\n' "$LEG_TITLE" "$RUN_ID"
+    printf 'Last 60 lines of the campaign console:\n\n```\n'
+    tail -n 60 /tmp/campaign-console.log
+    printf '```\n\n'
+    printf 'Rescue: the bundle is under `/mnt/nvme/bench/results/`, the tarball at `/tmp/bench-results-*.tgz`.\n'
+    printf 'The box is left running until its self-terminate ceiling (%s minutes after boot), so an operator can SSM in.\n' "$SELF_TERMINATE_MINUTES"
+  } > "$RESULTS_FILE"
+  upload_result fail "$RESULTS_FILE"
+
+  # Deliberately no poweroff. On a publish failure the results exist only on this
+  # box, and the NVMe bundle dies with it, so the box is left to the
+  # self-terminate ceiling (plus the reaper) instead of being released here. The
+  # tradeoff is instance-hours for a rescuable bundle.
+  log "campaign failed; leaving the box up for rescue until the self-terminate ceiling"
+  exit 1
+fi

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/slack-payload.sh
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/slack-payload.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# Builds the Slack webhook payload (Block Kit) for the bench-campaign and
+# bench-reaper notifications. The workflows call this instead of templating the
+# payload inline so the whole message layout is renderable on a laptop:
+#
+#   MODE=campaign STATE=ok CAMPAIGN_NAME=phase3-c6id8xl PHASE=3 ... \
+#       ./slack-payload.sh | jq .
+#
+# Env in, MODE=campaign:
+#   STATE (ok|fail), REASON, CAMPAIGN_NAME, PHASE, INGEST, QUERY, RUNS, WORKERS,
+#   INSTANCE_TYPE, HOT_NUM_LEDGERS, BUDGET_MINUTES, ELAPSED_MINUTES,
+#   DEADLINE_EPOCH, TARGET_REF, TARGET_SHA, BENCH_RUN_ID, VIEWER_URL,
+#   RESULTS_URI, RUN_URL, RUN_JSON (path to the converted results-site run JSON,
+#   for the ingestion-vs-target recap), EXCERPT (verdict-markdown lines, fail),
+#   BOX_ID, BOX_RESCUED (true when the box is left up), RUN_ID_TAG, BUCKET,
+#   RESULT_KEY, AWS_REGION, HARNESS_SHA, REPO_URL.
+# Env in, MODE=reaper:
+#   REAPED_JSON ('[{"id":"i-..","runId":"123..","overdueMin":42}, ...]'),
+#   UNTAGGED (space-separated instance ids), RUN_URL, REPO_URL.
+# Out: the payload JSON on stdout — {attachments: [{color, fallback, blocks}]}.
+# One status-colored attachment (the full-height stripe), with the one-line
+# summary in its fallback: Slack uses that for the notification preview and
+# old clients without rendering it (a top-level text field would display above
+# the card). Slack folds a tall attachment behind "Show more", so the blocks
+# are ordered important-first — header, lead, key metadata, BUTTONS, recap —
+# and only the secondary fields and the context footer risk the fold.
+#
+# Also runs on developer macOS, i.e. bash 3.2 + BSD date.
+set -euo pipefail
+
+MODE="${MODE:-campaign}"
+REPO_URL="${REPO_URL:-https://github.com/stellar/stellar-rpc}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+
+# 252 -> "4 h 12 m"; 420 -> "7 h"; 45 -> "45 m"; junk -> "".
+fmt_minutes() {
+  case "${1:-}" in '' | *[!0-9]*) echo ""; return ;; esac
+  if [ "$1" -ge 60 ] && [ "$(($1 % 60))" -eq 0 ]; then
+    echo "$(($1 / 60)) h"
+  elif [ "$1" -ge 60 ]; then
+    echo "$(($1 / 60)) h $(($1 % 60)) m"
+  else
+    echo "$1 m"
+  fi
+}
+
+# GNU date wants -d @epoch, BSD date wants -r epoch.
+fmt_epoch_hm() {
+  case "${1:-}" in '' | *[!0-9]*) echo ""; return ;; esac
+  date -u -r "$1" +%H:%M 2>/dev/null || date -u -d "@$1" +%H:%M 2>/dev/null || echo ""
+}
+
+# The S3 console object view for bucket $1, key $2 — an https link Slack can
+# open, unlike a raw s3:// URI.
+s3_object_url() {
+  [ -n "$1" ] && [ -n "$2" ] || { echo ""; return; }
+  echo "https://${AWS_REGION}.console.aws.amazon.com/s3/object/$1?region=${AWS_REGION}&prefix=$2"
+}
+
+# The S3 console browse view for an s3://bucket/prefix URI.
+s3_prefix_url() {
+  case "${1:-}" in s3://*) ;; *) echo ""; return ;; esac
+  local rest="${1#s3://}"
+  local bucket="${rest%%/*}"
+  local prefix="${rest#*/}"
+  [ "$prefix" != "$rest" ] || prefix=""
+  echo "https://${AWS_REGION}.console.aws.amazon.com/s3/buckets/${bucket}?region=${AWS_REGION}&prefix=${prefix}/"
+}
+
+if [ "$MODE" = "reaper" ]; then
+  REAPED_JSON="${REAPED_JSON:-[]}"
+  UNTAGGED="${UNTAGGED:-}"
+  jq -n \
+    --argjson reaped "$REAPED_JSON" \
+    --arg untagged "$UNTAGGED" \
+    --arg run_url "${RUN_URL:-}" \
+    --arg repo "$REPO_URL" \
+    '
+    def button($t; $u): {type: "button", text: {type: "plain_text", text: $t, emoji: true}, url: $u};
+    ($reaped | length) as $n
+    | ($untagged | split(" ") | map(select(. != ""))) as $loose
+    | {
+        attachments: [{
+          color: "#ecb22e",
+          fallback: "⚠️ bench reaper terminated past-deadline box(es): \($reaped | map(.id) | join(" ")) · \($run_url)",
+          blocks: (
+            [{type: "header", text: {type: "plain_text",
+              text: "⚠️ Reaper terminated \($n) past-deadline box\(if $n == 1 then "" else "es" end)", emoji: true}}]
+            + [{type: "section", text: {type: "mrkdwn", text: (
+                ( $reaped | map(
+                    (if .overdueMin >= 90 then "\((.overdueMin / 6 | round) / 10) h" else "\(.overdueMin) min" end) as $late
+                    | (if (.runId // "") != "" then "campaign run <\($repo)/actions/runs/\(.runId)|\(.runId)>" else "campaign run unknown" end) as $src
+                    | "• `\(.id)` — \($src), deadline passed *\($late)* ago"
+                  ) )
+                + ( $loose | map("• `\(.)` has no deadline tag — left alone (hand-launched?)") )
+                | join("\n")
+              )}}]
+            + (if $run_url != "" then
+                [{type: "actions", elements: [button("Reaper run"; $run_url)]}] else [] end)
+            + [{type: "context", elements: [{type: "mrkdwn",
+                text: "A reap means a campaign box outlived every in-band ceiling — worth a human look."}]}]
+          )
+        }]
+      }
+    '
+  exit 0
+fi
+
+[ "$MODE" = "campaign" ] || { echo "MODE must be campaign or reaper, got '$MODE'" >&2; exit 1; }
+STATE="${STATE:-}"
+[ "$STATE" = "ok" ] || [ "$STATE" = "fail" ] || { echo "STATE must be ok or fail, got '$STATE'" >&2; exit 1; }
+
+CAMPAIGN_NAME="${CAMPAIGN_NAME:-<unnamed>}"
+REASON="${REASON:-}"
+PHASE="${PHASE:-}"
+INGEST="${INGEST:-}"
+QUERY="${QUERY:-}"
+RUNS="${RUNS:-}"
+WORKERS="${WORKERS:-}"
+INSTANCE_TYPE="${INSTANCE_TYPE:-}"
+HOT_NUM_LEDGERS="${HOT_NUM_LEDGERS:-0}"
+TARGET_REF="${TARGET_REF:-}"
+TARGET_SHA="${TARGET_SHA:-}"
+BENCH_RUN_ID="${BENCH_RUN_ID:-}"
+VIEWER_URL="${VIEWER_URL:-}"
+RESULTS_URI="${RESULTS_URI:-}"
+RUN_URL="${RUN_URL:-}"
+RUN_JSON="${RUN_JSON:-}"
+EXCERPT="${EXCERPT:-}"
+BOX_ID="${BOX_ID:-}"
+BOX_RESCUED="${BOX_RESCUED:-false}"
+RUN_ID_TAG="${RUN_ID_TAG:-}"
+BUCKET="${BUCKET:-}"
+RESULT_KEY="${RESULT_KEY:-}"
+HARNESS_SHA="${HARNESS_SHA:-}"
+
+ELAPSED_H=$(fmt_minutes "${ELAPSED_MINUTES:-}")
+BUDGET_H=$(fmt_minutes "${BUDGET_MINUTES:-}")
+DEADLINE_HM=$(fmt_epoch_hm "${DEADLINE_EPOCH:-}")
+
+BOXLOG_URL=""
+VERDICT_URL=""
+if [ -n "$BUCKET" ] && [ -n "$RESULT_KEY" ]; then
+  BOXLOG_URL=$(s3_object_url "$BUCKET" "${RESULT_KEY%/*}/user-data.log")
+  VERDICT_URL=$(s3_object_url "$BUCKET" "$RESULT_KEY")
+fi
+BUNDLE_URL=$(s3_prefix_url "$RESULTS_URI")
+
+# The ingest emits the detail-viewer URL (https://<site>/?run=<id>); the card
+# links the run's summary page (https://<site>/summary.html?run=<id>) instead.
+SUMMARY_URL=""
+if [ -n "$VIEWER_URL" ]; then
+  BASE="${VIEWER_URL%%\?*}"
+  QUERY="${VIEWER_URL#"$BASE"}"
+  SUMMARY_URL="${BASE%/}/summary.html${QUERY}"
+fi
+
+# The ingestion-p99-vs-target recap, from the converted run JSON the ingest step
+# leaves in its benchmarks checkout. Per profile: p99 = driver.ingest_total.p99
+# aggregated median (ns); the display name comes from the phase workload with
+# the same tx/ledger as the unit name encodes. Tiers use the run's own reference
+# lines: over the block time, over the phase target, or under it. null (no file,
+# no hot ingest section, no target) just drops the block.
+RESULTS_BLOCK=null
+if [ "$STATE" = "ok" ] && [ -n "$RUN_JSON" ] && [ -r "$RUN_JSON" ]; then
+  RESULTS_BLOCK=$(jq -c '
+    def commafy: tostring | . as $s | ($s | length) as $l
+      | if $l <= 3 then $s else ($s[0:$l-3] | commafy) + "," + $s[$l-3:] end;
+    . as $root
+    | .campaign.phase as $ph
+    | ((.campaign.phase_targets // []) | map(select(.phase == $ph)) | first) as $t
+    | ($t.ingest_p99_target_ns // null) as $target
+    | ($t.block_time_ns // $root.checks.interval_ns // null) as $block
+    | ($root.ingest_hot // {}) as $ih
+    | if $ph == null or $target == null or $block == null or ($ih | length) == 0 then null else
+        ( [ ($root.dataset.unit_order // ($ih | keys))[]
+            | . as $u
+            | ($ih[$u].driver.ingest_total.p99.m // null) as $p99
+            | select($p99 != null)
+            | (try ($u | capture("-(?<txpl>[0-9]+)-c[0-9]+$").txpl | tonumber) catch null) as $txpl
+            | ((($t.workloads // []) | map(select(.tx_per_ledger == $txpl)) | first | .name) // $u) as $name
+            | {name: $name, txpl: $txpl, p99: $p99}
+          ] | sort_by(-.p99) ) as $rows
+        | if ($rows | length) == 0 then null else
+            (($target / 1e6) | round) as $target_ms
+            | (($block / 1e6) | round) as $block_ms
+            | {
+                header: "*Ingestion p99 vs the Phase \($ph) target (\($target_ms) ms)*",
+                lines: [ $rows[]
+                  | ((.p99 / 1e6) | round) as $ms
+                  | (((.p99 / $target * 10) | round) / 10) as $mult
+                  | (if $ms >= 1000 then "\((($ms / 100) | round) / 10) s" else "\($ms) ms" end) as $disp
+                  | (if .txpl == null then "" else " · \(.txpl | commafy) tx/ledger" end) as $load
+                  | (if .p99 > $block then "🔴 \(.name)\($load) — *\($disp)* (\($mult)× target · past the \($block_ms) ms block time)"
+                     elif .p99 > $target then "🟠 \(.name)\($load) — *\($disp)* (\($mult)× target)"
+                     else "🟢 \(.name)\($load) — *\($disp)* (under target)" end)
+                ],
+                footer: "_median of \($root.campaign.reps // 1) run\(if ($root.campaign.reps // 1) == 1 then "" else "s" end) · block time \($block_ms) ms_"
+              }
+          end
+      end
+  ' "$RUN_JSON" 2>/dev/null) || RESULTS_BLOCK=null
+  [ -n "$RESULTS_BLOCK" ] || RESULTS_BLOCK=null
+fi
+
+# The one-line summary: notification preview, old-client fallback, and what the
+# workflow step echoes into its summary.
+if [ "$STATE" = "ok" ]; then
+  TEXT="✅ bench campaign $CAMPAIGN_NAME passed — run_id=${BENCH_RUN_ID:-unknown} · ${SUMMARY_URL:-${RESULTS_URI:-s3://$BUCKET/$RESULT_KEY}} · $RUN_URL"
+else
+  TEXT="❌ bench campaign $CAMPAIGN_NAME failed: $REASON — box log s3://$BUCKET/${RESULT_KEY%/*}/user-data.log · $RUN_URL"
+fi
+
+jq -n \
+  --arg state "$STATE" \
+  --arg text "$TEXT" \
+  --arg name "$CAMPAIGN_NAME" \
+  --arg reason "$REASON" \
+  --arg phase "$PHASE" \
+  --arg ingest "$INGEST" \
+  --arg query "$QUERY" \
+  --arg runs "$RUNS" \
+  --arg workers "$WORKERS" \
+  --arg machine "$INSTANCE_TYPE" \
+  --arg hot_cap "$HOT_NUM_LEDGERS" \
+  --arg elapsed "$ELAPSED_H" \
+  --arg budget "$BUDGET_H" \
+  --arg deadline_hm "$DEADLINE_HM" \
+  --arg ref "$TARGET_REF" \
+  --arg sha "$TARGET_SHA" \
+  --arg bench "$BENCH_RUN_ID" \
+  --arg summary "$SUMMARY_URL" \
+  --arg run_url "$RUN_URL" \
+  --arg bundle_url "$BUNDLE_URL" \
+  --arg boxlog_url "$BOXLOG_URL" \
+  --arg verdict_url "$VERDICT_URL" \
+  --arg excerpt "$EXCERPT" \
+  --arg box "$BOX_ID" \
+  --arg rescued "$BOX_RESCUED" \
+  --arg runidtag "$RUN_ID_TAG" \
+  --arg repo "$REPO_URL" \
+  --arg harness "$HARNESS_SHA" \
+  --argjson results "$RESULTS_BLOCK" \
+  '
+  def button($t; $u): {type: "button", text: {type: "plain_text", text: $t, emoji: true}, url: $u};
+  def pbutton($t; $u): button($t; $u) + {style: "primary"};
+  def field($l; $v): {type: "mrkdwn", text: "*\($l)*\n\($v)"};
+
+  (if $sha != "" then "\($ref) @ <\($repo)/commit/\($sha)|\($sha[0:8])>" else $ref end) as $reftxt
+  | (if $elapsed != "" and $budget != "" then " in *\($elapsed)* of a \($budget) budget"
+     elif $elapsed != "" then " in *\($elapsed)*" else "" end) as $took
+
+  | (if $state == "ok" then
+      {
+        color: "#2eb67d",
+        header: "✅ Bench campaign passed — \($name | .[0:100])",
+        lead: "\(if $runs == "1" then "The run finished green" else "All *\($runs) runs* green" end)\($took).",
+        fields: ([
+          ["Phase", $phase],
+          ["Machine", ($machine + (if $workers != "" then " · \($workers) workers" else "" end))],
+          ["Benchmarked ref", $reftxt],
+          ["Run id", (if $bench != "" then "`\($bench)`" else "" end)]
+        ] | map(select(.[1] != "") | field(.[0]; .[1]))),
+        fields2: ([
+          ["Ingest", ($ingest + (if $hot_cap != "" and $hot_cap != "0" then " · capped at \($hot_cap) ledgers" else "" end))],
+          ["Query", $query]
+        ] | map(select(.[1] != "") | field(.[0]; .[1]))),
+        quote: "",
+        buttons: ([
+          (if $summary != "" then pbutton("View results"; $summary) else empty end),
+          (if $run_url != "" then button("GitHub run"; $run_url) else empty end),
+          (if $bundle_url != "" then button("Bundle on S3"; $bundle_url) else empty end)
+        ]),
+        context: ([
+          (if $summary != "" then "Ingested into the results site" else "Not on the results site — the ingest did not complete" end),
+          (if $harness != "" then "harness \($harness | .[0:8])" else empty end)
+        ] | join(" · "))
+      }
+    else
+      {
+        color: "#e01e5a",
+        header: "❌ Bench campaign failed — \($name | .[0:100])",
+        lead: "*Reason:* \($reason)\(if $elapsed != "" and $budget != "" then ", after \($elapsed) of a \($budget) budget" else "" end).",
+        fields: ([
+          ["Phase / Machine", ([$phase, $machine] | map(select(. != "")) | join(" · "))],
+          ["Benchmarked ref", $reftxt],
+          ["Box", (if $box != "" and $rescued == "true" then "`\($box)` — left up for rescue" else "" end)],
+          ["Run-id tag", (if $runidtag != "" and $rescued == "true" then "`\($runidtag)`" else "" end)]
+        ] | map(select(.[1] != "") | field(.[0]; .[1]))),
+        fields2: [],
+        quote: (if $excerpt != "" then ($excerpt | split("\n") | map(select(. != "") | "> " + .) | join("\n")) else "" end),
+        buttons: ([
+          (if $run_url != "" then pbutton("GitHub run"; $run_url) else empty end),
+          (if $boxlog_url != "" then button("Box log"; $boxlog_url) else empty end),
+          (if $verdict_url != "" then button("Verdict on S3"; $verdict_url) else empty end)
+        ]),
+        context: (
+          if $box != "" and $rescued == "true" then
+            "⚠️ The box stays up for debugging — terminate it by the run-id tag when done, or the reaper kills it at the deadline\(if $deadline_hm != "" then " (\($deadline_hm) UTC)" else "" end)."
+          elif $box != "" then "Box \($box) was terminated."
+          else "No box was launched." end)
+      }
+    end) as $m
+
+  | {
+      attachments: [{
+        color: $m.color,
+        fallback: $text,
+        blocks: (
+          [{type: "header", text: {type: "plain_text", text: $m.header, emoji: true}}]
+          + [{type: "section", text: {type: "mrkdwn", text: $m.lead}}]
+          + (if $m.quote != "" then [{type: "section", text: {type: "mrkdwn", text: $m.quote}}] else [] end)
+          + (if ($m.fields | length) > 0 then [{type: "section", fields: $m.fields}] else [] end)
+          + (if ($m.buttons | length) > 0 then [{type: "actions", elements: $m.buttons}] else [] end)
+          + (if $results != null then
+              [{type: "divider"},
+               {type: "section", text: {type: "mrkdwn",
+                 text: (([$results.header] + $results.lines + [$results.footer]) | join("\n"))}}]
+             else [] end)
+          + (if ($m.fields2 | length) > 0 then [{type: "section", fields: $m.fields2}] else [] end)
+          + (if $m.context != "" then [{type: "context", elements: [{type: "mrkdwn", text: $m.context}]}] else [] end)
+        )
+      }]
+    }
+  '

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/slack-payload.sh
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bench-campaign/slack-payload.sh
@@ -11,7 +11,9 @@
 #   INSTANCE_TYPE, HOT_NUM_LEDGERS, BUDGET_MINUTES, ELAPSED_MINUTES,
 #   DEADLINE_EPOCH, TARGET_REF, TARGET_SHA, BENCH_RUN_ID, VIEWER_URL,
 #   RESULTS_URI, RUN_URL, RUN_JSON (path to the converted results-site run JSON,
-#   for the ingestion-vs-target recap), EXCERPT (verdict-markdown lines, fail),
+#   for the ingestion-vs-target recap), INGEST_STATE (ingested|skipped|failed,
+#   empty when the ingest was never attempted) and INGEST_REASON (one line, why
+#   the run is not on the site), EXCERPT (verdict-markdown lines, fail),
 #   BOX_ID, BOX_RESCUED (true when the box is left up), RUN_ID_TAG, BUCKET,
 #   RESULT_KEY, AWS_REGION, HARNESS_SHA, REPO_URL.
 # Env in, MODE=reaper:
@@ -126,6 +128,8 @@ VIEWER_URL="${VIEWER_URL:-}"
 RESULTS_URI="${RESULTS_URI:-}"
 RUN_URL="${RUN_URL:-}"
 RUN_JSON="${RUN_JSON:-}"
+INGEST_STATE="${INGEST_STATE:-}"
+INGEST_REASON="${INGEST_REASON:-}"
 EXCERPT="${EXCERPT:-}"
 BOX_ID="${BOX_ID:-}"
 BOX_RESCUED="${BOX_RESCUED:-false}"
@@ -151,8 +155,8 @@ BUNDLE_URL=$(s3_prefix_url "$RESULTS_URI")
 SUMMARY_URL=""
 if [ -n "$VIEWER_URL" ]; then
   BASE="${VIEWER_URL%%\?*}"
-  QUERY="${VIEWER_URL#"$BASE"}"
-  SUMMARY_URL="${BASE%/}/summary.html${QUERY}"
+  URL_QUERY="${VIEWER_URL#"$BASE"}"
+  SUMMARY_URL="${BASE%/}/summary.html${URL_QUERY}"
 fi
 
 # The ingestion-p99-vs-target recap, from the converted run JSON the ingest step
@@ -240,6 +244,8 @@ jq -n \
   --arg runidtag "$RUN_ID_TAG" \
   --arg repo "$REPO_URL" \
   --arg harness "$HARNESS_SHA" \
+  --arg ingest_state "$INGEST_STATE" \
+  --arg ingest_reason "$INGEST_REASON" \
   --argjson results "$RESULTS_BLOCK" \
   '
   def button($t; $u): {type: "button", text: {type: "plain_text", text: $t, emoji: true}, url: $u};
@@ -250,11 +256,21 @@ jq -n \
   | (if $elapsed != "" and $budget != "" then " in *\($elapsed)* of a \($budget) budget"
      elif $elapsed != "" then " in *\($elapsed)*" else "" end) as $took
 
+  # The campaign passing and the run reaching the results site are two
+  # outcomes; a green campaign whose ingest broke still says so, in the lead
+  # (which never folds) as well as the footer. A viewer URL in hand means the
+  # ingest published, whatever the state says. Slack caps a section at 3000
+  # chars and a context element at 2000, hence the trimmed reason.
+  | ($ingest_reason | .[0:300]) as $ireason
+  | (if $summary != "" or $ingest_state == "" or $ingest_state == "ingested" then ""
+     elif $ingest_state == "failed" then " ⚠️ *Results-site ingest failed:* \($ireason)."
+     else " ℹ️ *Not ingested:* \($ireason)." end) as $ingest_note
+
   | (if $state == "ok" then
       {
         color: "#2eb67d",
         header: "✅ Bench campaign passed — \($name | .[0:100])",
-        lead: "\(if $runs == "1" then "The run finished green" else "All *\($runs) runs* green" end)\($took).",
+        lead: "\(if $runs == "1" then "The run finished green" else "All *\($runs) runs* green" end)\($took).\($ingest_note)",
         fields: ([
           ["Phase", $phase],
           ["Machine", ($machine + (if $workers != "" then " · \($workers) workers" else "" end))],
@@ -272,7 +288,10 @@ jq -n \
           (if $bundle_url != "" then button("Bundle on S3"; $bundle_url) else empty end)
         ]),
         context: ([
-          (if $summary != "" then "Ingested into the results site" else "Not on the results site — the ingest did not complete" end),
+          (if $summary != "" or $ingest_state == "ingested" then "Ingested into the results site"
+           elif $ingest_state == "failed" then "Not on the results site — ingest failed: \($ireason)"
+           elif $ingest_state == "skipped" then "Not on the results site — \($ireason)"
+           else "Not on the results site — the ingest did not complete" end),
           (if $harness != "" then "harness \($harness | .[0:8])" else empty end)
         ] | join(" · "))
       }

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bootstrap-common.sh
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/bootstrap-common.sh
@@ -34,7 +34,16 @@ DEFAULT_BRANCH=main
 log "installing aws cli + jq"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
-apt-get install -y -qq --no-install-recommends awscli jq curl ca-certificates
+apt-get install -y -qq --no-install-recommends jq curl ca-certificates unzip
+# Ubuntu 22.04 ships awscli as an apt package; 24.04 dropped it, so fall back
+# to the AWS CLI v2 bundle there. Failures before this point cannot publish a
+# verdict — the poller's budget deadline is what catches those.
+if ! apt-get install -y -qq --no-install-recommends awscli; then
+  log "no awscli apt package; installing AWS CLI v2 from the bundle"
+  curl -sSfL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip
+  unzip -q /tmp/awscliv2.zip -d /tmp
+  /tmp/aws/install
+fi
 
 # upload_result publishes {verdict, markdown} as the run's result object so the
 # gatherer (polling S3) sees a verdict. Covers the fail paths.

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/harness/gather.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/harness/gather.go
@@ -85,7 +85,8 @@ func Gather(ctx context.Context) error {
 		time.Sleep(pollInterval)
 	}
 
-	return writeTimeoutComment(ctx, runner, githubOutput, instanceID, resultsTimeout, debugLogLines)
+	headline := fmt.Sprintf("❌ Load test did not produce results within %.0fs.", resultsTimeout.Seconds())
+	return writeNoVerdictComment(ctx, runner, githubOutput, instanceID, headline, debugLogLines)
 }
 
 // ssmRunner runs shell commands on one instance over SSM RunShellScript.
@@ -137,17 +138,17 @@ func (r *ssmRunner) debugTail(ctx context.Context, n int) string {
 	return out
 }
 
-// writeTimeoutComment is the no-verdict path: it writes a comment to
-// /tmp/timeout-comment.md and records found=false.
-func writeTimeoutComment(
+// writeNoVerdictComment is the no-verdict path: it writes the caller's
+// headline plus the box context to /tmp/timeout-comment.md and records
+// found=false.
+func writeNoVerdictComment(
 	ctx context.Context,
 	runner *ssmRunner,
-	githubOutput, instanceID string,
-	resultsTimeout time.Duration,
+	githubOutput, instanceID, headline string,
 	debugLogLines int,
 ) error {
 	var b strings.Builder
-	fmt.Fprintf(&b, "❌ Load test did not produce results within %.0fs.\n\n", resultsTimeout.Seconds())
+	fmt.Fprintf(&b, "%s\n\n", headline)
 	fmt.Fprintf(&b, "Instance: `%s`\n", instanceID)
 	srv, repo, run := os.Getenv("GITHUB_SERVER_URL"), os.Getenv("GITHUB_REPOSITORY"), os.Getenv("GITHUB_RUN_ID")
 	if srv != "" && repo != "" && run != "" {

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/harness/relay.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/harness/relay.go
@@ -1,0 +1,212 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+)
+
+// Relay step-output states. Exactly one is written per poll window.
+const (
+	relayStateOK      = "ok"      // verdict seen, verdict == "ok"
+	relayStateFail    = "fail"    // verdict seen and not "ok", or the budget deadline passed with none
+	relayStateRunning = "running" // window closed with budget left: the next poll job takes over
+)
+
+// relayVerdictPending is the marker verdict the workflow's launch job seeds at
+// RESULT_KEY, so the key exists for the campaign's whole life. It reads as
+// "still running", and it makes a persistent fetch error a genuine fault
+// rather than a maybe-not-published-yet.
+const relayVerdictPending = "pending"
+
+// maxConsecutiveFetchErrors is how many failed polls in a row (~5 min at the
+// 30 s interval) the relay tolerates before calling the run faulted. The
+// launch job seeds RESULT_KEY, so persistent errors mean a config or
+// permissions fault, not a slow campaign; transient S3 hiccups never chain
+// this long.
+const maxConsecutiveFetchErrors = 10
+
+// Relay is the poll half of a campaign that outlives one GHA job. Where Gather
+// treats its whole timeout as a failure, Relay polls for a bounded window and
+// reports back which of three things happened: a verdict arrived, the campaign's
+// budget deadline passed without one, or the window merely closed — a handoff to
+// the next poll job, not a failure. The process exits 0 in all three cases; the
+// workflow gates on the state output.
+//
+// The workflow's launch job seeds RESULT_KEY with a "pending" marker, so the
+// object always exists: pending reads as still-running, and persistent fetch
+// errors read as a fault worth failing fast on instead of a slow campaign.
+func Relay(ctx context.Context) error {
+	cfg, err := loadRelayConfig()
+	if err != nil {
+		return err
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.region))
+	if err != nil {
+		return err
+	}
+	s3Client := s3.NewFromConfig(awsCfg)
+	runner := &ssmRunner{client: ssm.NewFromConfig(awsCfg), instanceID: cfg.instanceID}
+
+	start := time.Now()
+	// The window never runs past the deadline: budget exhaustion is a verdict of
+	// its own and there is no point polling beyond it.
+	windowEnd := start.Add(cfg.window)
+	if cfg.deadline.Before(windowEnd) {
+		windowEnd = cfg.deadline
+	}
+	logger.Infof("polling s3://%s/%s until %s (deadline %s)",
+		cfg.bucket, cfg.resultKey, windowEnd.UTC().Format(time.RFC3339), cfg.deadline.UTC().Format(time.RFC3339))
+
+	fetchErrs := 0
+	for pollCount := 1; time.Now().Before(windowEnd); pollCount++ {
+		res, derr := FetchResult(ctx, s3Client, cfg.bucket, cfg.resultKey)
+		if derr == nil || errors.Is(derr, ErrResultNotReady) {
+			fetchErrs = 0
+		}
+		switch {
+		case errors.Is(derr, ErrResultNotReady):
+			logger.Infof("still waiting for s3://%s/%s", cfg.bucket, cfg.resultKey)
+		case derr != nil:
+			fetchErrs++
+			logger.Warnf("result fetch failed (%d/%d); retrying: %v", fetchErrs, maxConsecutiveFetchErrors, derr)
+			if fetchErrs >= maxConsecutiveFetchErrors {
+				return cfg.reportFault(ctx, runner, fmt.Sprintf(
+					"❌ Relay gave up: %d consecutive result fetches failed (last: %v). "+
+						"The launch job seeds this key, so this is a permissions or config fault, not a pending campaign.",
+					fetchErrs, derr))
+			}
+		// A leftover object from a prior attempt (re-runs share RESULT_KEY) is
+		// "not published yet" so this attempt's box overwrites it.
+		case res.RunID != cfg.runID:
+			logger.Infof("ignoring stale result from run %s (want %s)", res.RunID, cfg.runID)
+		case res.Verdict == relayVerdictPending:
+			logger.Infof("campaign still running (pending marker at s3://%s/%s)", cfg.bucket, cfg.resultKey)
+		default:
+			return cfg.reportVerdict(res)
+		}
+
+		if pollCount%cfg.debugEveryPolls == 0 {
+			logger.Infof("debug tail:\n%s", runner.debugTail(ctx, cfg.debugLogLines))
+		}
+		time.Sleep(cfg.pollInterval)
+	}
+
+	if relayState(time.Now(), cfg.deadline) == relayStateRunning {
+		logger.Infof("window closed with %s of budget left; handing off to the next poll job",
+			time.Until(cfg.deadline).Round(time.Second))
+		return appendOutputs(cfg.githubOutput, "state="+relayStateRunning)
+	}
+
+	// Budget exhausted: the campaign overran the wall-clock estimate the workflow
+	// validated it against, so this is a failure and not a handoff. The reported
+	// duration is this window's wait — the poll chain spans jobs, so no single one
+	// of them knows the total.
+	logger.Warnf("budget deadline passed with no verdict after %s", time.Since(start).Round(time.Second))
+	return cfg.reportFault(ctx, runner, fmt.Sprintf(
+		"❌ Campaign budget deadline passed with no verdict (this window waited %s).",
+		time.Since(start).Round(time.Second)))
+}
+
+// reportFault is the no-verdict fail path: it logs the headline, writes it
+// (plus the box tail) where the workflow's summary step looks, and relays a
+// fail state.
+func (c *relayConfig) reportFault(ctx context.Context, runner *ssmRunner, headline string) error {
+	logger.Warnf("%s", headline)
+	if err := writeNoVerdictComment(
+		ctx, runner, c.githubOutput, c.instanceID, headline, c.debugLogLines,
+	); err != nil {
+		return err
+	}
+	return appendOutputs(c.githubOutput, "state="+relayStateFail)
+}
+
+// relayState reports the state of a poll window that ended without a verdict:
+// the campaign is still running while its budget deadline is in the future, and
+// has failed once the deadline has passed.
+func relayState(now, deadline time.Time) string {
+	if now.Before(deadline) {
+		return relayStateRunning
+	}
+	return relayStateFail
+}
+
+// relayConfig is Relay's validated environment.
+type relayConfig struct {
+	instanceID      string
+	region          string
+	githubOutput    string
+	bucket          string
+	resultKey       string
+	runID           string
+	pollInterval    time.Duration
+	debugLogLines   int
+	debugEveryPolls int
+	window          time.Duration
+	deadline        time.Time
+}
+
+// relayIntKeys are the numeric slots of the poller env contract.
+var relayIntKeys = []string{
+	"POLL_INTERVAL", "DEBUG_LOG_LINES", "DEBUG_LOG_EVERY_POLLS", "WINDOW_SECONDS", "DEADLINE_EPOCH",
+}
+
+// loadRelayConfig reads and validates the whole poller env before any AWS client
+// is built, so a mis-plumbed workflow fails in the first second.
+func loadRelayConfig() (*relayConfig, error) {
+	strs, err := RequireEnv(
+		"INSTANCE_ID", "AWS_REGION", "GITHUB_OUTPUT", "BUCKET", "RESULT_KEY", "RUN_ID",
+	)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := RequireEnv(relayIntKeys...); err != nil {
+		return nil, err
+	}
+	ints := map[string]int{}
+	for _, k := range relayIntKeys {
+		n, cerr := strconv.Atoi(os.Getenv(k))
+		if cerr != nil {
+			return nil, fmt.Errorf("%s: %w", k, cerr)
+		}
+		ints[k] = n
+	}
+	if ints["DEBUG_LOG_EVERY_POLLS"] < 1 {
+		return nil, fmt.Errorf("DEBUG_LOG_EVERY_POLLS must be positive, got %d", ints["DEBUG_LOG_EVERY_POLLS"])
+	}
+	return &relayConfig{
+		instanceID:      strs[0],
+		region:          strs[1],
+		githubOutput:    strs[2],
+		bucket:          strs[3],
+		resultKey:       strs[4],
+		runID:           strs[5],
+		pollInterval:    time.Duration(ints["POLL_INTERVAL"]) * time.Second,
+		debugLogLines:   ints["DEBUG_LOG_LINES"],
+		debugEveryPolls: ints["DEBUG_LOG_EVERY_POLLS"],
+		window:          time.Duration(ints["WINDOW_SECONDS"]) * time.Second,
+		deadline:        time.Unix(int64(ints["DEADLINE_EPOCH"]), 0),
+	}, nil
+}
+
+// reportVerdict writes the box's markdown where the workflow expects it and
+// relays the verdict as the window's state.
+func (c *relayConfig) reportVerdict(res *Result) error {
+	logger.Infof("result published by instance (verdict: %s)", res.Verdict)
+	if err := os.WriteFile("/tmp/results.md", []byte(res.Markdown), 0o644); err != nil {
+		return err
+	}
+	state := relayStateFail
+	if res.Verdict == relayStateOK {
+		state = relayStateOK
+	}
+	return appendOutputs(c.githubOutput, "state="+state)
+}

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/harness/relay_test.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/harness/relay_test.go
@@ -1,0 +1,85 @@
+package harness
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRelayState pins the handoff rule: only an exhausted budget turns a
+// verdict-less window into a failure.
+func TestRelayState(t *testing.T) {
+	deadline := time.Unix(1_700_000_000, 0)
+	for _, tc := range []struct {
+		name string
+		now  time.Time
+		want string
+	}{
+		{"budget left", deadline.Add(-time.Hour), relayStateRunning},
+		{"one second left", deadline.Add(-time.Second), relayStateRunning},
+		{"deadline reached", deadline, relayStateFail},
+		{"deadline passed", deadline.Add(time.Hour), relayStateFail},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, relayState(tc.now, deadline))
+		})
+	}
+}
+
+// relayEnv is the poller env contract, valid values throughout. Tests blank or
+// corrupt one slot at a time from it.
+var relayEnv = map[string]string{
+	"INSTANCE_ID":           "i-0123456789abcdef0",
+	"AWS_REGION":            "us-east-1",
+	"GITHUB_OUTPUT":         "/dev/null",
+	"BUCKET":                "stellar-rpc-ci-load-test",
+	"RESULT_KEY":            "runs/1/campaign/result.json",
+	"RUN_ID":                "1-1",
+	"POLL_INTERVAL":         "30",
+	"DEBUG_LOG_LINES":       "40",
+	"DEBUG_LOG_EVERY_POLLS": "10",
+	"WINDOW_SECONDS":        "19200",
+	"DEADLINE_EPOCH":        "1700000000",
+}
+
+// setRelayEnv installs the contract with overrides applied; an empty override
+// value stands for an unset variable.
+func setRelayEnv(t *testing.T, overrides map[string]string) {
+	t.Helper()
+	for k, v := range relayEnv {
+		if o, ok := overrides[k]; ok {
+			v = o
+		}
+		t.Setenv(k, v)
+	}
+}
+
+// TestRelayEnvValidation checks that a mis-plumbed workflow gets an error naming
+// the bad slot rather than a panic or an AWS call. Every case here must fail
+// before Relay reaches S3, which is why the env is otherwise complete.
+func TestRelayEnvValidation(t *testing.T) {
+	blankAll := map[string]string{}
+	for k := range relayEnv {
+		blankAll[k] = ""
+	}
+	for _, tc := range []struct {
+		name      string
+		overrides map[string]string
+		wantMsg   string
+	}{
+		{"nothing set", blankAll, "missing required env"},
+		{"no instance", map[string]string{"INSTANCE_ID": ""}, "INSTANCE_ID"},
+		{"no deadline", map[string]string{"DEADLINE_EPOCH": ""}, "DEADLINE_EPOCH"},
+		{"unparsable interval", map[string]string{"POLL_INTERVAL": "half a minute"}, "POLL_INTERVAL"},
+		{"zero debug cadence", map[string]string{"DEBUG_LOG_EVERY_POLLS": "0"}, "DEBUG_LOG_EVERY_POLLS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setRelayEnv(t, tc.overrides)
+			err := Relay(context.Background())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/harness/s3.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/harness/s3.go
@@ -23,7 +23,7 @@ import (
 // a 404.
 type Result struct {
 	SchemaVersion int             `json:"schemaVersion"`
-	Verdict       string          `json:"verdict"` // "ok" or "fail"
+	Verdict       string          `json:"verdict"` // "ok" or "fail"; bench-campaign launches also seed a "pending" marker
 	Markdown      string          `json:"markdown"`
 	Bench         json.RawMessage `json:"bench,omitempty"`
 	RunID         string          `json:"runId"`

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/relay/main.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/relay/main.go
@@ -1,0 +1,8 @@
+// Command relay is the windowed poller for campaigns that outlive one GHA job:
+// it polls S3 for the result object the box publishes and reports either the
+// verdict or a handoff to the next poll job as step outputs.
+package main
+
+import "github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/harness"
+
+func main() { harness.Run(harness.Relay) }

--- a/cmd/stellar-rpc/internal/rpcv2/bench/bench_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/bench_test.go
@@ -15,7 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
@@ -40,6 +43,39 @@ func testLogger() *supportlog.Entry {
 // ledgers tree root and the number of tx/event-bearing ledgers written.
 func writeSourcePack(t *testing.T, root string, chunkID chunk.ID, numLedgers uint32) (string, int) {
 	t.Helper()
+	first := chunkID.FirstLedger()
+	txLedgers := 0
+	packRoot := writeLedgerPack(t, root, chunkID, numLedgers, func(seq uint32) []byte {
+		if (seq-first)%eventEvery != 0 {
+			return rpcv2test.ZeroTxLCMBytes(t, seq)
+		}
+		txLedgers++
+		return rpcv2test.EventLCMBytes(t, seq)
+	})
+	return packRoot, txLedgers
+}
+
+// writeDenseSourcePack materializes a source ledger pack for chunkID under
+// root/ledgers holding numLedgers ledgers from the chunk's first sequence, each
+// carrying txPerLedger transactions. It returns the ledgers tree root. Tests
+// that measure how a sample spreads over ledgers need a fixture whose ledgers
+// hold more transactions than one ledger may contribute.
+func writeDenseSourcePack(
+	t *testing.T, root string, chunkID chunk.ID, numLedgers uint32, txPerLedger int,
+) string {
+	t.Helper()
+	return writeLedgerPack(t, root, chunkID, numLedgers, func(seq uint32) []byte {
+		return multiTxLCMBytes(t, seq, txPerLedger)
+	})
+}
+
+// writeLedgerPack writes numLedgers ledgers from chunkID's first sequence into
+// a source pack under root/ledgers, taking each ledger's bytes from build. It
+// returns the ledgers tree root.
+func writeLedgerPack(
+	t *testing.T, root string, chunkID chunk.ID, numLedgers uint32, build func(seq uint32) []byte,
+) string {
+	t.Helper()
 	layout := geometry.NewLayout(root)
 	packPath := layout.LedgerPackPath(chunkID)
 	require.NoError(t, os.MkdirAll(filepath.Dir(packPath), 0o755))
@@ -48,20 +84,54 @@ func writeSourcePack(t *testing.T, root string, chunkID chunk.ID, numLedgers uin
 	require.NoError(t, err)
 	defer func() { _ = w.Close() }()
 
-	txLedgers := 0
 	first := chunkID.FirstLedger()
 	for seq := first; seq < first+numLedgers; seq++ {
-		var raw []byte
-		if (seq-first)%eventEvery == 0 {
-			raw = rpcv2test.EventLCMBytes(t, seq)
-			txLedgers++
-		} else {
-			raw = rpcv2test.ZeroTxLCMBytes(t, seq)
-		}
-		require.NoError(t, w.AppendLedger(seq, raw))
+		require.NoError(t, w.AppendLedger(seq, build(seq)))
 	}
 	require.NoError(t, w.Commit())
-	return layout.LedgersRoot(), txLedgers
+	return layout.LedgersRoot()
+}
+
+// multiTxLCMBytes returns the marshaled bytes of a LedgerCloseMeta (V2) for
+// ledger seq carrying txCount transactions. Each transaction's random source
+// account gives it a distinct, valid pubnet hash, and its envelope is hashed
+// into the result pair, so the served by-hash path pairs the two back up.
+func multiTxLCMBytes(t *testing.T, seq uint32, txCount int) []byte {
+	t.Helper()
+	envelopes := make([]xdr.TransactionEnvelope, txCount)
+	processing := make([]xdr.TransactionResultMetaV1, txCount)
+	for i := range txCount {
+		envelopes[i] = xdr.TransactionEnvelope{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					SourceAccount: xdr.MustMuxedAddress(keypair.MustRandom().Address()),
+					Ext:           xdr.TransactionExt{V: 1, SorobanData: &xdr.SorobanTransactionData{}},
+				},
+			},
+		}
+		hash, err := network.HashTransactionInEnvelope(envelopes[i], network.PublicNetworkPassphrase)
+		require.NoError(t, err)
+
+		opResults := []xdr.OperationResult{}
+		processing[i] = xdr.TransactionResultMetaV1{
+			TxApplyProcessing: xdr.TransactionMeta{
+				V:  4,
+				V4: &xdr.TransactionMetaV4{Operations: []xdr.OperationMetaV2{{}}},
+			},
+			Result: xdr.TransactionResultPair{
+				TransactionHash: hash,
+				Result: xdr.TransactionResult{
+					FeeCharged: 100,
+					Result: xdr.TransactionResultResult{
+						Code:    xdr.TransactionResultCodeTxSuccess,
+						Results: &opResults,
+					},
+				},
+			},
+		}
+	}
+	return rpcv2test.V2LCMBytes(t, seq, 0, envelopes, processing)
 }
 
 // readCSV parses one report file into rows keyed by stage name; each row maps

--- a/cmd/stellar-rpc/internal/rpcv2/bench/cold.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/cold.go
@@ -110,7 +110,7 @@ func runCold(ctx context.Context, logger *supportlog.Entry, opts coldOptions) er
 	if catalogBase == "" {
 		catalogBase = opts.ColdRoot
 	}
-	cat, releaseCat, err := openScratchCatalog(catalogBase, layout, logger)
+	cat, releaseCat, err := openScratchCatalog(catalogBase, scratchPrefixIngest, layout, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/command.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/command.go
@@ -123,7 +123,7 @@ type runEnv struct {
 // SIGINT-canceled context, Info-level logger, profiling around run, an
 // invocation.json record written to --out after the run — with --out, the
 // profile flags, and each caller-supplied flag group bound. bench-ingest passes
-// its ledger-source group, bench-query its sweep group.
+// its ledger-source group, bench-query its leg group.
 func newBenchCommand(
 	use, short string, prof *profileFlags,
 	run func(ctx context.Context, logger *supportlog.Entry, env runEnv) error,

--- a/cmd/stellar-rpc/internal/rpcv2/bench/command.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/command.go
@@ -110,6 +110,15 @@ type flagBinder interface {
 	bind(cmd *cobra.Command)
 }
 
+// runEnv is what a bench run gets from its command wrapper: where to write,
+// and a place to record facts the run resolves for itself — ones
+// invocation.json cannot read off a flag, such as whether page-cache eviction
+// is supported on this platform.
+type runEnv struct {
+	OutDir string
+	Extra  map[string]string
+}
+
 // newBenchCommand builds one bench subcommand skeleton — no positional args,
 // SIGINT-canceled context, Info-level logger, profiling around run, an
 // invocation.json record written to --out after the run — with --out, the
@@ -117,7 +126,7 @@ type flagBinder interface {
 // its ledger-source group, bench-query its sweep group.
 func newBenchCommand(
 	use, short string, prof *profileFlags,
-	run func(ctx context.Context, logger *supportlog.Entry, outDir string) error,
+	run func(ctx context.Context, logger *supportlog.Entry, env runEnv) error,
 	groups ...flagBinder,
 ) *cobra.Command {
 	var outDir string
@@ -130,13 +139,14 @@ func newBenchCommand(
 			ctx, stop, logger := benchContext()
 			defer stop()
 			startedAt := time.Now().UTC()
-			runErr := prof.around(logger, func() error { return run(ctx, logger, outDir) })
+			env := runEnv{OutDir: outDir, Extra: map[string]string{}}
+			runErr := prof.around(logger, func() error { return run(ctx, logger, env) })
 			// The --out dir is created by the run itself, so a run that
 			// failed early (e.g. in validation) leaves nowhere to write the
 			// record and this write fails too. In that case only warn about
 			// the write: the error the user needs to see is the run's own.
 			if err := writeInvocationJSON(
-				outDir, cmd, captureFlags(cmd), startedAt, time.Now().UTC(), runErr,
+				outDir, cmd, captureFlags(cmd), env.Extra, startedAt, time.Now().UTC(), runErr,
 			); err != nil {
 				if runErr == nil {
 					return err
@@ -167,7 +177,7 @@ func newColdCommand() *cobra.Command {
 	cmd := newBenchCommand("cold",
 		"Benchmark cold ingestion: the daemon's backfill (chunk freezes + txhash index builds) over a chunk range",
 		&prof,
-		func(ctx context.Context, logger *supportlog.Entry, outDir string) error {
+		func(ctx context.Context, logger *supportlog.Entry, env runEnv) error {
 			return runCold(ctx, logger, coldOptions{
 				Source:     src.config(),
 				StartChunk: chunk.ID(startChunk),
@@ -175,7 +185,7 @@ func newColdCommand() *cobra.Command {
 				Workers:    workers,
 				ColdRoot:   coldOutDir,
 				CatalogDir: catalogDir,
-				OutDir:     outDir,
+				OutDir:     env.OutDir,
 			})
 		}, &src)
 	fs := cmd.Flags()
@@ -205,7 +215,7 @@ func newHotCommand() *cobra.Command {
 	cmd := newBenchCommand("hot",
 		"Benchmark hot ingestion: the daemon's live ingestion loop over a chunk range",
 		&prof,
-		func(ctx context.Context, logger *supportlog.Entry, outDir string) error {
+		func(ctx context.Context, logger *supportlog.Entry, env runEnv) error {
 			return runHot(ctx, logger, hotOptions{
 				Source:        src.config(),
 				StartChunk:    chunk.ID(startChunk),
@@ -214,7 +224,7 @@ func newHotCommand() *cobra.Command {
 				HotRoot:       hotDir,
 				CatalogDir:    catalogDir,
 				CloseInterval: closeInterval,
-				OutDir:        outDir,
+				OutDir:        env.OutDir,
 			})
 		}, &src)
 	fs := cmd.Flags()

--- a/cmd/stellar-rpc/internal/rpcv2/bench/command.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/command.go
@@ -104,13 +104,21 @@ func writePartialCSVs(logger *supportlog.Entry, sink *csvSink, outDir string) {
 	}
 }
 
-// newBenchCommand builds one bench-ingest subcommand skeleton — no positional
-// args, SIGINT-canceled context, Info-level logger, profiling around run, an
-// invocation.json record written to --out after the run — with the source,
-// profile, and --out flags bound.
+// flagBinder is one flag group a subcommand binds — the shape sourceFlags,
+// profileFlags, and queryFlags share.
+type flagBinder interface {
+	bind(cmd *cobra.Command)
+}
+
+// newBenchCommand builds one bench subcommand skeleton — no positional args,
+// SIGINT-canceled context, Info-level logger, profiling around run, an
+// invocation.json record written to --out after the run — with --out, the
+// profile flags, and each caller-supplied flag group bound. bench-ingest passes
+// its ledger-source group, bench-query its sweep group.
 func newBenchCommand(
-	use, short string, src *sourceFlags, prof *profileFlags,
+	use, short string, prof *profileFlags,
 	run func(ctx context.Context, logger *supportlog.Entry, outDir string) error,
+	groups ...flagBinder,
 ) *cobra.Command {
 	var outDir string
 	cmd := &cobra.Command{
@@ -139,8 +147,10 @@ func newBenchCommand(
 		},
 	}
 	cmd.Flags().StringVar(&outDir, "out", "bench-out", "output dir for the CSV report and invocation.json")
-	src.bind(cmd)
 	prof.bind(cmd)
+	for _, g := range groups {
+		g.bind(cmd)
+	}
 	return cmd
 }
 
@@ -156,7 +166,7 @@ func newColdCommand() *cobra.Command {
 	)
 	cmd := newBenchCommand("cold",
 		"Benchmark cold ingestion: the daemon's backfill (chunk freezes + txhash index builds) over a chunk range",
-		&src, &prof,
+		&prof,
 		func(ctx context.Context, logger *supportlog.Entry, outDir string) error {
 			return runCold(ctx, logger, coldOptions{
 				Source:     src.config(),
@@ -167,7 +177,7 @@ func newColdCommand() *cobra.Command {
 				CatalogDir: catalogDir,
 				OutDir:     outDir,
 			})
-		})
+		}, &src)
 	fs := cmd.Flags()
 	fs.Uint32Var(&startChunk, "start-chunk", 0, "first chunk ID to backfill (required)")
 	fs.IntVar(&numChunks, "num-chunks", 1, "how many consecutive chunks to backfill starting at --start-chunk")
@@ -194,7 +204,7 @@ func newHotCommand() *cobra.Command {
 	)
 	cmd := newBenchCommand("hot",
 		"Benchmark hot ingestion: the daemon's live ingestion loop over a chunk range",
-		&src, &prof,
+		&prof,
 		func(ctx context.Context, logger *supportlog.Entry, outDir string) error {
 			return runHot(ctx, logger, hotOptions{
 				Source:        src.config(),
@@ -206,7 +216,7 @@ func newHotCommand() *cobra.Command {
 				CloseInterval: closeInterval,
 				OutDir:        outDir,
 			})
-		})
+		}, &src)
 	fs := cmd.Flags()
 	fs.Uint32Var(&startChunk, "start-chunk", 0, "first chunk ID to ingest (required)")
 	fs.IntVar(&numChunks, "num-chunks", 1,

--- a/cmd/stellar-rpc/internal/rpcv2/bench/command.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/command.go
@@ -123,7 +123,7 @@ type runEnv struct {
 // SIGINT-canceled context, Info-level logger, profiling around run, an
 // invocation.json record written to --out after the run — with --out, the
 // profile flags, and each caller-supplied flag group bound. bench-ingest passes
-// its ledger-source group, bench-query its leg group.
+// its ledger-source group, bench-query its query group.
 func newBenchCommand(
 	use, short string, prof *profileFlags,
 	run func(ctx context.Context, logger *supportlog.Entry, env runEnv) error,

--- a/cmd/stellar-rpc/internal/rpcv2/bench/command.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/command.go
@@ -2,6 +2,8 @@ package bench
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -121,9 +123,10 @@ type runEnv struct {
 
 // newBenchCommand builds one bench subcommand skeleton — no positional args,
 // SIGINT-canceled context, Info-level logger, profiling around run, an
-// invocation.json record written to --out after the run — with --out, the
-// profile flags, and each caller-supplied flag group bound. bench-ingest passes
-// its ledger-source group, bench-query its query group.
+// invocation.json record written to --out when the run starts and again when it
+// stops — with --out, the profile flags, and each caller-supplied flag group
+// bound. bench-ingest passes its ledger-source group, bench-query its query
+// group.
 func newBenchCommand(
 	use, short string, prof *profileFlags,
 	run func(ctx context.Context, logger *supportlog.Entry, env runEnv) error,
@@ -140,11 +143,20 @@ func newBenchCommand(
 			defer stop()
 			startedAt := time.Now().UTC()
 			env := runEnv{OutDir: outDir, Extra: map[string]string{}}
+			// The record is written twice: once now, so a run killed
+			// outright still leaves its argv and start time in --out, and
+			// once when the run stops, with the end time and the outcome.
+			// Creating --out here is also the earliest point an unwritable
+			// one can be reported.
+			if err := os.MkdirAll(outDir, 0o755); err != nil {
+				return fmt.Errorf("create --out dir %s: %w", outDir, err)
+			}
+			if err := writeStartInvocationJSON(outDir, cmd, captureFlags(cmd), env.Extra, startedAt); err != nil {
+				return err
+			}
 			runErr := prof.around(logger, func() error { return run(ctx, logger, env) })
-			// The --out dir is created by the run itself, so a run that
-			// failed early (e.g. in validation) leaves nowhere to write the
-			// record and this write fails too. In that case only warn about
-			// the write: the error the user needs to see is the run's own.
+			// A failing final write only warns: the error the user needs to
+			// see is the run's own, and the start record is already on disk.
 			if err := writeInvocationJSON(
 				outDir, cmd, captureFlags(cmd), env.Extra, startedAt, time.Now().UTC(), runErr,
 			); err != nil {

--- a/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
@@ -152,7 +152,10 @@ var fileSpecs = func() []fileSpec {
 //     its basename.
 //   - In a type's file, total_r<rate> is that leg's headline distribution — the
 //     scheduled latency of every measured request. service_r<rate>,
-//     found_r<rate>, and miss_r<rate> are side rows over the same requests.
+//     found_r<rate>, and miss_r<rate> are side rows over the same requests. A
+//     consumer must read <qtype>_r<rate>_shed alongside total_r<rate>, because
+//     once a leg sheds, total_r<rate> covers only the requests the dispatcher
+//     was able to offer.
 //   - In driver.csv, <qtype>_r<rate> with no further suffix is the leg's
 //     wall-clock. <qtype>_r<rate>_millirps, _lag, and _shed are that leg's
 //     driver metrics: the achieved rate times 1000, the dispatch-lag
@@ -490,13 +493,17 @@ func withUnknown[V any](order []string, m map[string]V) []string {
 }
 
 // keepsZeroSamples reports whether a row keeps its zero-duration samples. These
-// rows are distributions or counts in which a zero is a real observation — a
-// ledger that committed on time, a request dispatched on time, a leg that shed
-// nothing — rather than a piece of work too fast for the timer to see.
+// rows are distributions, counts, or rates in which a zero is a real
+// observation — a ledger that committed on time, a request dispatched on time,
+// a leg that shed nothing, a leg that answered nothing — rather than a piece of
+// work too fast for the timer to see.
+//
+// The rule is a whole-label suffix rule shared by the ingest and query schemas,
+// so the ingest report's pace_lag is covered by the _lag suffix.
 func keepsZeroSamples(label string) bool {
-	return label == driverPaceLag ||
-		strings.HasSuffix(label, driverLegLagSuffix) ||
-		strings.HasSuffix(label, driverLegShedSuffix)
+	return strings.HasSuffix(label, driverLegLagSuffix) ||
+		strings.HasSuffix(label, driverLegShedSuffix) ||
+		strings.HasSuffix(label, driverLegRPSSuffix)
 }
 
 // file is one aggregated CSV file: its basename (without .csv) and its rows.
@@ -591,19 +598,34 @@ func writeCSV(path string, rows []row) error {
 func (s *csvSink) logSummary(logger *supportlog.Entry) {
 	for _, f := range s.files() {
 		for _, r := range f.rows {
-			// peak_rss_bytes carries bytes in its duration fields; render it
-			// as a byte count, not a garbled duration.
-			if f.name == fileDriver && r.name == driverPeakRSS {
-				logger.Infof("%-10s %-12s n=%-7d bytes=%d", f.name, r.name, r.n, r.total.Nanoseconds())
-				continue
-			}
-			logger.Infof("%-10s %-12s n=%-7d items=%-9d total=%-12s p50=%-10s p90=%-10s p99=%-10s max=%s",
-				f.name, r.name, r.n, r.items,
-				r.total.Round(time.Microsecond),
-				r.p50.Round(time.Microsecond),
-				r.p90.Round(time.Microsecond),
-				r.p99.Round(time.Microsecond),
-				r.maxv.Round(time.Microsecond))
+			logRow(logger, f.name, r)
 		}
 	}
+}
+
+// logRow logs one aggregated row. Three driver rows hold a plain number in
+// their duration columns rather than a time — the run's peak RSS in bytes, a
+// leg's achieved rate in thousandths of a request per second, and a leg's shed
+// count — so each is rendered as the number it holds.
+func logRow(logger *supportlog.Entry, fileName string, r row) {
+	switch {
+	case fileName != fileDriver:
+	case r.name == driverPeakRSS:
+		logger.Infof("%-10s %-12s n=%-7d bytes=%d", fileName, r.name, r.n, r.total.Nanoseconds())
+		return
+	case strings.HasSuffix(r.name, driverLegRPSSuffix):
+		logger.Infof("%-10s %-12s n=%-7d rps=%.3f", fileName, r.name, r.n,
+			float64(r.total.Nanoseconds())/milliPerUnit)
+		return
+	case strings.HasSuffix(r.name, driverLegShedSuffix):
+		logger.Infof("%-10s %-12s n=%-7d shed=%d", fileName, r.name, r.n, r.items)
+		return
+	}
+	logger.Infof("%-10s %-12s n=%-7d items=%-9d total=%-12s p50=%-10s p90=%-10s p99=%-10s max=%s",
+		fileName, r.name, r.n, r.items,
+		r.total.Round(time.Microsecond),
+		r.p50.Round(time.Microsecond),
+		r.p90.Round(time.Microsecond),
+		r.p99.Round(time.Microsecond),
+		r.maxv.Round(time.Microsecond))
 }

--- a/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
@@ -84,7 +84,7 @@ type fileSpec struct {
 	rowOrder []string
 }
 
-// fileSpecs is the whole report schema, in file emission order:
+// fileSpecs is the bench-ingest report schema, in file emission order:
 //
 //   - one CSV per cold data type the ingest engine reports (ledgers.csv,
 //     txhash.csv, events.csv), one row per cold pipeline stage (term_index →
@@ -140,6 +140,33 @@ var fileSpecs = func() []fileSpec {
 	)
 }()
 
+// querySpecs is the bench-query report schema for one run: one CSV per swept
+// query type, each holding a total_c<W> row per concurrency level, plus
+// driver.csv holding the fixture open, the per-cell wall-clocks
+// (<qtype>_c<W>), and the peak RSS. Unlike fileSpecs it is built per run, since
+// the row set is the --types × --query-concurrency sweep the flags asked for.
+//
+// The labels are the results converter's contract, not a presentation choice:
+// it discovers the query types by globbing the run dir for CSVs other than
+// driver.csv, reads each cell from that type's total_c<W> row and the matching
+// <qtype>_c<W> driver row, and files every driver row WITHOUT a _c<W> suffix
+// (open, peak_rss_bytes) under "setup".
+func querySpecs(types []string, concurrency []int) []fileSpec {
+	specs := make([]fileSpec, 0, len(types)+1)
+	driverRows := make([]string, 0, len(types)*len(concurrency)+2)
+	driverRows = append(driverRows, driverQueryOpen)
+	for _, qtype := range types {
+		rows := make([]string, 0, len(concurrency))
+		for _, w := range concurrency {
+			rows = append(rows, queryCellRow(w))
+			driverRows = append(driverRows, queryDriverRow(qtype, w))
+		}
+		specs = append(specs, fileSpec{name: qtype, rowOrder: rows})
+	}
+	driverRows = append(driverRows, driverPeakRSS)
+	return append(specs, fileSpec{name: fileDriver, rowOrder: driverRows})
+}
+
 // sample is one observed (duration, item-count) pair.
 type sample struct {
 	d     time.Duration
@@ -184,6 +211,12 @@ type csvSink struct {
 	mu   sync.Mutex
 	rows map[rowKey]*series // every signal is one sample on a (file, row) key
 
+	// specs is the report schema this sink renders through: fileSpecs for an
+	// ingest run, querySpecs(...) for a query run, whose file and row set is the
+	// sweep the flags asked for rather than a fixed vocabulary. Read-only after
+	// construction.
+	specs []fileSpec
+
 	// hotBurst accumulates the current hot ledger's HotPhase durations so
 	// HotPhase can reconstruct the per-ledger end-to-end ingest_total (the
 	// phases partition the per-ledger total). Guarded by mu.
@@ -205,9 +238,15 @@ var (
 	_ observability.Metrics = (*csvSink)(nil)
 )
 
-// newCSVSink returns an empty recorder.
+// newCSVSink returns an empty recorder rendering through the bench-ingest
+// schema.
 func newCSVSink() *csvSink {
-	return &csvSink{rows: make(map[rowKey]*series)}
+	return newSchemaCSVSink(fileSpecs)
+}
+
+// newSchemaCSVSink returns an empty recorder rendering through specs.
+func newSchemaCSVSink(specs []fileSpec) *csvSink {
+	return &csvSink{rows: make(map[rowKey]*series), specs: specs}
 }
 
 // HotPhase records one phase of one hot ledger ingest into hot.csv, and
@@ -427,8 +466,8 @@ type file struct {
 	rows []row
 }
 
-// files aggregates every recorded series into the report's CSV files, in
-// fileSpecs order (a file outside the schema is appended after, sorted, its
+// files aggregates every recorded series into the report's CSV files, in the
+// sink's schema order (a file outside the schema is appended after, sorted, its
 // rows ordered by sorted label).
 func (s *csvSink) files() []file {
 	s.mu.Lock()
@@ -442,9 +481,9 @@ func (s *csvSink) files() []file {
 		byFile[k.file][k.row] = sr
 	}
 
-	names := make([]string, len(fileSpecs))
-	rowOrders := make(map[string][]string, len(fileSpecs))
-	for i, spec := range fileSpecs {
+	names := make([]string, len(s.specs))
+	rowOrders := make(map[string][]string, len(s.specs))
+	for i, spec := range s.specs {
 		names[i] = spec.name
 		rowOrders[spec.name] = spec.rowOrder
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
@@ -146,7 +146,7 @@ var fileSpecs = func() []fileSpec {
 // holding the setup rows and each leg's driver metrics. It is built per run,
 // since the row set is the --types × --target-rps ladder the flags asked for.
 //
-// The labels are the results converter's contract, not a presentation choice:
+// The labels are the results converter's contract:
 //
 //   - Every CSV in the run dir other than driver.csv is a query type, named by
 //     its basename.
@@ -245,7 +245,7 @@ type csvSink struct {
 
 	// specs is the report schema this sink renders through: fileSpecs for an
 	// ingest run, querySpecs(...) for a query run, whose file and row set is the
-	// ladder the flags asked for rather than a fixed vocabulary. Read-only after
+	// --types × --target-rps ladder the flags asked for. Read-only after
 	// construction.
 	specs []fileSpec
 
@@ -494,12 +494,12 @@ func withUnknown[V any](order []string, m map[string]V) []string {
 
 // keepsZeroSamples reports whether a row keeps its zero-duration samples. These
 // rows are distributions, counts, or rates in which a zero is a real
-// observation — a ledger that committed on time, a request dispatched on time,
-// a leg that shed nothing, a leg that answered nothing — rather than a piece of
-// work too fast for the timer to see.
+// observation: a ledger that committed on time, a request dispatched on time, a
+// leg that shed nothing, a leg that answered nothing. Everywhere else a zero
+// means work too fast for the timer to see, which aggregate drops.
 //
-// The rule is a whole-label suffix rule shared by the ingest and query schemas,
-// so the ingest report's pace_lag is covered by the _lag suffix.
+// The rule matches whole label suffixes and is shared by the ingest and query
+// schemas: the ingest report's pace_lag is covered by the _lag suffix.
 func keepsZeroSamples(label string) bool {
 	return strings.HasSuffix(label, driverLegLagSuffix) ||
 		strings.HasSuffix(label, driverLegShedSuffix) ||
@@ -603,10 +603,10 @@ func (s *csvSink) logSummary(logger *supportlog.Entry) {
 	}
 }
 
-// logRow logs one aggregated row. Three driver rows hold a plain number in
-// their duration columns rather than a time — the run's peak RSS in bytes, a
+// logRow logs one aggregated row as a percentile line. Three driver rows carry
+// a plain number in their duration columns — the run's peak RSS in bytes, a
 // leg's achieved rate in thousandths of a request per second, and a leg's shed
-// count — so each is rendered as the number it holds.
+// count — so each of those is rendered as the number it holds.
 func logRow(logger *supportlog.Entry, fileName string, r row) {
 	switch {
 	case fileName != fileDriver:

--- a/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -142,24 +143,37 @@ var fileSpecs = func() []fileSpec {
 
 // querySpecs is the bench-query report schema for one run: one CSV per swept
 // query type, each holding a total_c<W> row per concurrency level, plus
-// driver.csv holding the fixture open, the per-cell wall-clocks
-// (<qtype>_c<W>), and the peak RSS. Unlike fileSpecs it is built per run, since
-// the row set is the --types × --query-concurrency sweep the flags asked for.
+// driver.csv holding the fixture open, the page-cache evictions, the per-cell
+// wall-clocks (<qtype>_c<W>), and the peak RSS. Unlike fileSpecs it is built per
+// run, since the row set is the --types × --query-concurrency sweep the flags
+// asked for.
 //
 // The labels are the results converter's contract, not a presentation choice:
 // it discovers the query types by globbing the run dir for CSVs other than
 // driver.csv, reads each cell from that type's total_c<W> row and the matching
 // <qtype>_c<W> driver row, and files every driver row WITHOUT a _c<W> suffix
-// (open, peak_rss_bytes) under "setup".
+// (open, evict, peak_rss_bytes) under "setup".
+//
+// txhash carries two more rows per concurrency level, found_c<W> and miss_c<W>,
+// splitting the same samples its total_c<W> row blends. The converter matches
+// total_c<W> alone, so the split is invisible to the site and exists for the CSV
+// and the log summary — see recordCell.
 func querySpecs(types []string, concurrency []int) []fileSpec {
 	specs := make([]fileSpec, 0, len(types)+1)
-	driverRows := make([]string, 0, len(types)*len(concurrency)+2)
-	driverRows = append(driverRows, driverQueryOpen)
+	driverRows := make([]string, 0, len(types)*len(concurrency)+3)
+	driverRows = append(driverRows, driverQueryOpen, driverQueryEvict)
 	for _, qtype := range types {
 		rows := make([]string, 0, len(concurrency))
 		for _, w := range concurrency {
 			rows = append(rows, queryCellRow(w))
 			driverRows = append(driverRows, queryDriverRow(qtype, w))
+		}
+		if qtype == queryTypeTxHash {
+			for _, stage := range []string{txHashStageFound, txHashStageMiss} {
+				for _, w := range concurrency {
+					rows = append(rows, stage+"_c"+strconv.Itoa(w))
+				}
+			}
 		}
 		specs = append(specs, fileSpec{name: qtype, rowOrder: rows})
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -141,38 +141,53 @@ var fileSpecs = func() []fileSpec {
 	)
 }()
 
-// querySpecs is the bench-query report schema for one run: one CSV per swept
-// query type, each holding a total_c<W> row per concurrency level, plus
-// driver.csv holding the fixture open, the page-cache evictions, the per-cell
-// wall-clocks (<qtype>_c<W>), and the peak RSS. Unlike fileSpecs it is built per
-// run, since the row set is the --types × --query-concurrency sweep the flags
-// asked for.
+// querySpecs is the bench-query report schema for one run: one CSV per query
+// type, each holding the latency rows of that type's legs, plus driver.csv
+// holding the setup rows and each leg's driver metrics. It is built per run,
+// since the row set is the --types × --target-rps ladder the flags asked for.
 //
 // The labels are the results converter's contract, not a presentation choice:
-// it discovers the query types by globbing the run dir for CSVs other than
-// driver.csv, reads each cell from that type's total_c<W> row and the matching
-// <qtype>_c<W> driver row, and files every driver row WITHOUT a _c<W> suffix
-// (open, evict, peak_rss_bytes) under "setup".
 //
-// txhash carries two more rows per concurrency level, found_c<W> and miss_c<W>,
-// splitting the same samples its total_c<W> row blends. The converter matches
-// total_c<W> alone, so the split is invisible to the site and exists for the CSV
-// and the log summary — see recordCell.
-func querySpecs(types []string, concurrency []int) []fileSpec {
+//   - Every CSV in the run dir other than driver.csv is a query type, named by
+//     its basename.
+//   - In a type's file, total_r<rate> is that leg's headline distribution — the
+//     scheduled latency of every measured request. service_r<rate>,
+//     found_r<rate>, and miss_r<rate> are side rows over the same requests.
+//   - In driver.csv, <qtype>_r<rate> with no further suffix is the leg's
+//     wall-clock. <qtype>_r<rate>_millirps, _lag, and _shed are that leg's
+//     driver metrics: the achieved rate times 1000, the dispatch-lag
+//     distribution, and the shed count.
+//   - A driver row with no _r<rate> segment (open, evict, peak_rss_bytes) is
+//     setup.
+//
+// txhash carries the found_r<rate> and miss_r<rate> rows, splitting the same
+// requests its total_r<rate> row blends. The converter matches total_r<rate>
+// alone, so the split is invisible to the site and exists for the CSV and the
+// log summary — see recordLeg.
+func querySpecs(types []string, rates []float64) []fileSpec {
 	specs := make([]fileSpec, 0, len(types)+1)
-	driverRows := make([]string, 0, len(types)*len(concurrency)+3)
+	legSuffixes := []string{driverLegRPSSuffix, driverLegLagSuffix, driverLegShedSuffix}
+	driverRows := make([]string, 0, len(types)*len(rates)*(len(legSuffixes)+1)+3)
 	driverRows = append(driverRows, driverQueryOpen, driverQueryEvict)
 	for _, qtype := range types {
-		rows := make([]string, 0, len(concurrency))
-		for _, w := range concurrency {
-			rows = append(rows, queryCellRow(w))
-			driverRows = append(driverRows, queryDriverRow(qtype, w))
+		rows := make([]string, 0, len(rates)*2)
+		for _, rps := range rates {
+			rows = append(rows, queryTotalRow(rps))
+		}
+		for _, rps := range rates {
+			rows = append(rows, queryServiceRow(rps))
 		}
 		if qtype == queryTypeTxHash {
 			for _, stage := range []string{txHashStageFound, txHashStageMiss} {
-				for _, w := range concurrency {
-					rows = append(rows, stage+"_c"+strconv.Itoa(w))
+				for _, rps := range rates {
+					rows = append(rows, queryStageRow(stage, rps))
 				}
+			}
+		}
+		for _, rps := range rates {
+			driverRows = append(driverRows, queryDriverRow(qtype, rps))
+			for _, suffix := range legSuffixes {
+				driverRows = append(driverRows, queryDriverLegRow(qtype, rps, suffix))
 			}
 		}
 		specs = append(specs, fileSpec{name: qtype, rowOrder: rows})
@@ -227,7 +242,7 @@ type csvSink struct {
 
 	// specs is the report schema this sink renders through: fileSpecs for an
 	// ingest run, querySpecs(...) for a query run, whose file and row set is the
-	// sweep the flags asked for rather than a fixed vocabulary. Read-only after
+	// ladder the flags asked for rather than a fixed vocabulary. Read-only after
 	// construction.
 	specs []fileSpec
 
@@ -424,9 +439,9 @@ type row struct {
 
 // aggregate reduces a series to a row, filtering out zero-duration samples so
 // work too fast for the timer (an empty ledger's stage) doesn't skew the
-// percentiles. For pace_lag, zeros are always included (they represent
-// on-time ledgers and are part of the lag distribution). ok is false when no
-// sample survives the filter — the row is suppressed.
+// percentiles. Rows whose zeros are real observations pass includeZeros and
+// keep them (see keepsZeroSamples). ok is false when no sample survives the
+// filter — the row is suppressed.
 func aggregate(name string, s *series, includeZeros bool) (row, bool) {
 	durs := make([]time.Duration, 0, len(s.samples))
 	items := 0
@@ -474,6 +489,16 @@ func withUnknown[V any](order []string, m map[string]V) []string {
 	return append(slices.Clone(order), extra...)
 }
 
+// keepsZeroSamples reports whether a row keeps its zero-duration samples. These
+// rows are distributions or counts in which a zero is a real observation — a
+// ledger that committed on time, a request dispatched on time, a leg that shed
+// nothing — rather than a piece of work too fast for the timer to see.
+func keepsZeroSamples(label string) bool {
+	return label == driverPaceLag ||
+		strings.HasSuffix(label, driverLegLagSuffix) ||
+		strings.HasSuffix(label, driverLegShedSuffix)
+}
+
 // file is one aggregated CSV file: its basename (without .csv) and its rows.
 type file struct {
 	name string
@@ -508,8 +533,7 @@ func (s *csvSink) files() []file {
 		var rows []row
 		for _, label := range withUnknown(rowOrders[name], byRow) {
 			if sr := byRow[label]; sr != nil {
-				// pace_lag is for paced runs; include zero-lag samples (on-time ledgers).
-				if r, ok := aggregate(label, sr, label == driverPaceLag); ok {
+				if r, ok := aggregate(label, sr, keepsZeroSamples(label)); ok {
 					rows = append(rows, r)
 				}
 			}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/csvsink_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/csvsink_test.go
@@ -290,8 +290,8 @@ func TestKeepsZeroSamples(t *testing.T) {
 		"pace_lag":            true,
 		"txhash_r300_lag":     true,
 		"events_r0.5_shed":    true,
+		"ledgers_r1_millirps": true,
 		"ledgers_r1":          false,
-		"ledgers_r1_millirps": false,
 		"open":                false,
 	} {
 		assert.Equal(t, want, keepsZeroSamples(label), "keepsZeroSamples(%q)", label)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/csvsink_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/csvsink_test.go
@@ -260,6 +260,44 @@ func TestCSVSinkPaceLagBelowFirstSeq(t *testing.T) {
 	assert.Empty(t, paceLagSamples(sink))
 }
 
+// TestCSVSinkKeepsZeroLagAndShedSamples pins the query bench's zero-keeping
+// rows against the ordinary filter: a leg's _lag and _shed rows survive with
+// nothing but zero durations, while a latency row whose only sample is zero is
+// still dropped as work too fast for the timer.
+func TestCSVSinkKeepsZeroLagAndShedSamples(t *testing.T) {
+	sink := newSchemaCSVSink(querySpecs([]string{queryTypeLedgers}, []float64{1}))
+	sink.observe(fileDriver, "ledgers_r1_lag", 0, 1)
+	sink.observe(fileDriver, "ledgers_r1_lag", 0, 1)
+	sink.observe(fileDriver, "ledgers_r1_shed", 0, 0)
+	sink.observe(queryTypeLedgers, "total_r1", 0, 1)
+
+	outDir := t.TempDir()
+	written, err := sink.writeCSVs(outDir)
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	driver := readCSV(t, filepath.Join(outDir, "driver.csv"))
+	require.Contains(t, driver, "ledgers_r1_lag")
+	assert.EqualValues(t, 2, driver["ledgers_r1_lag"]["n"])
+	require.Contains(t, driver, "ledgers_r1_shed")
+	assert.EqualValues(t, 1, driver["ledgers_r1_shed"]["n"])
+	assert.NoFileExists(t, filepath.Join(outDir, "ledgers.csv"))
+}
+
+// TestKeepsZeroSamples pins which rows keep their zero-duration samples.
+func TestKeepsZeroSamples(t *testing.T) {
+	for label, want := range map[string]bool{
+		"pace_lag":            true,
+		"txhash_r300_lag":     true,
+		"events_r0.5_shed":    true,
+		"ledgers_r1":          false,
+		"ledgers_r1_millirps": false,
+		"open":                false,
+	} {
+		assert.Equal(t, want, keepsZeroSamples(label), "keepsZeroSamples(%q)", label)
+	}
+}
+
 // mustWriteCSVs writes the sink's report to a temp dir and returns it.
 func mustWriteCSVs(t *testing.T, sink *csvSink) string {
 	t.Helper()

--- a/cmd/stellar-rpc/internal/rpcv2/bench/doc.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/doc.go
@@ -10,8 +10,8 @@
 // interfaces.
 //
 // A query run reads a dataset an ingest run left on disk. It rebuilds the
-// catalog state those artifacts imply, then sweeps the requested query types at
-// each requested reader concurrency through query.ReadView — the daemon's read
+// catalog state those artifacts imply, then issues the requested query types at
+// each requested arrival rate through query.ReadView — the daemon's read
 // facade, so routing resolves each chunk's tier exactly as a served request
 // does — and times each query itself.
 //

--- a/cmd/stellar-rpc/internal/rpcv2/bench/doc.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/doc.go
@@ -1,11 +1,20 @@
-// Package bench benchmarks full-history ingestion: the cold backfill that
-// bulk-materializes past ledgers at startup, and the hot loop that ingests the
-// live stream as it advances.
+// Package bench benchmarks full-history storage from both sides: writes
+// (bench-ingest) and reads (bench-query). Each side has a cold and a hot
+// subcommand, since the two tiers are different code paths with different
+// numbers.
 //
-// A run drives the daemon's production ingestion code over a
+// An ingest run drives the daemon's production ingestion code over a
 // benchmark-controlled ledger source and times it: cold calls
 // backfill.RunBackfill, hot calls the production ingestion loop. Both report
 // their per-stage timings through the MetricSink and observability.Metrics
-// interfaces; a csvSink implements those interfaces, collects the signals, and
-// aggregates each run into percentile CSV reports.
+// interfaces.
+//
+// A query run reads a dataset an ingest run left on disk. It rebuilds the
+// catalog state those artifacts imply, then sweeps the requested query types at
+// each requested reader concurrency through query.ReadView — the daemon's read
+// facade, so routing resolves each chunk's tier exactly as a served request
+// does — and times each query itself.
+//
+// Either way a csvSink collects the signals and aggregates the run into
+// percentile CSV reports, laid out by the schema that run declared.
 package bench

--- a/cmd/stellar-rpc/internal/rpcv2/bench/evict_linux.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/evict_linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package bench
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// evictSupported reports that this platform can drop a file's pages from the
+// OS page cache, so a cold measurement really starts cold.
+const evictSupported = true
+
+// evictFile drops path's pages from the OS page cache via
+// POSIX_FADV_DONTNEED. It opens a sidecar descriptor purely to have something
+// to advise on: fadvise targets the inode's page cache, not one descriptor, so
+// a reader already holding the file open is unaffected. Offset 0 and length 0
+// mean the whole file.
+//
+// The hint is reliable for clean file pages, which is what a frozen cold
+// artifact is — nothing in a query run dirties them.
+func evictFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_DONTNEED); err != nil {
+		return fmt.Errorf("fadvise dontneed %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/evict_linux.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/evict_linux.go
@@ -27,7 +27,8 @@ func evictFile(path string) error {
 		return fmt.Errorf("open %s: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
-	if err := unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_DONTNEED); err != nil {
+	fd := int(f.Fd()) //nolint:gosec // an open descriptor is a small non-negative number and fits an int
+	if err := unix.Fadvise(fd, 0, 0, unix.FADV_DONTNEED); err != nil {
 		return fmt.Errorf("fadvise dontneed %s: %w", path, err)
 	}
 	return nil

--- a/cmd/stellar-rpc/internal/rpcv2/bench/evict_other.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/evict_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package bench
+
+// evictSupported reports that this platform cannot drop a file's pages from the
+// OS page cache. POSIX_FADV_DONTNEED is not portable — macOS would need
+// F_NOCACHE through a different fcntl — and campaigns run on Linux, so the
+// other platforms get the no-op and a run there records eviction as
+// unsupported (see invocation.json's extra.pageCacheEviction).
+const evictSupported = false
+
+// evictFile does nothing off Linux, leaving the page cache warm. Returning nil
+// keeps a cross-platform build working; a cold benchmark run on such a platform
+// measures warm reads, which is why the run records that eviction did not
+// happen instead of implying it did.
+func evictFile(string) error { return nil }

--- a/cmd/stellar-rpc/internal/rpcv2/bench/hot.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/hot.go
@@ -107,7 +107,7 @@ func runHot(ctx context.Context, logger *supportlog.Entry, opts hotOptions) erro
 	if catalogBase == "" {
 		catalogBase = opts.HotRoot
 	}
-	cat, releaseCat, err := openScratchCatalog(catalogBase, layout, logger)
+	cat, releaseCat, err := openScratchCatalog(catalogBase, scratchPrefixIngest, layout, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/invocation.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/invocation.go
@@ -23,7 +23,9 @@ type invocationRecord struct {
 	Binary        binaryInfo        `json:"binary"`
 	Hostname      string            `json:"hostname"`
 	StartedAt     string            `json:"startedAt"`
-	FinishedAt    string            `json:"finishedAt"`
+	// FinishedAt is absent in the record written when the run starts, and
+	// carries the end time in the record written when it stops.
+	FinishedAt string `json:"finishedAt,omitempty"`
 	// Extra carries facts the run resolved for itself rather than read off a
 	// flag — whether page-cache eviction actually ran, for instance, which
 	// depends on the platform as well as the flag. Absent when the run recorded
@@ -41,10 +43,22 @@ type binaryInfo struct {
 	Branch         string `json:"branch"`
 }
 
-// writeInvocationJSON writes an invocation record as JSON to outDir/invocation.json.
-// startedAt and finishedAt should be UTC times. runErr is the run's outcome: nil
-// for a successful run, otherwise its message lands in the record's error field.
-// The JSON is formatted with indentation and a trailing newline.
+// writeStartInvocationJSON writes the record of a run that has just started:
+// the command, its flags, and the start time, with no finishedAt and no error.
+// A process killed outright still leaves in --out what it was asked to do. The
+// write at the end of the run overwrites the same file.
+func writeStartInvocationJSON(
+	outDir string, cmd *cobra.Command, flags, extra map[string]string, startedAt time.Time,
+) error {
+	return writeInvocationJSON(outDir, cmd, flags, extra, startedAt, time.Time{}, nil)
+}
+
+// writeInvocationJSON writes an invocation record as JSON to outDir/invocation.json,
+// replacing the file if it is already there. startedAt and finishedAt should be UTC
+// times; a zero finishedAt leaves the field out, which is how a run in progress
+// records itself. runErr is the run's outcome: nil for a successful run, otherwise
+// its message lands in the record's error field. The JSON is formatted with
+// indentation and a trailing newline.
 func writeInvocationJSON(
 	outDir string,
 	cmd *cobra.Command,
@@ -59,6 +73,11 @@ func writeInvocationJSON(
 		errMsg = runErr.Error()
 	}
 
+	var finished string
+	if !finishedAt.IsZero() {
+		finished = finishedAt.UTC().Format(time.RFC3339)
+	}
+
 	record := invocationRecord{
 		SchemaVersion: 1,
 		Command:       cmd.CommandPath(),
@@ -71,7 +90,7 @@ func writeInvocationJSON(
 		},
 		Hostname:   hostname,
 		StartedAt:  startedAt.UTC().Format(time.RFC3339),
-		FinishedAt: finishedAt.UTC().Format(time.RFC3339),
+		FinishedAt: finished,
 		Error:      errMsg,
 	}
 	if len(extra) > 0 {

--- a/cmd/stellar-rpc/internal/rpcv2/bench/invocation.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/invocation.go
@@ -24,6 +24,11 @@ type invocationRecord struct {
 	Hostname      string            `json:"hostname"`
 	StartedAt     string            `json:"startedAt"`
 	FinishedAt    string            `json:"finishedAt"`
+	// Extra carries facts the run resolved for itself rather than read off a
+	// flag — whether page-cache eviction actually ran, for instance, which
+	// depends on the platform as well as the flag. Absent when the run recorded
+	// none.
+	Extra map[string]string `json:"extra,omitempty"`
 	// Error carries a failed run's error message; absent on a successful run.
 	Error string `json:"error,omitempty"`
 }
@@ -43,7 +48,7 @@ type binaryInfo struct {
 func writeInvocationJSON(
 	outDir string,
 	cmd *cobra.Command,
-	flags map[string]string,
+	flags, extra map[string]string,
 	startedAt, finishedAt time.Time,
 	runErr error,
 ) error {
@@ -68,6 +73,9 @@ func writeInvocationJSON(
 		StartedAt:  startedAt.UTC().Format(time.RFC3339),
 		FinishedAt: finishedAt.UTC().Format(time.RFC3339),
 		Error:      errMsg,
+	}
+	if len(extra) > 0 {
+		record.Extra = extra
 	}
 
 	data, err := json.MarshalIndent(record, "", "  ")

--- a/cmd/stellar-rpc/internal/rpcv2/bench/invocation_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/invocation_test.go
@@ -66,7 +66,9 @@ func TestWriteInvocationJSON(t *testing.T) {
 	startedAt := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
 	finishedAt := time.Date(2026, 7, 21, 12, 5, 30, 0, time.UTC)
 
-	err := writeInvocationJSON(outDir, cmd, flags, startedAt, finishedAt, nil)
+	extra := map[string]string{"pageCacheEviction": "on"}
+
+	err := writeInvocationJSON(outDir, cmd, flags, extra, startedAt, finishedAt, nil)
 	require.NoError(t, err)
 
 	// Verify the file exists and is readable
@@ -88,6 +90,9 @@ func TestWriteInvocationJSON(t *testing.T) {
 	assert.Equal(t, "1000", record.Flags["start-chunk"])
 	assert.Contains(t, record.Flags, "num-chunks")
 	assert.Equal(t, "10", record.Flags["num-chunks"])
+
+	// The run's own facts land beside the flags, not among them.
+	assert.Equal(t, "on", record.Extra["pageCacheEviction"])
 
 	// Verify timestamps
 	assert.Equal(t, "2026-07-21T12:00:00Z", record.StartedAt)
@@ -114,7 +119,7 @@ func TestWriteInvocationJSONWithError(t *testing.T) {
 	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
 
 	runErr := errors.New("backfill [chunk 3, chunk 3]: boom")
-	require.NoError(t, writeInvocationJSON(outDir, cmd, nil, now, now, runErr))
+	require.NoError(t, writeInvocationJSON(outDir, cmd, nil, nil, now, now, runErr))
 
 	data, err := os.ReadFile(filepath.Join(outDir, "invocation.json"))
 	require.NoError(t, err)
@@ -123,6 +128,11 @@ func TestWriteInvocationJSONWithError(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &record))
 	assert.Equal(t, runErr.Error(), record.Error)
 	assert.Equal(t, 1, record.SchemaVersion)
+
+	// A run that recorded no facts of its own omits the key entirely.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.NotContains(t, raw, "extra")
 }
 
 // TestCaptureFlags verifies that captureFlags extracts all flag values from

--- a/cmd/stellar-rpc/internal/rpcv2/bench/invocation_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/invocation_test.go
@@ -47,6 +47,69 @@ func TestCommandRecordsFailedRun(t *testing.T) {
 	assert.NotEmpty(t, record.FinishedAt)
 }
 
+// TestCommandWritesInvocationBeforeTheRun drives bench-ingest hot with a source
+// its validation rejects, so the run returns before it would have created --out.
+// The record is there anyway, which only the write at the start of the run can
+// have produced.
+func TestCommandWritesInvocationBeforeTheRun(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "csv")
+
+	cmd := NewCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		"hot",
+		"--source", "bogus",
+		"--start-chunk", "0",
+		"--hot-dir", t.TempDir(),
+		"--out", outDir,
+	})
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "--source=bogus")
+
+	data, readErr := os.ReadFile(filepath.Join(outDir, "invocation.json"))
+	require.NoError(t, readErr)
+	var record invocationRecord
+	require.NoError(t, json.Unmarshal(data, &record))
+	assert.Equal(t, "bench-ingest hot", record.Command)
+	assert.Equal(t, "bogus", record.Flags["source"])
+	assert.NotEmpty(t, record.StartedAt)
+	// The run finished, so the second write replaced the start record with the
+	// outcome.
+	assert.Equal(t, err.Error(), record.Error)
+	assert.NotEmpty(t, record.FinishedAt)
+}
+
+// TestWriteStartInvocationJSON pins the record a run leaves the moment it
+// starts: the command, its flags and a start time, with no finishedAt and no
+// error key, so a reader can tell a run that never reached its end from one that
+// did.
+func TestWriteStartInvocationJSON(t *testing.T) {
+	outDir := t.TempDir()
+	parent := &cobra.Command{Use: "bench-query"}
+	cmd := &cobra.Command{Use: "cold"}
+	parent.AddCommand(cmd)
+
+	flags := map[string]string{"cold-dir": "/bench/ds", "types": "ledgers,txhash"}
+	startedAt := time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC)
+	require.NoError(t, writeStartInvocationJSON(outDir, cmd, flags, nil, startedAt))
+
+	data, err := os.ReadFile(filepath.Join(outDir, "invocation.json"))
+	require.NoError(t, err)
+
+	var record invocationRecord
+	require.NoError(t, json.Unmarshal(data, &record))
+	assert.Equal(t, 1, record.SchemaVersion)
+	assert.Equal(t, "bench-query cold", record.Command)
+	assert.Equal(t, "2026-08-28T09:00:00Z", record.StartedAt)
+	assert.Equal(t, "/bench/ds", record.Flags["cold-dir"])
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.NotContains(t, raw, "finishedAt")
+	assert.NotContains(t, raw, "error")
+}
+
 // TestWriteInvocationJSON verifies that writeInvocationJSON produces a valid
 // invocation.json file with the expected schema and content.
 func TestWriteInvocationJSON(t *testing.T) {

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query.go
@@ -392,9 +392,9 @@ func runQueryCell(
 func recordCell(sink *csvSink, qtype string, w int, res sweepResult) {
 	total := queryCellRow(w)
 	for _, s := range res.samples {
-		sink.observe(qtype, total, s.d, s.items)
+		sink.observe(qtype, total, s.service, s.items)
 		if s.stage != "" {
-			sink.observe(qtype, s.stage+"_c"+strconv.Itoa(w), s.d, s.items)
+			sink.observe(qtype, s.stage+"_c"+strconv.Itoa(w), s.service, s.items)
 		}
 	}
 	sink.observe(fileDriver, queryDriverRow(qtype, w), res.wall, len(res.samples))

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"slices"
 	"strconv"
@@ -57,22 +58,46 @@ const (
 //nolint:gochecknoglobals // fixed vocabulary, read-only
 var allQueryTypes = []string{queryTypeLedgers, queryTypeTxPage, queryTypeTxHash, queryTypeEvents}
 
-// Query report row labels. Each per-type CSV carries one total_c<W> row per
-// swept concurrency level — that cell's per-query distribution — and driver.csv
-// carries the matching <qtype>_c<W> cell wall-clock plus the fixture open.
+// Query report row labels. A row belonging to one leg carries an _r<rate>
+// segment holding that leg's target rate as --target-rps spelled it: a per-type
+// CSV names its latency rows total_r<rate> and service_r<rate>, and driver.csv
+// names one leg's rows <qtype>_r<rate> plus the three suffixed variants below.
+// A driver row with no _r<rate> segment belongs to the run's setup.
 const (
-	queryRowTotalPrefix = "total_c"
-	driverQueryOpen     = "open"  // fixture open: catalog, handles, first read view
-	driverQueryEvict    = "evict" // one page-cache eviction pass before a cold cell
+	queryRowTotalPrefix   = "total_r"
+	queryRowServicePrefix = "service_r"
+	driverLegRPSSuffix    = "_millirps"
+	driverLegLagSuffix    = "_lag"
+	driverLegShedSuffix   = "_shed"
+	driverQueryOpen       = "open"  // fixture open: catalog, handles, first read view
+	driverQueryEvict      = "evict" // one page-cache eviction pass before a cold leg
 )
 
-// queryCellRow is a per-type CSV's row label for concurrency level w.
-func queryCellRow(w int) string { return queryRowTotalPrefix + strconv.Itoa(w) }
+// formatRPS renders a target rate as its row label spells it: the shortest
+// decimal that reads back as the same rate, so 0.5 stays "0.5" and 300 stays
+// "300".
+func formatRPS(rps float64) string { return strconv.FormatFloat(rps, 'f', -1, 64) }
 
-// queryDriverRow is driver.csv's cell wall-clock row label for one query type
-// at concurrency level w.
-func queryDriverRow(qtype string, w int) string {
-	return qtype + "_c" + strconv.Itoa(w)
+// queryTotalRow is a per-type CSV's scheduled-latency row label for the leg at
+// rate rps.
+func queryTotalRow(rps float64) string { return queryRowTotalPrefix + formatRPS(rps) }
+
+// queryServiceRow is a per-type CSV's service-time row label for the leg at
+// rate rps.
+func queryServiceRow(rps float64) string { return queryRowServicePrefix + formatRPS(rps) }
+
+// queryStageRow is a per-type CSV's row label for one sub-stage of the leg at
+// rate rps.
+func queryStageRow(stage string, rps float64) string { return stage + "_r" + formatRPS(rps) }
+
+// queryDriverRow is driver.csv's wall-clock row label for one query type's leg
+// at rate rps.
+func queryDriverRow(qtype string, rps float64) string { return qtype + "_r" + formatRPS(rps) }
+
+// queryDriverLegRow is driver.csv's row label for one of a leg's driver
+// metrics: queryDriverRow's label plus the metric's suffix.
+func queryDriverLegRow(qtype string, rps float64, suffix string) string {
+	return queryDriverRow(qtype, rps) + suffix
 }
 
 // Defaults for the read-shape flags. The two span defaults are the v2 page caps
@@ -88,17 +113,26 @@ const (
 	defaultSeed         = 1
 )
 
-// queryFlags is the sweep flag set both bench-query subcommands share, beyond
-// the --out and profiling flags newBenchCommand binds. The spellings and value
-// formats of --types, --query-concurrency, --iters, and --warmup are the
-// campaign runner's argv contract; the read-shape flags after them are
-// bench-side only, so the runner's argv keeps working untouched.
+// Defaults for the two flags that shape a leg. defaultLegDuration is long
+// enough that a slow rate still schedules a useful number of requests and short
+// enough that a four-type ladder finishes in minutes; defaultTargetRPS is a
+// single modest rate, so a bare invocation runs one leg per type.
+const (
+	defaultLegDuration = 60 * time.Second
+	defaultTargetRPS   = "10"
+)
+
+// queryFlags is the flag set both bench-query subcommands share, beyond the
+// --out and profiling flags newBenchCommand binds. The spellings and value
+// formats of --types, --target-rps, --duration, and --warmup are the campaign
+// runner's argv contract; the read-shape flags after them are bench-side only,
+// so the runner's argv keeps working untouched.
 type queryFlags struct {
 	types       string
-	concurrency string
-	iters       int
+	targetRPS   string
+	duration    time.Duration
 	warmup      int
-	warmupBound bool // bind --warmup (hot only; a cold cell evicts instead of warming)
+	warmupBound bool // bind --warmup (hot only; a cold leg evicts instead of warming)
 
 	ledgersSpan  uint32
 	txPageSpan   uint32
@@ -112,13 +146,14 @@ type queryFlags struct {
 func (f *queryFlags) bind(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.StringVar(&f.types, "types", strings.Join(allQueryTypes, ","),
-		"comma-separated query types to sweep: "+strings.Join(allQueryTypes, " | "))
-	fs.StringVar(&f.concurrency, "query-concurrency", "1",
-		"comma-separated reader concurrency levels to sweep, e.g. 1,4,16")
-	fs.IntVar(&f.iters, "iters", f.iters, "measured queries per type per concurrency level")
+		"comma-separated query types to run: "+strings.Join(allQueryTypes, " | "))
+	fs.StringVar(&f.targetRPS, "target-rps", defaultTargetRPS,
+		"comma-separated arrival rates to run, in requests per second, e.g. 0.5,1,2")
+	fs.DurationVar(&f.duration, "duration", defaultLegDuration, "how long each --target-rps leg runs")
 	if f.warmupBound {
 		fs.IntVar(&f.warmup, "warmup", f.warmup,
-			"unmeasured queries per cell before the measured ones, warming the store's caches")
+			"unmeasured queries per leg, dispatched at the leg's rate before measurement starts, "+
+				"warming the store's caches")
 	}
 	fs.Uint32Var(&f.ledgersSpan, "ledgers-span", defaultLedgersSpan,
 		"ledgers one ledgers query scans (1 = a point read)")
@@ -138,13 +173,13 @@ func (f *queryFlags) bind(cmd *cobra.Command) {
 		"seed for the work each query picks, so a re-run reads the same ledgers")
 }
 
-// queryPlan is the validated sweep: which types, at which concurrency levels,
-// how many queries per cell, and the shape of each query.
+// queryPlan is the validated run: which types, at which arrival rates, how long
+// each leg runs, and the shape of each query.
 type queryPlan struct {
-	Types       []string
-	Concurrency []int
-	Iters       int
-	Warmup      int
+	Types     []string
+	TargetRPS []float64
+	Duration  time.Duration
+	Warmup    int
 
 	LedgersSpan  uint32
 	TxPageSpan   uint32
@@ -154,25 +189,25 @@ type queryPlan struct {
 	Passphrase   string
 	Seed         int64
 
-	// Evict drops the cold artifacts from the OS page cache before each cell's
-	// measured pass. Cold only: the hot tier's steady state is a warm cache, so
-	// its cells warm up instead.
+	// Evict drops the cold artifacts from the OS page cache before each leg's
+	// measured requests. Cold only: the hot tier's steady state is a warm cache,
+	// so its legs warm up instead.
 	Evict bool
 }
 
-// plan parses and validates the sweep flags.
+// plan parses and validates the flags.
 func (f *queryFlags) plan() (queryPlan, error) {
 	types, err := parseQueryTypes(f.types)
 	if err != nil {
 		return queryPlan{}, err
 	}
-	concurrency, err := parseConcurrency(f.concurrency)
+	rates, err := parseTargetRPS(f.targetRPS)
 	if err != nil {
 		return queryPlan{}, err
 	}
 	switch {
-	case f.iters < 1:
-		return queryPlan{}, fmt.Errorf("--iters must be >= 1, got %d", f.iters)
+	case f.duration <= 0:
+		return queryPlan{}, fmt.Errorf("--duration must be > 0, got %v", f.duration)
 	case f.warmup < 0:
 		return queryPlan{}, fmt.Errorf("--warmup must be >= 0, got %d", f.warmup)
 	case f.ledgersSpan < 1:
@@ -190,8 +225,8 @@ func (f *queryFlags) plan() (queryPlan, error) {
 	}
 	return queryPlan{
 		Types:        types,
-		Concurrency:  concurrency,
-		Iters:        f.iters,
+		TargetRPS:    rates,
+		Duration:     f.duration,
 		Warmup:       f.warmup,
 		LedgersSpan:  f.ledgersSpan,
 		TxPageSpan:   f.txPageSpan,
@@ -226,25 +261,31 @@ func parseQueryTypes(s string) ([]string, error) {
 	return types, nil
 }
 
-// parseConcurrency splits --query-concurrency into the reader counts to sweep,
-// rejecting an empty list, a non-integer, a level below 1, or a repeat.
-func parseConcurrency(s string) ([]int, error) {
+// parseTargetRPS splits --target-rps into the arrival rates to run, keeping the
+// caller's order and rejecting an empty list, an empty entry, a non-number, a
+// rate that is not positive and finite, or a repeat (a repeated rate would
+// collide on its CSV rows).
+func parseTargetRPS(s string) ([]float64, error) {
 	fields := strings.Split(s, ",")
-	levels := make([]int, 0, len(fields))
+	rates := make([]float64, 0, len(fields))
 	for _, f := range fields {
-		w, err := strconv.Atoi(strings.TrimSpace(f))
+		field := strings.TrimSpace(f)
+		if field == "" {
+			return nil, fmt.Errorf("--target-rps has an empty entry: %q", s)
+		}
+		rps, err := strconv.ParseFloat(field, 64)
 		if err != nil {
-			return nil, fmt.Errorf("--query-concurrency: %q is not a list of integers", s)
+			return nil, fmt.Errorf("--target-rps: %q is not a list of numbers", s)
 		}
-		if w < 1 {
-			return nil, fmt.Errorf("--query-concurrency levels must be >= 1, got %d", w)
+		if rps <= 0 || math.IsNaN(rps) || math.IsInf(rps, 0) {
+			return nil, fmt.Errorf("--target-rps rates must be > 0, got %v", rps)
 		}
-		if slices.Contains(levels, w) {
-			return nil, fmt.Errorf("--query-concurrency repeats %d", w)
+		if slices.Contains(rates, rps) {
+			return nil, fmt.Errorf("--target-rps repeats %v", rps)
 		}
-		levels = append(levels, w)
+		rates = append(rates, rps)
 	}
-	return levels, nil
+	return rates, nil
 }
 
 // queryFixture is the read side of one bench-query run, assembled over a
@@ -273,7 +314,7 @@ type queryFixture struct {
 	// database actually holds, narrowed further by --sample-ledgers.
 	FirstLedger, LastLedger uint32
 
-	// EvictPaths are the on-disk artifacts a cold cell drops from the page cache
+	// EvictPaths are the on-disk artifacts a cold leg drops from the page cache
 	// before it measures. Empty for a hot fixture, whose data lives in RocksDB's
 	// own caches rather than in files the bench can advise on.
 	EvictPaths []string
@@ -287,7 +328,7 @@ func (f *queryFixture) view() (*query.ReadView, error) {
 
 // verifyServes acquires a read view and resolves each benchmarked chunk's
 // ledger store, so a dataset that cannot be served fails at open with the
-// chunk named — not per-query, deep inside the sweep. It runs the real routing
+// chunk named — not per-query, deep inside a leg. It runs the real routing
 // (ReadView.Ledgers → resolveTier), which is also what makes it a check: the
 // fixture publishes state for one tier only.
 func (f *queryFixture) verifyServes() error {
@@ -305,9 +346,8 @@ func (f *queryFixture) verifyServes() error {
 }
 
 // evictColdArtifacts drops the fixture's cold artifacts from the OS page cache
-// and reports how many files it advised. Without it a cold cell after the first
-// reads what the previous cell just paged in, and the sweep would show a warming
-// curve rather than a concurrency curve.
+// and reports how many files it advised. Without it a leg after the first would
+// read what the previous leg paged in; with it every leg's numbers are cold.
 //
 // A file that cannot be opened is skipped rather than failing the run: the
 // artifact set is derived from the layout, so a kind the dataset never produced
@@ -326,13 +366,14 @@ func (f *queryFixture) evictColdArtifacts() (int, error) {
 	return evicted, nil
 }
 
-// runQuerySweep sweeps every requested type at every concurrency level against
-// the fixture, recording each cell's per-query distribution in the sink.
+// runQueryLegs runs every requested type at every requested rate against the
+// fixture, recording each leg's per-request distribution in the sink.
 //
-// A type's corpus is sampled once, before its first cell, and shared by every
-// concurrency level: re-sampling per level would make the levels read different
-// work and turn the concurrency curve into noise.
-func runQuerySweep(
+// A type's corpus is sampled once, before its first leg, and shared by every
+// rate: re-sampling per rate would make the legs read different work, so a
+// difference between two legs would be a difference in the work rather than in
+// the rate.
+func runQueryLegs(
 	ctx context.Context, logger *supportlog.Entry, f *queryFixture, p queryPlan, sink *csvSink,
 ) error {
 	for _, qtype := range p.Types {
@@ -340,9 +381,9 @@ func runQuerySweep(
 		if err != nil {
 			return fmt.Errorf("prepare the %s benchmark: %w", qtype, err)
 		}
-		for _, w := range p.Concurrency {
-			if err := runQueryCell(logger, f, p, sink, qtype, w, req); err != nil {
-				return fmt.Errorf("query %s at concurrency %d: %w", qtype, w, err)
+		for _, rps := range p.TargetRPS {
+			if err := runQueryLeg(ctx, logger, f, p, sink, qtype, rps, req); err != nil {
+				return fmt.Errorf("query %s at %s rps: %w", qtype, formatRPS(rps), err)
 			}
 			if err := ctx.Err(); err != nil {
 				return err
@@ -352,15 +393,15 @@ func runQuerySweep(
 	return nil
 }
 
-// runQueryCell runs one (type, concurrency) cell: page-cache eviction for a
-// cold run, then p.Warmup unmeasured requests and p.Iters measured ones on each
-// of w workers.
+// runQueryLeg runs one (type, rate) leg: page-cache eviction for a cold run,
+// then p.Warmup unmeasured requests and the leg's measured ones, all dispatched
+// at rps requests per second over p.Duration.
 //
-// The cell's seed mixes in the type so two types do not read the same ledgers in
+// The leg's seed mixes in the type so two types do not read the same ledgers in
 // the same order, which would let the second inherit the first's warm cache.
-func runQueryCell(
-	logger *supportlog.Entry, f *queryFixture, p queryPlan, sink *csvSink,
-	qtype string, w int, req queryRequest,
+func runQueryLeg(
+	ctx context.Context, logger *supportlog.Entry, f *queryFixture, p queryPlan, sink *csvSink,
+	qtype string, rps float64, req queryRequest,
 ) error {
 	if p.Evict {
 		start := time.Now()
@@ -370,40 +411,76 @@ func runQueryCell(
 		}
 		sink.observe(fileDriver, driverQueryEvict, time.Since(start), evicted)
 	}
-	logger.Infof("query %s at concurrency %d: %d iters, %d warmup", qtype, w, p.Iters, p.Warmup)
+	logger.Infof("query %s at %s rps for %s: %d measured requests, %d warmup",
+		qtype, formatRPS(rps), p.Duration, measuredRequests(rps, p.Duration), p.Warmup)
 
-	res := runSweep(w, p.Warmup, p.Iters, p.Seed+int64(len(qtype)), req)
-	if res.errs > 0 {
-		return fmt.Errorf("%d of %d requests failed", res.errs, w*p.Iters)
+	res, err := runPacedLeg(ctx, rps, p.Duration, p.Warmup, p.Seed+int64(len(qtype)), req)
+	if err != nil {
+		return err
 	}
-	recordCell(sink, qtype, w, res)
+	if res.errs > 0 {
+		return fmt.Errorf("%d of %d requests failed", res.errs, res.dispatched)
+	}
+	recordLeg(sink, qtype, rps, res)
 	return nil
 }
 
-// recordCell files one cell's samples into the report.
+// recordLeg files one leg's samples into the report.
 //
-// Every sample lands in the type's total_c<W> row — the blended cell the results
-// converter reads — and a sample carrying a sub-stage additionally lands in a
-// <stage>_c<W> row of the same file. The converter ignores those extra rows
-// (it matches total_c<W> alone), so they cost the site nothing and give the CSV
-// and the log summary the split that matters locally: txhash's found and
-// not-found lookups do different amounts of work, and a blended p99 cannot say
-// which of them moved.
-func recordCell(sink *csvSink, qtype string, w int, res sweepResult) {
-	total := queryCellRow(w)
+// In the type's own CSV every request lands in the total_r<rate> row — the
+// scheduled latency the results converter reads — and in the service_r<rate>
+// row, which holds the same requests' service times; a request carrying a
+// sub-stage lands in a <stage>_r<rate> row too. The converter matches
+// total_r<rate> alone, so the side rows cost the site nothing and give the CSV
+// and the log summary the splits that matter locally: what the store spent
+// against what a client waited, and txhash's found lookups against its
+// not-found ones, which do different amounts of work.
+//
+// driver.csv gets the leg's four driver rows. <qtype>_r<rate> is the leg wall.
+// The _millirps row's duration columns carry the achieved rate times 1000 as an
+// integer, the way peak_rss_bytes carries bytes. The _lag row holds one sample
+// per dispatched request, so it is the distribution of how far behind schedule
+// the dispatcher ran. The _shed row is written for every leg, so a leg that
+// shed nothing says so with a zero rather than by leaving the row out.
+func recordLeg(sink *csvSink, qtype string, rps float64, res legResult) {
+	total := queryTotalRow(rps)
+	service := queryServiceRow(rps)
 	for _, s := range res.samples {
-		sink.observe(qtype, total, s.service, s.items)
+		sink.observe(qtype, total, s.scheduled, s.items)
+		sink.observe(qtype, service, s.service, s.items)
 		if s.stage != "" {
-			sink.observe(qtype, s.stage+"_c"+strconv.Itoa(w), s.service, s.items)
+			sink.observe(qtype, queryStageRow(s.stage, rps), s.scheduled, s.items)
 		}
 	}
-	sink.observe(fileDriver, queryDriverRow(qtype, w), res.wall, len(res.samples))
+
+	answered := len(res.samples)
+	sink.observe(fileDriver, queryDriverRow(qtype, rps), res.wall, answered)
+	sink.observe(fileDriver, queryDriverLegRow(qtype, rps, driverLegRPSSuffix),
+		achievedMilliRPS(answered, res.wall), answered)
+	for _, lag := range res.lags {
+		sink.observe(fileDriver, queryDriverLegRow(qtype, rps, driverLegLagSuffix), lag, 1)
+	}
+	sink.observe(fileDriver, queryDriverLegRow(qtype, rps, driverLegShedSuffix), 0, res.shed)
+}
+
+// milliPerUnit is the scale the _millirps row stores an achieved rate at, so a
+// fractional rate survives an integer CSV column.
+const milliPerUnit = 1000
+
+// achievedMilliRPS returns the rate answered requests were served at over wall,
+// scaled by milliPerUnit and carried as a duration so it fits the CSV's
+// duration columns. A leg with no wall to divide by reports zero.
+func achievedMilliRPS(answered int, wall time.Duration) time.Duration {
+	if wall <= 0 {
+		return 0
+	}
+	return time.Duration(math.Round(float64(answered) / wall.Seconds() * milliPerUnit))
 }
 
 // runQueryBench is the body both bench-query subcommands share: prepare --out,
-// open the tier's fixture (timing the open into driver.csv), sweep, and report.
-// A failed sweep still writes the partial report and the peak RSS, so the setup
-// rows and whatever cells completed survive.
+// open the tier's fixture (timing the open into driver.csv), run the legs, and
+// report. A failed run still writes the partial report and the peak RSS, so the
+// setup rows and whatever legs completed survive.
 func runQueryBench(
 	ctx context.Context, logger *supportlog.Entry, p queryPlan, outDir string,
 	open func() (*queryFixture, func(), error),
@@ -412,7 +489,7 @@ func runQueryBench(
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return fmt.Errorf("create --out dir %s: %w", outDir, err)
 	}
-	sink := newSchemaCSVSink(querySpecs(p.Types, p.Concurrency))
+	sink := newSchemaCSVSink(querySpecs(p.Types, p.TargetRPS))
 
 	start := time.Now()
 	f, release, err := open()
@@ -423,7 +500,7 @@ func runQueryBench(
 	sink.observe(fileDriver, driverQueryOpen, time.Since(start), len(f.Chunks))
 	logger.Infof("serving ledgers [%d, %d] over %d chunk(s)", f.FirstLedger, f.LastLedger, len(f.Chunks))
 
-	err = runQuerySweep(ctx, logger, f, p, sink)
+	err = runQueryLegs(ctx, logger, f, p, sink)
 	// VmHWM never decreases, so it can be read before the error check and a
 	// failed run's partial CSV still gets the row.
 	recordPeakRSS(logger, sink, readPeakRSS)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query.go
@@ -100,15 +100,17 @@ func queryDriverLegRow(qtype string, rps float64, suffix string) string {
 	return queryDriverRow(qtype, rps) + suffix
 }
 
-// Defaults for the read-shape flags. The two span defaults are the v2 page caps
-// for their endpoints, so a default run reads what a client asks for; the miss
+// Defaults for the read-shape flags. The ledgers span and the events limit are
+// the request shapes fixed by the team SLA (getLedgers max=10; getEvents small
+// page, 10 matches), so a default run measures the shapes the SLA rows quote;
+// the txpage span and limit are the v2 page caps for that endpoint; the miss
 // fraction matches the share of by-hash lookups a production node sees asking
 // for a hash that never landed.
 const (
-	defaultLedgersSpan  = 20
+	defaultLedgersSpan  = 10
 	defaultTxPageSpan   = 5
 	defaultTxPageLimit  = 200
-	defaultEventsLimit  = 100
+	defaultEventsLimit  = 10
 	defaultMissFraction = 0.12
 	defaultSeed         = 1
 )

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query.go
@@ -1,0 +1,316 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
+)
+
+// NewQueryCommand returns the `bench-query` command tree: `cold` benchmarks
+// reads served from frozen artifacts, `hot` reads served from a hot chunk
+// database. Both measure through query.ReadView — the stable read seam — so a
+// store-reader refactor moves the numbers without moving the benchmark.
+func NewQueryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bench-query",
+		Short: "Benchmark full-history reads",
+	}
+	cmd.AddCommand(newQueryColdCommand(), newQueryHotCommand())
+	return cmd
+}
+
+// The query types --types selects, in the order the report lists them. Each
+// names one read path through query.ReadView, and each is also a report CSV
+// basename (see querySpecs).
+const (
+	// queryTypeLedgers: point reads and fixed-length range scans over
+	// ReadView.ScanLedgers — getLedgers' path.
+	queryTypeLedgers = "ledgers"
+	// queryTypeTxPage: the paged ledger walk getTransactions performs,
+	// extracting each ledger's transactions in sequence.
+	queryTypeTxPage = "txpage"
+	// queryTypeTxHash: the full by-hash lookup getTransaction performs — hot
+	// indexes first, then the frozen window indexes with the MPHF candidate
+	// verified against the ledger. Never an index probe alone.
+	queryTypeTxHash = "txhash"
+	// queryTypeEvents: ReadView.QueryEvents over a filter set derived from the
+	// benchmarked chunk.
+	queryTypeEvents = "events"
+)
+
+// allQueryTypes is every type --types accepts, in report order. It is also the
+// list the campaign runner passes verbatim.
+//
+//nolint:gochecknoglobals // fixed vocabulary, read-only
+var allQueryTypes = []string{queryTypeLedgers, queryTypeTxPage, queryTypeTxHash, queryTypeEvents}
+
+// Query report row labels. Each per-type CSV carries one total_c<W> row per
+// swept concurrency level — that cell's per-query distribution — and driver.csv
+// carries the matching <qtype>_c<W> cell wall-clock plus the fixture open.
+const (
+	queryRowTotalPrefix = "total_c"
+	driverQueryOpen     = "open" // fixture open: catalog, handles, first read view
+)
+
+// queryCellRow is a per-type CSV's row label for concurrency level w.
+func queryCellRow(w int) string { return queryRowTotalPrefix + strconv.Itoa(w) }
+
+// queryDriverRow is driver.csv's cell wall-clock row label for one query type
+// at concurrency level w.
+func queryDriverRow(qtype string, w int) string {
+	return qtype + "_c" + strconv.Itoa(w)
+}
+
+// errQueryTypeUnimplemented is what a sweep cell returns until #856 B2 fills in
+// the per-type bodies. It is deliberately loud: a run reaches it only after the
+// flag surface, the fixture, and the report schema have all been exercised, and
+// the PARTIAL report it leaves behind carries the setup rows.
+var errQueryTypeUnimplemented = errors.New("query bench body not implemented")
+
+// queryFlags is the sweep flag set both bench-query subcommands share, beyond
+// the --out and profiling flags newBenchCommand binds. The spellings and value
+// formats are the campaign runner's argv contract: --types is a comma-separated
+// type list, --query-concurrency a comma-separated reader-count list.
+type queryFlags struct {
+	types       string
+	concurrency string
+	iters       int
+	warmup      int
+	warmupBound bool // bind --warmup (hot only; a cold cell evicts instead of warming)
+}
+
+func (f *queryFlags) bind(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.StringVar(&f.types, "types", strings.Join(allQueryTypes, ","),
+		"comma-separated query types to sweep: "+strings.Join(allQueryTypes, " | "))
+	fs.StringVar(&f.concurrency, "query-concurrency", "1",
+		"comma-separated reader concurrency levels to sweep, e.g. 1,4,16")
+	fs.IntVar(&f.iters, "iters", f.iters, "measured queries per type per concurrency level")
+	if f.warmupBound {
+		fs.IntVar(&f.warmup, "warmup", f.warmup,
+			"unmeasured queries per cell before the measured ones, warming the store's caches")
+	}
+}
+
+// queryPlan is the validated sweep: which types, at which concurrency levels,
+// for how many queries per cell.
+type queryPlan struct {
+	Types       []string
+	Concurrency []int
+	Iters       int
+	Warmup      int
+}
+
+// plan parses and validates the sweep flags.
+func (f *queryFlags) plan() (queryPlan, error) {
+	types, err := parseQueryTypes(f.types)
+	if err != nil {
+		return queryPlan{}, err
+	}
+	concurrency, err := parseConcurrency(f.concurrency)
+	if err != nil {
+		return queryPlan{}, err
+	}
+	if f.iters < 1 {
+		return queryPlan{}, fmt.Errorf("--iters must be >= 1, got %d", f.iters)
+	}
+	if f.warmup < 0 {
+		return queryPlan{}, fmt.Errorf("--warmup must be >= 0, got %d", f.warmup)
+	}
+	return queryPlan{Types: types, Concurrency: concurrency, Iters: f.iters, Warmup: f.warmup}, nil
+}
+
+// parseQueryTypes splits --types, keeping the caller's order and rejecting an
+// empty list, an unknown type, or a repeat (a repeated type would collide on
+// its CSV rows).
+func parseQueryTypes(s string) ([]string, error) {
+	fields := strings.Split(s, ",")
+	types := make([]string, 0, len(fields))
+	for _, f := range fields {
+		qtype := strings.TrimSpace(f)
+		if qtype == "" {
+			return nil, fmt.Errorf("--types has an empty entry: %q", s)
+		}
+		if !slices.Contains(allQueryTypes, qtype) {
+			return nil, fmt.Errorf("--types: unknown query type %q (want %s)",
+				qtype, strings.Join(allQueryTypes, " | "))
+		}
+		if slices.Contains(types, qtype) {
+			return nil, fmt.Errorf("--types repeats %q", qtype)
+		}
+		types = append(types, qtype)
+	}
+	return types, nil
+}
+
+// parseConcurrency splits --query-concurrency into the reader counts to sweep,
+// rejecting an empty list, a non-integer, a level below 1, or a repeat.
+func parseConcurrency(s string) ([]int, error) {
+	fields := strings.Split(s, ",")
+	levels := make([]int, 0, len(fields))
+	for _, f := range fields {
+		w, err := strconv.Atoi(strings.TrimSpace(f))
+		if err != nil {
+			return nil, fmt.Errorf("--query-concurrency: %q is not a list of integers", s)
+		}
+		if w < 1 {
+			return nil, fmt.Errorf("--query-concurrency levels must be >= 1, got %d", w)
+		}
+		if slices.Contains(levels, w) {
+			return nil, fmt.Errorf("--query-concurrency repeats %d", w)
+		}
+		levels = append(levels, w)
+	}
+	return levels, nil
+}
+
+// queryFixture is the read side of one bench-query run, assembled over a
+// dataset an earlier bench-ingest run left on disk: the scratch catalog whose
+// keys make that dataset servable, the registry holding the hot handles, and
+// the ledger range the per-type corpora may sample from.
+//
+// Both tiers build one so the measured code path is the daemon's: every query
+// takes a read view, and every read view resolves its tier through
+// ReadView.resolveTier. Neither fixture can serve the other's tier — the cold
+// one publishes no hot handle, the hot one freezes no artifact — so a resolve
+// that succeeds proves the intended tier served it.
+type queryFixture struct {
+	registry *query.Registry
+
+	// Chunks is the benchmarked chunk range, ascending.
+	Chunks []chunk.ID
+
+	// FirstLedger and LastLedger bound the ledgers the corpora may sample:
+	// the chunk range's span for a cold fixture, and for a hot one what the hot
+	// database actually holds, narrowed further by --sample-ledgers.
+	FirstLedger, LastLedger uint32
+}
+
+// view acquires one read view. Every measured query takes its own, as a served
+// request does; the caller MUST Release it.
+func (f *queryFixture) view() (*query.ReadView, error) {
+	return f.registry.NewReadView()
+}
+
+// verifyServes acquires a read view and resolves each benchmarked chunk's
+// ledger store, so a dataset that cannot be served fails at open with the
+// chunk named — not per-query, deep inside the sweep. It runs the real routing
+// (ReadView.Ledgers → resolveTier), which is also what makes it a check: the
+// fixture publishes state for one tier only.
+func (f *queryFixture) verifyServes() error {
+	view, err := f.view()
+	if err != nil {
+		return fmt.Errorf("acquire read view: %w", err)
+	}
+	defer view.Release()
+	for _, c := range f.Chunks {
+		if _, err := view.Ledgers(c); err != nil {
+			return fmt.Errorf("chunk %s has no servable ledger store: %w", c, err)
+		}
+	}
+	return nil
+}
+
+// runQuerySweep sweeps every requested type at every concurrency level against
+// the fixture, recording each cell's per-query distribution in the sink.
+//
+// The per-type bodies and the concurrency worker pool are #856 B2: each cell
+// currently returns errQueryTypeUnimplemented naming its type, so a run proves
+// out the flag surface, the fixture open, and the report schema, then writes a
+// PARTIAL report holding the setup rows.
+func runQuerySweep(
+	ctx context.Context, logger *supportlog.Entry, f *queryFixture, p queryPlan, sink *csvSink,
+) error {
+	for _, qtype := range p.Types {
+		for _, w := range p.Concurrency {
+			logger.Infof("query %s at concurrency %d: %d iters (warmup %d)", qtype, w, p.Iters, p.Warmup)
+			if err := runQueryCell(ctx, f, p, sink, qtype, w); err != nil {
+				return fmt.Errorf("query %s at concurrency %d: %w", qtype, w, err)
+			}
+		}
+	}
+	return nil
+}
+
+// runQueryCell runs one (type, concurrency) cell: p.Warmup unmeasured queries
+// then p.Iters measured ones, recording each query as a total_c<W> sample in
+// the type's CSV and the cell's wall-clock as driver.csv's <qtype>_c<W> row.
+//
+// #856 B2 fills in the bodies against the ReadView seams — ScanLedgers for
+// ledgers and txpage, the read_assembly lookup for txhash, QueryEvents for
+// events — plus the worker pool that gives a level above 1 its readers, and the
+// page-cache eviction a cold cell runs first.
+func runQueryCell(
+	_ context.Context, _ *queryFixture, _ queryPlan, _ *csvSink, qtype string, _ int,
+) error {
+	switch qtype {
+	case queryTypeLedgers, queryTypeTxPage, queryTypeTxHash, queryTypeEvents:
+		return fmt.Errorf("%w: %s", errQueryTypeUnimplemented, qtype)
+	default:
+		// Unreachable: parseQueryTypes rejects anything else.
+		return fmt.Errorf("unknown query type %q", qtype)
+	}
+}
+
+// runQueryBench is the body both bench-query subcommands share: prepare --out,
+// open the tier's fixture (timing the open into driver.csv), sweep, and report.
+// A failed sweep still writes the partial report and the peak RSS, so the setup
+// rows and whatever cells completed survive.
+func runQueryBench(
+	ctx context.Context, logger *supportlog.Entry, p queryPlan, outDir string,
+	open func() (*queryFixture, func(), error),
+) error {
+	// Surface an unwritable --out before opening the dataset.
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create --out dir %s: %w", outDir, err)
+	}
+	sink := newSchemaCSVSink(querySpecs(p.Types, p.Concurrency))
+
+	start := time.Now()
+	f, release, err := open()
+	if err != nil {
+		return err
+	}
+	defer release()
+	sink.observe(fileDriver, driverQueryOpen, time.Since(start), len(f.Chunks))
+	logger.Infof("serving ledgers [%d, %d] over %d chunk(s)", f.FirstLedger, f.LastLedger, len(f.Chunks))
+
+	err = runQuerySweep(ctx, logger, f, p, sink)
+	// VmHWM never decreases, so it can be read before the error check and a
+	// failed run's partial CSV still gets the row.
+	recordPeakRSS(logger, sink, readPeakRSS)
+	if err != nil {
+		writePartialCSVs(logger, sink, outDir)
+		return err
+	}
+
+	sink.logSummary(logger)
+	written, err := sink.writeCSVs(outDir)
+	if err != nil {
+		return err
+	}
+	logger.Infof("wrote %d CSVs to %s", len(written), outDir)
+	return nil
+}
+
+// chunkRange returns the ascending chunk IDs in [start, start+num). The caller's
+// validate() proved start+num-1 stays within maxChunkID.
+func chunkRange(start chunk.ID, num int) []chunk.ID {
+	chunks := make([]chunk.ID, 0, num)
+	for i := range uint32(num) { //nolint:gosec // num >= 1, bounded by validate()
+		chunks = append(chunks, start+chunk.ID(i))
+	}
+	return chunks
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query.go
@@ -122,9 +122,9 @@ const (
 	defaultTargetRPS   = "10"
 )
 
-// maxTargetRPS is the highest arrival rate --target-rps accepts. Above it a leg
-// schedules more arrivals than one dispatch loop can issue, so the leg would
-// report the loop's own speed rather than the store's.
+// maxTargetRPS is the highest arrival rate --target-rps accepts: the ceiling at
+// which the single dispatch loop that issues a leg's arrivals can still keep to
+// its schedule. A leg above it measures the loop's own speed.
 const maxTargetRPS = 1_000_000
 
 // minLegSamples is the number of measured requests below which a leg's
@@ -135,14 +135,14 @@ const minLegSamples = 100
 // queryFlags is the flag set both bench-query subcommands share, beyond the
 // --out and profiling flags newBenchCommand binds. The spellings and value
 // formats of --types, --target-rps, --duration, and --warmup are the campaign
-// runner's argv contract; the read-shape flags after them are bench-side only,
-// so the runner's argv keeps working untouched.
+// runner's argv contract; the read-shape flags after them are bench-side only
+// and outside that contract.
 type queryFlags struct {
 	types       string
 	targetRPS   string
 	duration    time.Duration
 	warmup      int
-	warmupBound bool // bind --warmup (hot only; a cold leg evicts instead of warming)
+	warmupBound bool // bind --warmup (hot only; a cold leg evicts its page cache)
 
 	ledgersSpan  uint32
 	txPageSpan   uint32
@@ -201,7 +201,7 @@ type queryPlan struct {
 
 	// Evict drops the cold artifacts from the OS page cache before each leg's
 	// measured requests. Cold only: the hot tier's steady state is a warm cache,
-	// so its legs warm up instead.
+	// so its legs warm one up first.
 	Evict bool
 }
 
@@ -249,8 +249,8 @@ func (f *queryFlags) plan() (queryPlan, error) {
 }
 
 // parseQueryTypes splits --types, keeping the caller's order and rejecting an
-// empty list, an unknown type, or a repeat (a repeated type would collide on
-// its CSV rows).
+// empty list, an unknown type, or a repeat (a type names its own CSV file, so
+// it may appear once).
 func parseQueryTypes(s string) ([]string, error) {
 	fields := strings.Split(s, ",")
 	types := make([]string, 0, len(fields))
@@ -273,8 +273,8 @@ func parseQueryTypes(s string) ([]string, error) {
 
 // parseTargetRPS splits --target-rps into the arrival rates to run, keeping the
 // caller's order and rejecting an empty list, an empty entry, a non-number, a
-// rate that is not positive and finite, a rate above maxTargetRPS, or a repeat
-// (a repeated rate would collide on its CSV rows).
+// rate that is zero, negative, NaN or infinite, a rate above maxTargetRPS, or a
+// repeat (a rate names its leg's CSV rows, so it may appear once).
 func parseTargetRPS(s string) ([]float64, error) {
 	fields := strings.Split(s, ",")
 	rates := make([]float64, 0, len(fields))
@@ -329,7 +329,7 @@ type queryFixture struct {
 
 	// EvictPaths are the on-disk artifacts a cold leg drops from the page cache
 	// before it measures. Empty for a hot fixture, whose data lives in RocksDB's
-	// own caches rather than in files the bench can advise on.
+	// own caches, which the bench cannot advise the kernel about.
 	EvictPaths []string
 }
 
@@ -340,10 +340,9 @@ func (f *queryFixture) view() (*query.ReadView, error) {
 }
 
 // verifyServes acquires a read view and resolves each benchmarked chunk's
-// ledger store, so a dataset that cannot be served fails at open with the
-// chunk named — not per-query, deep inside a leg. It runs the real routing
-// (ReadView.Ledgers → resolveTier), which is also what makes it a check: the
-// fixture publishes state for one tier only.
+// ledger store, so a dataset that cannot be served fails at open, with the
+// chunk named. It runs the real routing (ReadView.Ledgers → resolveTier), which
+// is also what makes it a check: the fixture publishes state for one tier only.
 func (f *queryFixture) verifyServes() error {
 	view, err := f.view()
 	if err != nil {
@@ -359,12 +358,12 @@ func (f *queryFixture) verifyServes() error {
 }
 
 // evictColdArtifacts drops the fixture's cold artifacts from the OS page cache
-// and reports how many files it advised. Without it a leg after the first would
-// read what the previous leg paged in; with it every leg's numbers are cold.
+// and reports how many files it advised. It runs before every leg, so each leg
+// reads from disk and its numbers are cold.
 //
-// A file that cannot be opened is skipped rather than failing the run: the
-// artifact set is derived from the layout, so a kind the dataset never produced
-// is a legitimate absence.
+// A file that cannot be opened is skipped and the run continues: the artifact
+// set is derived from the layout, so a kind the dataset never produced is a
+// legitimate absence.
 func (f *queryFixture) evictColdArtifacts() (int, error) {
 	evicted := 0
 	for _, path := range f.EvictPaths {
@@ -383,9 +382,8 @@ func (f *queryFixture) evictColdArtifacts() (int, error) {
 // fixture, recording each leg's per-request distribution in the sink.
 //
 // A type's corpus is sampled once, before its first leg, and shared by every
-// rate: re-sampling per rate would make the legs read different work, so a
-// difference between two legs would be a difference in the work rather than in
-// the rate.
+// rate, so the legs of one type all read the same work and what separates two
+// of them is the rate.
 func runQueryLegs(
 	ctx context.Context, logger *supportlog.Entry, f *queryFixture, p queryPlan, sink *csvSink,
 ) error {
@@ -410,8 +408,8 @@ func runQueryLegs(
 // then p.Warmup unmeasured requests and the leg's measured ones, all dispatched
 // at rps requests per second over p.Duration.
 //
-// The leg's seed mixes in the type so two types do not read the same ledgers in
-// the same order, which would let the second inherit the first's warm cache.
+// The leg's seed mixes in the type, so two types read different ledgers in
+// different orders and neither inherits the other's warm cache.
 func runQueryLeg(
 	ctx context.Context, logger *supportlog.Entry, f *queryFixture, p queryPlan, sink *csvSink,
 	qtype string, rps float64, req queryRequest,
@@ -459,12 +457,11 @@ func runQueryLeg(
 // which runs to the last request's completion and so covers the leg's drain
 // tail. The _millirps row's duration columns carry the achieved rate times 1000
 // as an integer, the way peak_rss_bytes carries bytes; it is the answered
-// requests over the window the leg offered, so the drain tail shows in the
-// latency rows and in the wall row rather than in the rate. The _lag row holds
-// one sample per measured position, shed positions included, so it is the
-// distribution of how far behind schedule the dispatcher ran. The _shed row is
-// written for every leg, so a leg that shed nothing says so with a zero rather
-// than by leaving the row out.
+// requests over the window the leg offered, and the wall row carries the drain
+// tail. The _lag row holds one sample per measured position, shed positions
+// included, so it is the distribution of how far behind schedule the dispatcher
+// ran. The _shed row is written for every leg, so a leg that shed nothing
+// reports a zero.
 func recordLeg(sink *csvSink, qtype string, rps float64, res legResult) {
 	total := queryTotalRow(rps)
 	service := queryServiceRow(rps)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stellar/go-stellar-sdk/network"
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 )
 
@@ -61,7 +63,8 @@ var allQueryTypes = []string{queryTypeLedgers, queryTypeTxPage, queryTypeTxHash,
 // carries the matching <qtype>_c<W> cell wall-clock plus the fixture open.
 const (
 	queryRowTotalPrefix = "total_c"
-	driverQueryOpen     = "open" // fixture open: catalog, handles, first read view
+	driverQueryOpen     = "open"  // fixture open: catalog, handles, first read view
+	driverQueryEvict    = "evict" // one page-cache eviction pass before a cold cell
 )
 
 // queryCellRow is a per-type CSV's row label for concurrency level w.
@@ -73,22 +76,38 @@ func queryDriverRow(qtype string, w int) string {
 	return qtype + "_c" + strconv.Itoa(w)
 }
 
-// errQueryTypeUnimplemented is what a sweep cell returns until #856 B2 fills in
-// the per-type bodies. It is deliberately loud: a run reaches it only after the
-// flag surface, the fixture, and the report schema have all been exercised, and
-// the PARTIAL report it leaves behind carries the setup rows.
-var errQueryTypeUnimplemented = errors.New("query bench body not implemented")
+// Defaults for the read-shape flags. The two span defaults are the v2 page caps
+// for their endpoints, so a default run reads what a client asks for; the miss
+// fraction matches the share of by-hash lookups a production node sees asking
+// for a hash that never landed.
+const (
+	defaultLedgersSpan  = 20
+	defaultTxPageSpan   = 5
+	defaultTxPageLimit  = 200
+	defaultEventsLimit  = 100
+	defaultMissFraction = 0.12
+	defaultSeed         = 1
+)
 
 // queryFlags is the sweep flag set both bench-query subcommands share, beyond
 // the --out and profiling flags newBenchCommand binds. The spellings and value
-// formats are the campaign runner's argv contract: --types is a comma-separated
-// type list, --query-concurrency a comma-separated reader-count list.
+// formats of --types, --query-concurrency, --iters, and --warmup are the
+// campaign runner's argv contract; the read-shape flags after them are
+// bench-side only, so the runner's argv keeps working untouched.
 type queryFlags struct {
 	types       string
 	concurrency string
 	iters       int
 	warmup      int
 	warmupBound bool // bind --warmup (hot only; a cold cell evicts instead of warming)
+
+	ledgersSpan  uint32
+	txPageSpan   uint32
+	txPageLimit  int
+	eventsLimit  int
+	missFraction float64
+	passphrase   string
+	seed         int64
 }
 
 func (f *queryFlags) bind(cmd *cobra.Command) {
@@ -102,15 +121,44 @@ func (f *queryFlags) bind(cmd *cobra.Command) {
 		fs.IntVar(&f.warmup, "warmup", f.warmup,
 			"unmeasured queries per cell before the measured ones, warming the store's caches")
 	}
+	fs.Uint32Var(&f.ledgersSpan, "ledgers-span", defaultLedgersSpan,
+		"ledgers one ledgers query scans (1 = a point read)")
+	fs.Uint32Var(&f.txPageSpan, "txpage-span", defaultTxPageSpan,
+		"ledgers one txpage query walks")
+	fs.IntVar(&f.txPageLimit, "txpage-limit", defaultTxPageLimit,
+		"transactions one txpage query materializes before it stops, as a page cap")
+	fs.IntVar(&f.eventsLimit, "events-limit", defaultEventsLimit,
+		"events one events page may return")
+	fs.Float64Var(&f.missFraction, "miss-fraction", defaultMissFraction,
+		"share of txhash lookups asking for a hash that never landed, in [0, 1] "+
+			"(a miss probes every index, so it is the path's worst case)")
+	fs.StringVar(&f.passphrase, "network-passphrase", network.PublicNetworkPassphrase,
+		"network passphrase the dataset's transactions were signed under; txhash and "+
+			"txpage need it to pair envelopes, and a wrong one fails the corpus build")
+	fs.Int64Var(&f.seed, "seed", defaultSeed,
+		"seed for the work each query picks, so a re-run reads the same ledgers")
 }
 
 // queryPlan is the validated sweep: which types, at which concurrency levels,
-// for how many queries per cell.
+// how many queries per cell, and the shape of each query.
 type queryPlan struct {
 	Types       []string
 	Concurrency []int
 	Iters       int
 	Warmup      int
+
+	LedgersSpan  uint32
+	TxPageSpan   uint32
+	TxPageLimit  int
+	EventsLimit  int
+	MissFraction float64
+	Passphrase   string
+	Seed         int64
+
+	// Evict drops the cold artifacts from the OS page cache before each cell's
+	// measured pass. Cold only: the hot tier's steady state is a warm cache, so
+	// its cells warm up instead.
+	Evict bool
 }
 
 // plan parses and validates the sweep flags.
@@ -123,13 +171,37 @@ func (f *queryFlags) plan() (queryPlan, error) {
 	if err != nil {
 		return queryPlan{}, err
 	}
-	if f.iters < 1 {
+	switch {
+	case f.iters < 1:
 		return queryPlan{}, fmt.Errorf("--iters must be >= 1, got %d", f.iters)
-	}
-	if f.warmup < 0 {
+	case f.warmup < 0:
 		return queryPlan{}, fmt.Errorf("--warmup must be >= 0, got %d", f.warmup)
+	case f.ledgersSpan < 1:
+		return queryPlan{}, fmt.Errorf("--ledgers-span must be >= 1, got %d", f.ledgersSpan)
+	case f.txPageSpan < 1:
+		return queryPlan{}, fmt.Errorf("--txpage-span must be >= 1, got %d", f.txPageSpan)
+	case f.txPageLimit < 1:
+		return queryPlan{}, fmt.Errorf("--txpage-limit must be >= 1, got %d", f.txPageLimit)
+	case f.eventsLimit < 1:
+		return queryPlan{}, fmt.Errorf("--events-limit must be >= 1, got %d", f.eventsLimit)
+	case f.missFraction < 0 || f.missFraction > 1:
+		return queryPlan{}, fmt.Errorf("--miss-fraction must be in [0, 1], got %v", f.missFraction)
+	case f.passphrase == "":
+		return queryPlan{}, errors.New("--network-passphrase is required")
 	}
-	return queryPlan{Types: types, Concurrency: concurrency, Iters: f.iters, Warmup: f.warmup}, nil
+	return queryPlan{
+		Types:        types,
+		Concurrency:  concurrency,
+		Iters:        f.iters,
+		Warmup:       f.warmup,
+		LedgersSpan:  f.ledgersSpan,
+		TxPageSpan:   f.txPageSpan,
+		TxPageLimit:  f.txPageLimit,
+		EventsLimit:  f.eventsLimit,
+		MissFraction: f.missFraction,
+		Passphrase:   f.passphrase,
+		Seed:         f.seed,
+	}, nil
 }
 
 // parseQueryTypes splits --types, keeping the caller's order and rejecting an
@@ -189,6 +261,21 @@ func parseConcurrency(s string) ([]int, error) {
 type queryFixture struct {
 	registry *query.Registry
 
+	// Logger reports what the fixture cannot return — a cold tx-hash index that
+	// failed to close after a request used it, for instance.
+	Logger *supportlog.Entry
+
+	// Layout resolves the dataset's paths. The by-hash benchmark needs it to
+	// open the frozen window indexes, and a cold run to evict them; both are
+	// jobs the read facade will own once its cold index accessor lands (see
+	// queryFixture.coldTxIndexes).
+	Layout geometry.Layout
+
+	// Passphrase is the network the dataset's transactions were signed under.
+	// Materializing a transaction pairs its envelope by hash, so txpage and
+	// txhash both need it and a wrong one makes every lookup a miss.
+	Passphrase string
+
 	// Chunks is the benchmarked chunk range, ascending.
 	Chunks []chunk.ID
 
@@ -196,6 +283,11 @@ type queryFixture struct {
 	// the chunk range's span for a cold fixture, and for a hot one what the hot
 	// database actually holds, narrowed further by --sample-ledgers.
 	FirstLedger, LastLedger uint32
+
+	// EvictPaths are the on-disk artifacts a cold cell drops from the page cache
+	// before it measures. Empty for a hot fixture, whose data lives in RocksDB's
+	// own caches rather than in files the bench can advise on.
+	EvictPaths []string
 }
 
 // view acquires one read view. Every measured query takes its own, as a served
@@ -223,45 +315,100 @@ func (f *queryFixture) verifyServes() error {
 	return nil
 }
 
+// evictColdArtifacts drops the fixture's cold artifacts from the OS page cache
+// and reports how many files it advised. Without it a cold cell after the first
+// reads what the previous cell just paged in, and the sweep would show a warming
+// curve rather than a concurrency curve.
+//
+// A file that cannot be opened is skipped rather than failing the run: the
+// artifact set is derived from the layout, so a kind the dataset never produced
+// is a legitimate absence.
+func (f *queryFixture) evictColdArtifacts() (int, error) {
+	evicted := 0
+	for _, path := range f.EvictPaths {
+		if err := evictFile(path); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return evicted, fmt.Errorf("evict %s from the page cache: %w", path, err)
+		}
+		evicted++
+	}
+	return evicted, nil
+}
+
 // runQuerySweep sweeps every requested type at every concurrency level against
 // the fixture, recording each cell's per-query distribution in the sink.
 //
-// The per-type bodies and the concurrency worker pool are #856 B2: each cell
-// currently returns errQueryTypeUnimplemented naming its type, so a run proves
-// out the flag surface, the fixture open, and the report schema, then writes a
-// PARTIAL report holding the setup rows.
+// A type's corpus is sampled once, before its first cell, and shared by every
+// concurrency level: re-sampling per level would make the levels read different
+// work and turn the concurrency curve into noise.
 func runQuerySweep(
 	ctx context.Context, logger *supportlog.Entry, f *queryFixture, p queryPlan, sink *csvSink,
 ) error {
 	for _, qtype := range p.Types {
+		req, err := newQueryRequest(ctx, logger, f, p, qtype)
+		if err != nil {
+			return fmt.Errorf("prepare the %s benchmark: %w", qtype, err)
+		}
 		for _, w := range p.Concurrency {
-			logger.Infof("query %s at concurrency %d: %d iters (warmup %d)", qtype, w, p.Iters, p.Warmup)
-			if err := runQueryCell(ctx, f, p, sink, qtype, w); err != nil {
+			if err := runQueryCell(logger, f, p, sink, qtype, w, req); err != nil {
 				return fmt.Errorf("query %s at concurrency %d: %w", qtype, w, err)
+			}
+			if err := ctx.Err(); err != nil {
+				return err
 			}
 		}
 	}
 	return nil
 }
 
-// runQueryCell runs one (type, concurrency) cell: p.Warmup unmeasured queries
-// then p.Iters measured ones, recording each query as a total_c<W> sample in
-// the type's CSV and the cell's wall-clock as driver.csv's <qtype>_c<W> row.
+// runQueryCell runs one (type, concurrency) cell: page-cache eviction for a
+// cold run, then p.Warmup unmeasured requests and p.Iters measured ones on each
+// of w workers.
 //
-// #856 B2 fills in the bodies against the ReadView seams — ScanLedgers for
-// ledgers and txpage, the read_assembly lookup for txhash, QueryEvents for
-// events — plus the worker pool that gives a level above 1 its readers, and the
-// page-cache eviction a cold cell runs first.
+// The cell's seed mixes in the type so two types do not read the same ledgers in
+// the same order, which would let the second inherit the first's warm cache.
 func runQueryCell(
-	_ context.Context, _ *queryFixture, _ queryPlan, _ *csvSink, qtype string, _ int,
+	logger *supportlog.Entry, f *queryFixture, p queryPlan, sink *csvSink,
+	qtype string, w int, req queryRequest,
 ) error {
-	switch qtype {
-	case queryTypeLedgers, queryTypeTxPage, queryTypeTxHash, queryTypeEvents:
-		return fmt.Errorf("%w: %s", errQueryTypeUnimplemented, qtype)
-	default:
-		// Unreachable: parseQueryTypes rejects anything else.
-		return fmt.Errorf("unknown query type %q", qtype)
+	if p.Evict {
+		start := time.Now()
+		evicted, err := f.evictColdArtifacts()
+		if err != nil {
+			return err
+		}
+		sink.observe(fileDriver, driverQueryEvict, time.Since(start), evicted)
 	}
+	logger.Infof("query %s at concurrency %d: %d iters, %d warmup", qtype, w, p.Iters, p.Warmup)
+
+	res := runSweep(w, p.Warmup, p.Iters, p.Seed+int64(len(qtype)), req)
+	if res.errs > 0 {
+		return fmt.Errorf("%d of %d requests failed", res.errs, w*p.Iters)
+	}
+	recordCell(sink, qtype, w, res)
+	return nil
+}
+
+// recordCell files one cell's samples into the report.
+//
+// Every sample lands in the type's total_c<W> row — the blended cell the results
+// converter reads — and a sample carrying a sub-stage additionally lands in a
+// <stage>_c<W> row of the same file. The converter ignores those extra rows
+// (it matches total_c<W> alone), so they cost the site nothing and give the CSV
+// and the log summary the split that matters locally: txhash's found and
+// not-found lookups do different amounts of work, and a blended p99 cannot say
+// which of them moved.
+func recordCell(sink *csvSink, qtype string, w int, res sweepResult) {
+	total := queryCellRow(w)
+	for _, s := range res.samples {
+		sink.observe(qtype, total, s.d, s.items)
+		if s.stage != "" {
+			sink.observe(qtype, s.stage+"_c"+strconv.Itoa(w), s.d, s.items)
+		}
+	}
+	sink.observe(fileDriver, queryDriverRow(qtype, w), res.wall, len(res.samples))
 }
 
 // runQueryBench is the body both bench-query subcommands share: prepare --out,

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query.go
@@ -122,6 +122,16 @@ const (
 	defaultTargetRPS   = "10"
 )
 
+// maxTargetRPS is the highest arrival rate --target-rps accepts. Above it a leg
+// schedules more arrivals than one dispatch loop can issue, so the leg would
+// report the loop's own speed rather than the store's.
+const maxTargetRPS = 1_000_000
+
+// minLegSamples is the number of measured requests below which a leg's
+// percentiles are reported with a warning: a p99 over fewer samples than this
+// is one or two requests wide.
+const minLegSamples = 100
+
 // queryFlags is the flag set both bench-query subcommands share, beyond the
 // --out and profiling flags newBenchCommand binds. The spellings and value
 // formats of --types, --target-rps, --duration, and --warmup are the campaign
@@ -263,8 +273,8 @@ func parseQueryTypes(s string) ([]string, error) {
 
 // parseTargetRPS splits --target-rps into the arrival rates to run, keeping the
 // caller's order and rejecting an empty list, an empty entry, a non-number, a
-// rate that is not positive and finite, or a repeat (a repeated rate would
-// collide on its CSV rows).
+// rate that is not positive and finite, a rate above maxTargetRPS, or a repeat
+// (a repeated rate would collide on its CSV rows).
 func parseTargetRPS(s string) ([]float64, error) {
 	fields := strings.Split(s, ",")
 	rates := make([]float64, 0, len(fields))
@@ -279,6 +289,9 @@ func parseTargetRPS(s string) ([]float64, error) {
 		}
 		if rps <= 0 || math.IsNaN(rps) || math.IsInf(rps, 0) {
 			return nil, fmt.Errorf("--target-rps rates must be > 0, got %v", rps)
+		}
+		if rps > maxTargetRPS {
+			return nil, fmt.Errorf("--target-rps rates must be <= %v, got %v", float64(maxTargetRPS), rps)
 		}
 		if slices.Contains(rates, rps) {
 			return nil, fmt.Errorf("--target-rps repeats %v", rps)
@@ -411,8 +424,14 @@ func runQueryLeg(
 		}
 		sink.observe(fileDriver, driverQueryEvict, time.Since(start), evicted)
 	}
+	measured := measuredRequests(rps, p.Duration)
 	logger.Infof("query %s at %s rps for %s: %d measured requests, %d warmup",
-		qtype, formatRPS(rps), p.Duration, measuredRequests(rps, p.Duration), p.Warmup)
+		qtype, formatRPS(rps), p.Duration, measured, p.Warmup)
+	if measured < minLegSamples {
+		logger.Warnf("query %s at %s rps measures %d requests: its percentiles rest on fewer than "+
+			"%d samples, so a longer --duration makes them steadier",
+			qtype, formatRPS(rps), measured, minLegSamples)
+	}
 
 	res, err := runPacedLeg(ctx, rps, p.Duration, p.Warmup, p.Seed+int64(len(qtype)), req)
 	if err != nil {
@@ -436,12 +455,16 @@ func runQueryLeg(
 // against what a client waited, and txhash's found lookups against its
 // not-found ones, which do different amounts of work.
 //
-// driver.csv gets the leg's four driver rows. <qtype>_r<rate> is the leg wall.
-// The _millirps row's duration columns carry the achieved rate times 1000 as an
-// integer, the way peak_rss_bytes carries bytes. The _lag row holds one sample
-// per dispatched request, so it is the distribution of how far behind schedule
-// the dispatcher ran. The _shed row is written for every leg, so a leg that
-// shed nothing says so with a zero rather than by leaving the row out.
+// driver.csv gets the leg's four driver rows. <qtype>_r<rate> is the leg wall,
+// which runs to the last request's completion and so covers the leg's drain
+// tail. The _millirps row's duration columns carry the achieved rate times 1000
+// as an integer, the way peak_rss_bytes carries bytes; it is the answered
+// requests over the window the leg offered, so the drain tail shows in the
+// latency rows and in the wall row rather than in the rate. The _lag row holds
+// one sample per measured position, shed positions included, so it is the
+// distribution of how far behind schedule the dispatcher ran. The _shed row is
+// written for every leg, so a leg that shed nothing says so with a zero rather
+// than by leaving the row out.
 func recordLeg(sink *csvSink, qtype string, rps float64, res legResult) {
 	total := queryTotalRow(rps)
 	service := queryServiceRow(rps)
@@ -456,7 +479,7 @@ func recordLeg(sink *csvSink, qtype string, rps float64, res legResult) {
 	answered := len(res.samples)
 	sink.observe(fileDriver, queryDriverRow(qtype, rps), res.wall, answered)
 	sink.observe(fileDriver, queryDriverLegRow(qtype, rps, driverLegRPSSuffix),
-		achievedMilliRPS(answered, res.wall), answered)
+		achievedMilliRPS(answered, res.offered), answered)
 	for _, lag := range res.lags {
 		sink.observe(fileDriver, queryDriverLegRow(qtype, rps, driverLegLagSuffix), lag, 1)
 	}
@@ -467,14 +490,15 @@ func recordLeg(sink *csvSink, qtype string, rps float64, res legResult) {
 // fractional rate survives an integer CSV column.
 const milliPerUnit = 1000
 
-// achievedMilliRPS returns the rate answered requests were served at over wall,
-// scaled by milliPerUnit and carried as a duration so it fits the CSV's
-// duration columns. A leg with no wall to divide by reports zero.
-func achievedMilliRPS(answered int, wall time.Duration) time.Duration {
-	if wall <= 0 {
+// achievedMilliRPS returns the rate answered requests were served at over the
+// window the leg offered, scaled by milliPerUnit and carried as a duration so
+// it fits the CSV's duration columns. A leg with no offered window to divide by
+// reports zero.
+func achievedMilliRPS(answered int, offered time.Duration) time.Duration {
+	if offered <= 0 {
 		return 0
 	}
-	return time.Duration(math.Round(float64(answered) / wall.Seconds() * milliPerUnit))
+	return time.Duration(math.Round(float64(answered) / offered.Seconds() * milliPerUnit))
 }
 
 // runQueryBench is the body both bench-query subcommands share: prepare --out,

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query.go
@@ -16,7 +16,6 @@ import (
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 )
 
@@ -260,16 +259,6 @@ func parseConcurrency(s string) ([]int, error) {
 // that succeeds proves the intended tier served it.
 type queryFixture struct {
 	registry *query.Registry
-
-	// Logger reports what the fixture cannot return — a cold tx-hash index that
-	// failed to close after a request used it, for instance.
-	Logger *supportlog.Entry
-
-	// Layout resolves the dataset's paths. The by-hash benchmark needs it to
-	// open the frozen window indexes, and a cold run to evict them; both are
-	// jobs the read facade will own once its cold index accessor lands (see
-	// queryFixture.coldTxIndexes).
-	Layout geometry.Layout
 
 	// Passphrase is the network the dataset's transactions were signed under.
 	// Materializing a transaction pairs its envelope by hash, so txpage and

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
@@ -192,8 +192,8 @@ func openColdFixture(logger *supportlog.Entry, opts coldQueryOptions) (*queryFix
 
 // coldArtifactPaths lists every file the benchmarked chunks are served from —
 // each chunk's artifacts plus the frozen tx-hash window indexes — so a cold leg
-// can drop them from the page cache. It reads the catalog rather than the disk,
-// so it names exactly what routing will open.
+// can drop them from the page cache. The list comes from the catalog, so it
+// names exactly what routing will open.
 func coldArtifactPaths(cat *catalog.Catalog, layout geometry.Layout, chunks []chunk.ID) []string {
 	var paths []string
 	for _, c := range chunks {
@@ -274,9 +274,9 @@ func kindList(kinds []geometry.Kind) string {
 // production order does: a terminal coverage demotes the per-chunk .bin keys it
 // supersedes.
 //
-// An absent index is not an error — a shallow dataset whose backfill built no
-// index is a real state, and the txhash leg reports the empty probe set rather
-// than the open failing for the three types that do not need it.
+// An absent index is a real state — a shallow dataset's backfill builds none —
+// so the open succeeds, the txhash leg reports an empty probe set, and the
+// three types that do not need the index run as usual.
 func commitDiskTxHashIndex(
 	logger *supportlog.Entry, cat *catalog.Catalog, layout geometry.Layout, lo, hi chunk.ID,
 ) error {

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
@@ -19,13 +19,9 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 )
 
-// defaultColdIters is --iters' default for a cold cell. Cold queries are the
-// slow tier, so the default is the smaller of the two.
-const defaultColdIters = 100
-
 func newQueryColdCommand() *cobra.Command {
 	var (
-		qf         = queryFlags{iters: defaultColdIters}
+		qf         = queryFlags{}
 		prof       profileFlags
 		startChunk uint32
 		numChunks  int
@@ -56,7 +52,7 @@ func newQueryColdCommand() *cobra.Command {
 	fs.StringVar(&coldDir, "cold-dir", "",
 		"root of the frozen artifact tree to query, as bench-ingest cold's --cold-out-dir laid it out (required)")
 	fs.BoolVar(&evict, "evict-page-cache", true,
-		"drop the cold artifacts from the OS page cache before each cell, so a cold read is really cold "+
+		"drop the cold artifacts from the OS page cache before each leg, so a cold read is really cold "+
 			"(Linux only; elsewhere the run records that it did not happen)")
 	markRequired(cmd, "start-chunk", "cold-dir")
 	return cmd
@@ -91,7 +87,7 @@ type coldQueryOptions struct {
 	StartChunk chunk.ID
 	NumChunks  int
 
-	// Plan is the validated --types × --query-concurrency sweep.
+	// Plan is the validated --types × --target-rps ladder.
 	Plan queryPlan
 
 	// OutDir receives the CSV report.
@@ -195,7 +191,7 @@ func openColdFixture(logger *supportlog.Entry, opts coldQueryOptions) (*queryFix
 }
 
 // coldArtifactPaths lists every file the benchmarked chunks are served from —
-// each chunk's artifacts plus the frozen tx-hash window indexes — so a cold cell
+// each chunk's artifacts plus the frozen tx-hash window indexes — so a cold leg
 // can drop them from the page cache. It reads the catalog rather than the disk,
 // so it names exactly what routing will open.
 func coldArtifactPaths(cat *catalog.Catalog, layout geometry.Layout, chunks []chunk.ID) []string {
@@ -279,7 +275,7 @@ func kindList(kinds []geometry.Kind) string {
 // supersedes.
 //
 // An absent index is not an error — a shallow dataset whose backfill built no
-// index is a real state, and the txhash cell reports the empty probe set rather
+// index is a real state, and the txhash leg reports the empty probe set rather
 // than the open failing for the three types that do not need it.
 func commitDiskTxHashIndex(
 	logger *supportlog.Entry, cat *catalog.Catalog, layout geometry.Layout, lo, hi chunk.ID,

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
@@ -178,11 +178,9 @@ func openColdFixture(logger *supportlog.Entry, opts coldQueryOptions) (*queryFix
 	}
 
 	registry := query.NewRegistry(cat, geometry.NewRetention(0, opts.StartChunk))
-	registry.SetLatestLedger(end.LastLedger())
+	registry.SetLatestLedger(end.LastLedger(), 0)
 	f := &queryFixture{
 		registry:    registry,
-		Logger:      logger,
-		Layout:      layout,
 		Passphrase:  opts.Plan.Passphrase,
 		Chunks:      chunks,
 		FirstLedger: opts.StartChunk.FirstLedger(),

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
@@ -30,21 +30,24 @@ func newQueryColdCommand() *cobra.Command {
 		startChunk uint32
 		numChunks  int
 		coldDir    string
+		evict      bool
 	)
 	cmd := newBenchCommand("cold",
 		"Benchmark cold reads: queries served from a chunk range's frozen artifacts",
 		&prof,
-		func(ctx context.Context, logger *supportlog.Entry, outDir string) error {
+		func(ctx context.Context, logger *supportlog.Entry, env runEnv) error {
 			plan, err := qf.plan()
 			if err != nil {
 				return err
 			}
+			plan.Evict = evict
+			env.Extra["pageCacheEviction"] = evictionState(evict)
 			return runQueryCold(ctx, logger, coldQueryOptions{
 				ColdRoot:   coldDir,
 				StartChunk: chunk.ID(startChunk),
 				NumChunks:  numChunks,
 				Plan:       plan,
-				OutDir:     outDir,
+				OutDir:     env.OutDir,
 			})
 		}, &qf)
 	fs := cmd.Flags()
@@ -52,8 +55,26 @@ func newQueryColdCommand() *cobra.Command {
 	fs.IntVar(&numChunks, "num-chunks", 1, "how many consecutive chunks to query starting at --start-chunk")
 	fs.StringVar(&coldDir, "cold-dir", "",
 		"root of the frozen artifact tree to query, as bench-ingest cold's --cold-out-dir laid it out (required)")
+	fs.BoolVar(&evict, "evict-page-cache", true,
+		"drop the cold artifacts from the OS page cache before each cell, so a cold read is really cold "+
+			"(Linux only; elsewhere the run records that it did not happen)")
 	markRequired(cmd, "start-chunk", "cold-dir")
 	return cmd
+}
+
+// evictionState is what invocation.json records about page-cache eviction: what
+// was asked for, and — since the syscall exists only on Linux — whether this
+// platform could honor it. A cold number measured without eviction is a warm
+// number, so that distinction has to reach the results.
+func evictionState(requested bool) string {
+	switch {
+	case !requested:
+		return "off"
+	case evictSupported:
+		return "on"
+	default:
+		return "unsupported-on-this-platform"
+	}
 }
 
 // coldQueryOptions configures one cold read benchmark run.
@@ -160,15 +181,46 @@ func openColdFixture(logger *supportlog.Entry, opts coldQueryOptions) (*queryFix
 	registry.SetLatestLedger(end.LastLedger())
 	f := &queryFixture{
 		registry:    registry,
+		Logger:      logger,
+		Layout:      layout,
+		Passphrase:  opts.Plan.Passphrase,
 		Chunks:      chunks,
 		FirstLedger: opts.StartChunk.FirstLedger(),
 		LastLedger:  end.LastLedger(),
+		EvictPaths:  coldArtifactPaths(cat, layout, chunks),
 	}
 	if err := f.verifyServes(); err != nil {
 		release()
 		return nil, nil, err
 	}
 	return f, release, nil
+}
+
+// coldArtifactPaths lists every file the benchmarked chunks are served from —
+// each chunk's artifacts plus the frozen tx-hash window indexes — so a cold cell
+// can drop them from the page cache. It reads the catalog rather than the disk,
+// so it names exactly what routing will open.
+func coldArtifactPaths(cat *catalog.Catalog, layout geometry.Layout, chunks []chunk.ID) []string {
+	var paths []string
+	for _, c := range chunks {
+		for _, kind := range geometry.AllKinds() {
+			state, err := cat.State(c, kind)
+			if err != nil || state != geometry.StateFrozen {
+				continue
+			}
+			paths = append(paths, layout.ArtifactPaths(c, kind)...)
+		}
+	}
+	covs, err := cat.AllTxHashIndexKeys()
+	if err != nil {
+		return paths
+	}
+	for _, cov := range covs {
+		if cov.State == geometry.StateFrozen {
+			paths = append(paths, layout.TxHashIndexFilePath(cov))
+		}
+	}
+	return paths
 }
 
 // freezeChunks runs the freeze bracket over each chunk for the artifact kinds

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
@@ -162,7 +162,8 @@ func openColdFixture(logger *supportlog.Entry, opts coldQueryOptions) (*queryFix
 		release()
 		return nil, nil, err
 	}
-	if err := commitDiskTxHashIndex(logger, cat, layout, opts.StartChunk, end); err != nil {
+	txHashRequested := slices.Contains(opts.Plan.Types, queryTypeTxHash)
+	if err := commitDiskTxHashIndex(logger, cat, layout, opts.StartChunk, end, txHashRequested); err != nil {
 		release()
 		return nil, nil, err
 	}
@@ -274,11 +275,15 @@ func kindList(kinds []geometry.Kind) string {
 // production order does: a terminal coverage demotes the per-chunk .bin keys it
 // supersedes.
 //
-// An absent index is a real state — a shallow dataset's backfill builds none —
-// so the open succeeds, the txhash leg reports an empty probe set, and the
-// three types that do not need the index run as usual.
+// An absent index is a real state — a shallow dataset's backfill builds none.
+// txHashRequested says whether this run needs one: with the txhash type in
+// --types every by-hash lookup would fail once the legs started, so the open
+// fails here instead, naming the range and the directory the index is expected
+// in. Without it the open succeeds with a warning, and the three types that do
+// not read the index run as usual.
 func commitDiskTxHashIndex(
 	logger *supportlog.Entry, cat *catalog.Catalog, layout geometry.Layout, lo, hi chunk.ID,
+	txHashRequested bool,
 ) error {
 	txLayout := cat.TxHashIndexLayout()
 	cov, ok, err := diskTxHashCoverage(layout, txLayout, lo, hi)
@@ -286,6 +291,13 @@ func commitDiskTxHashIndex(
 		return err
 	}
 	if !ok {
+		if txHashRequested {
+			return fmt.Errorf(
+				"no tx-hash window index on disk covers chunks [%s, %s], and --types includes %s: "+
+					"expected an .idx file spanning that range in %s; ingest the range with a cold run that "+
+					"builds the index, or drop %s from --types",
+				lo, hi, queryTypeTxHash, layout.TxHashIndexDir(txLayout.TxHashIndexID(lo)), queryTypeTxHash)
+		}
 		logger.Warnf("no tx-hash window index on disk covers chunks [%s, %s]: cold by-hash lookups have nothing to probe",
 			lo, hi)
 		return nil

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
@@ -1,0 +1,323 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/catalog"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
+)
+
+// defaultColdIters is --iters' default for a cold cell. Cold queries are the
+// slow tier, so the default is the smaller of the two.
+const defaultColdIters = 100
+
+func newQueryColdCommand() *cobra.Command {
+	var (
+		qf         = queryFlags{iters: defaultColdIters}
+		prof       profileFlags
+		startChunk uint32
+		numChunks  int
+		coldDir    string
+	)
+	cmd := newBenchCommand("cold",
+		"Benchmark cold reads: queries served from a chunk range's frozen artifacts",
+		&prof,
+		func(ctx context.Context, logger *supportlog.Entry, outDir string) error {
+			plan, err := qf.plan()
+			if err != nil {
+				return err
+			}
+			return runQueryCold(ctx, logger, coldQueryOptions{
+				ColdRoot:   coldDir,
+				StartChunk: chunk.ID(startChunk),
+				NumChunks:  numChunks,
+				Plan:       plan,
+				OutDir:     outDir,
+			})
+		}, &qf)
+	fs := cmd.Flags()
+	fs.Uint32Var(&startChunk, "start-chunk", 0, "first chunk to query (required)")
+	fs.IntVar(&numChunks, "num-chunks", 1, "how many consecutive chunks to query starting at --start-chunk")
+	fs.StringVar(&coldDir, "cold-dir", "",
+		"root of the frozen artifact tree to query, as bench-ingest cold's --cold-out-dir laid it out (required)")
+	markRequired(cmd, "start-chunk", "cold-dir")
+	return cmd
+}
+
+// coldQueryOptions configures one cold read benchmark run.
+type coldQueryOptions struct {
+	// ColdRoot is the layout root of the frozen artifacts to query — the tree
+	// a bench-ingest cold run (or a campaign's golden pack download) produced.
+	// It is read-only apart from the run's scratch catalog, created and removed
+	// under it.
+	ColdRoot string
+
+	// StartChunk and NumChunks give the chunk range to query,
+	// [StartChunk, StartChunk+NumChunks). Every chunk in it must be materialized
+	// under ColdRoot.
+	StartChunk chunk.ID
+	NumChunks  int
+
+	// Plan is the validated --types × --query-concurrency sweep.
+	Plan queryPlan
+
+	// OutDir receives the CSV report.
+	OutDir string
+}
+
+// validate checks the flags and chunk range before runQueryCold touches the
+// filesystem.
+func (o coldQueryOptions) validate() error {
+	if o.ColdRoot == "" {
+		return errors.New("--cold-dir is required")
+	}
+	if o.NumChunks < 1 {
+		return fmt.Errorf("--num-chunks must be >= 1, got %d", o.NumChunks)
+	}
+	// The frontier hot key sits one chunk above the range (see openColdFixture),
+	// so the range must end below the last valid chunk ID, not at it. uint64 so
+	// the sum cannot wrap before the compare.
+	if end := uint64(o.StartChunk) + uint64(o.NumChunks) - 1; end >= uint64(maxChunkID) {
+		return fmt.Errorf("--start-chunk=%d with --num-chunks=%d ends at chunk %d, at or past the last valid chunk ID %d",
+			uint32(o.StartChunk), o.NumChunks, end, uint32(maxChunkID))
+	}
+	return nil
+}
+
+// runQueryCold benchmarks the cold read path: queries against the frozen
+// artifacts under --cold-dir, routed through a read view exactly as a served
+// request is.
+func runQueryCold(ctx context.Context, logger *supportlog.Entry, opts coldQueryOptions) error {
+	if err := opts.validate(); err != nil {
+		return err
+	}
+	return runQueryBench(ctx, logger, opts.Plan, opts.OutDir, func() (*queryFixture, func(), error) {
+		return openColdFixture(logger, opts)
+	})
+}
+
+// openColdFixture makes an on-disk frozen artifact tree servable and returns the
+// read fixture over it, plus the release that tears the fixture down.
+//
+// bench-ingest cold writes its artifacts under a SCRATCH catalog it then throws
+// away, so the tree arrives with the files but no catalog naming them. This
+// rebuilds the catalog state the tree implies, reproducing the deployment those
+// artifacts came from:
+//
+//   - every chunk in the range runs the freeze bracket (MarkChunkFreezing then
+//     FlipChunkFrozen) for each kind whose files are actually on disk, so a kind
+//     the backfill did not produce — or whose .bin a terminal index build already
+//     swept — is absent rather than a frozen key pointing at nothing;
+//   - the tx-hash window index on disk is committed under its own bracket, read
+//     back from the .idx filename so the catalog names the coverage the by-hash
+//     lookup will probe;
+//   - the chunk one past the range gets a "ready" hot key. That key is what makes
+//     the range complete: LastCompleteChunk is the lowest ready hot chunk minus
+//     one, and NewReadView fails outright without a ready hot chunk. It carries
+//     no published handle, so routing resolves it to no tier and no query can
+//     reach it — it is the frontier a cold range always sits below, nothing more.
+//
+// Retention is full-history from the range's first chunk, so the whole range
+// stays above the view's floor, and the latest ledger is the range's last.
+func openColdFixture(logger *supportlog.Entry, opts coldQueryOptions) (*queryFixture, func(), error) {
+	layout := geometry.NewLayout(opts.ColdRoot)
+	cat, releaseCat, err := openScratchCatalog(opts.ColdRoot, scratchPrefixQuery, layout, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+	release := releaseCat
+
+	chunks := chunkRange(opts.StartChunk, opts.NumChunks)
+	end := chunks[len(chunks)-1]
+	if err := freezeChunks(cat, layout, chunks); err != nil {
+		release()
+		return nil, nil, err
+	}
+	if err := commitDiskTxHashIndex(logger, cat, layout, opts.StartChunk, end); err != nil {
+		release()
+		return nil, nil, err
+	}
+	// The frontier: a ready hot chunk above the range, so the range counts as
+	// complete. No dir is created and no handle published — see the doc comment.
+	if err := cat.FlipHotReady(end + 1); err != nil {
+		release()
+		return nil, nil, fmt.Errorf("mark frontier hot chunk %s ready: %w", end+1, err)
+	}
+
+	registry := query.NewRegistry(cat, geometry.NewRetention(0, opts.StartChunk))
+	registry.SetLatestLedger(end.LastLedger())
+	f := &queryFixture{
+		registry:    registry,
+		Chunks:      chunks,
+		FirstLedger: opts.StartChunk.FirstLedger(),
+		LastLedger:  end.LastLedger(),
+	}
+	if err := f.verifyServes(); err != nil {
+		release()
+		return nil, nil, err
+	}
+	return f, release, nil
+}
+
+// freezeChunks runs the freeze bracket over each chunk for the artifact kinds
+// materialized under the layout, and reports which kinds each chunk got. A
+// chunk whose ledger pack is missing fails the open: without it no query type
+// can run, and a later per-query ErrUnavailable would be far harder to read.
+func freezeChunks(cat *catalog.Catalog, layout geometry.Layout, chunks []chunk.ID) error {
+	for _, c := range chunks {
+		var present []geometry.Kind
+		for _, kind := range geometry.AllKinds() {
+			if artifactOnDisk(layout, c, kind) {
+				present = append(present, kind)
+			}
+		}
+		if !slices.Contains(present, geometry.KindLedgers) {
+			return fmt.Errorf("chunk %s has no ledger pack under the layout (%s): the dataset does not cover it",
+				c, layout.LedgerPackPath(c))
+		}
+		if err := cat.MarkChunkFreezing(c, present...); err != nil {
+			return fmt.Errorf("mark chunk %s freezing: %w", c, err)
+		}
+		if err := cat.FlipChunkFrozen(c, present...); err != nil {
+			return fmt.Errorf("flip chunk %s frozen: %w", c, err)
+		}
+		cat.Logger().Infof("chunk %s frozen for kinds %s", c, kindList(present))
+	}
+	return nil
+}
+
+// artifactOnDisk reports whether every file a (chunk, kind) artifact owns
+// exists, which is what a "frozen" key promises.
+func artifactOnDisk(layout geometry.Layout, c chunk.ID, kind geometry.Kind) bool {
+	paths := layout.ArtifactPaths(c, kind)
+	if len(paths) == 0 {
+		return false
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// kindList renders an artifact-kind set for a log line.
+func kindList(kinds []geometry.Kind) string {
+	names := make([]string, len(kinds))
+	for i, k := range kinds {
+		names[i] = string(k)
+	}
+	return strings.Join(names, ",")
+}
+
+// commitDiskTxHashIndex commits the tx-hash window index covering [lo, hi] under
+// its freeze bracket, so ReadView.ColdTxHashIndexCoverages returns the coverage
+// the by-hash lookup opens. The commit runs AFTER the chunks are frozen, as the
+// production order does: a terminal coverage demotes the per-chunk .bin keys it
+// supersedes.
+//
+// An absent index is not an error — a shallow dataset whose backfill built no
+// index is a real state, and the txhash cell reports the empty probe set rather
+// than the open failing for the three types that do not need it.
+func commitDiskTxHashIndex(
+	logger *supportlog.Entry, cat *catalog.Catalog, layout geometry.Layout, lo, hi chunk.ID,
+) error {
+	txLayout := cat.TxHashIndexLayout()
+	cov, ok, err := diskTxHashCoverage(layout, txLayout, lo, hi)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		logger.Warnf("no tx-hash window index on disk covers chunks [%s, %s]: cold by-hash lookups have nothing to probe",
+			lo, hi)
+		return nil
+	}
+	marked, err := cat.MarkTxHashIndexFreezing(cov.Index, cov.Lo, cov.Hi)
+	if err != nil {
+		return fmt.Errorf("mark tx-hash index %s freezing: %w", cov.Key, err)
+	}
+	if err := cat.CommitTxHashIndex(marked); err != nil {
+		return fmt.Errorf("commit tx-hash index %s: %w", marked.Key, err)
+	}
+	logger.Infof("tx-hash index %s covers chunks [%s, %s]", cov.Index, cov.Lo, cov.Hi)
+	return nil
+}
+
+// diskTxHashCoverage reads back the widest window-index coverage on disk that
+// spans [lo, hi]. The .idx files are named {lo:08d}-{hi:08d}.idx under their
+// index's dir, so the coverage comes from the filename rather than being
+// assumed: a backfill's index covers the whole range it ingested, which is
+// usually wider than the chunks one query leg reads.
+//
+// Only the index containing lo is considered. A range straddling two window
+// indexes would need both, and no such range is benchmarked — the runner queries
+// one chunk at a time.
+func diskTxHashCoverage(
+	layout geometry.Layout, txLayout geometry.TxHashIndexLayout, lo, hi chunk.ID,
+) (geometry.TxHashIndexCoverage, bool, error) {
+	idx := txLayout.TxHashIndexID(lo)
+	if txLayout.TxHashIndexID(hi) != idx {
+		return geometry.TxHashIndexCoverage{}, false,
+			fmt.Errorf("chunks [%s, %s] straddle two tx-hash window indexes; query one index's chunks at a time", lo, hi)
+	}
+	dir := layout.TxHashIndexDir(idx)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return geometry.TxHashIndexCoverage{}, false, nil
+		}
+		return geometry.TxHashIndexCoverage{}, false, fmt.Errorf("read tx-hash index dir %s: %w", dir, err)
+	}
+	var best geometry.TxHashIndexCoverage
+	found := false
+	for _, e := range entries {
+		covLo, covHi, ok := parseIndexFileName(e.Name())
+		if !ok || covLo > lo || covHi < hi {
+			continue
+		}
+		if !found || covHi > best.Hi {
+			best = geometry.TxHashIndexCoverage{
+				Index: idx, Lo: covLo, Hi: covHi,
+				Key:   geometry.TxHashIndexKey(idx, covLo, covHi),
+				State: geometry.StateFrozen,
+			}
+			found = true
+		}
+	}
+	return best, found, nil
+}
+
+// parseIndexFileName decodes a window index's {lo:08d}-{hi:08d}.idx basename —
+// the reverse of geometry.Layout.TxHashIndexFilePath. ok is false for anything
+// else in the dir (a partial write, a stray file).
+func parseIndexFileName(name string) (chunk.ID, chunk.ID, bool) {
+	stem, isIdx := strings.CutSuffix(filepath.Base(name), ".idx")
+	if !isIdx {
+		return 0, 0, false
+	}
+	loStr, hiStr, split := strings.Cut(stem, "-")
+	if !split {
+		return 0, 0, false
+	}
+	lo, err := geometry.ParsePadded(loStr)
+	if err != nil {
+		return 0, 0, false
+	}
+	hi, err := geometry.ParsePadded(hiStr)
+	if err != nil || hi < lo {
+		return 0, 0, false
+	}
+	return chunk.ID(lo), chunk.ID(hi), true
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_cold.go
@@ -13,6 +13,7 @@ import (
 
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
 
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/adapters"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/catalog"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
@@ -175,7 +176,13 @@ func openColdFixture(logger *supportlog.Entry, opts coldQueryOptions) (*queryFix
 	}
 
 	registry := query.NewRegistry(cat, geometry.NewRetention(0, opts.StartChunk))
-	registry.SetLatestLedger(end.LastLedger(), 0)
+	registry.SetLatestLedger(end.LastLedger(), query.UnknownCloseTime())
+	// Stamp the window edges' close times the way startup.go does, so served
+	// requests do not pay a ledger decode to learn the latest close time.
+	if err := adapters.SeedCloseTimes(registry); err != nil {
+		release()
+		return nil, nil, fmt.Errorf("seed close times: %w", err)
+	}
 	f := &queryFixture{
 		registry:    registry,
 		Passphrase:  opts.Plan.Passphrase,

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
@@ -179,18 +179,23 @@ func (s *txHashSampler) sampleChunk(view *query.ReadView, c chunk.ID, first, las
 			continue
 		}
 		s.read[seq] = struct{}{}
-		raw, err := reader.GetLedgerRaw(seq)
+		// The ledger bytes are on loan inside the callback, so the hashes are
+		// picked there; they are value arrays and outlive the loan.
+		var picked [][32]byte
+		err := reader.WithLedger(seq, func(raw []byte) error {
+			parts, err := sdkingest.ExtractLedgerTxParts(xdr.LedgerCloseMetaView(raw))
+			if err != nil {
+				return fmt.Errorf("extract tx parts of ledger %d: %w", seq, err)
+			}
+			picked = sampleHashesFromLedger(s.rng, parts)
+			return nil
+		})
 		if errors.Is(err, stores.ErrNotFound) {
 			continue
 		}
 		if err != nil {
 			return fmt.Errorf("read ledger %d: %w", seq, err)
 		}
-		parts, err := sdkingest.ExtractLedgerTxParts(xdr.LedgerCloseMetaView(raw))
-		if err != nil {
-			return fmt.Errorf("extract tx parts of ledger %d: %w", seq, err)
-		}
-		picked := sampleHashesFromLedger(s.rng, parts)
 		if len(picked) == 0 {
 			continue
 		}
@@ -246,7 +251,7 @@ func verifySampledHashResolves(
 		return err
 	}
 	reader := adapters.NewTransactionReader(f.Passphrase, nil)
-	if _, err := reader.GetTransaction(adapters.WithView(ctx, view), xdr.Hash(hash)); err != nil {
+	if _, err := reader.GetTransaction(query.WithView(ctx, view), xdr.Hash(hash)); err != nil {
 		return fmt.Errorf("probe of a known transaction hash failed: %w "+
 			"(the fixture's tx-hash index may be missing or unreadable)", err)
 	}
@@ -264,12 +269,16 @@ func verifyEnvelopePairing(view *query.ReadView, passphrase string, hash [32]byt
 	if err != nil {
 		return fmt.Errorf("resolve ledgers of the sampled ledger %d: %w", seq, err)
 	}
-	raw, err := reader.GetLedgerRaw(seq)
+	var found bool
+	var pairErr error
+	err = reader.WithLedger(seq, func(raw []byte) error {
+		_, found, pairErr = sdkingest.LedgerTransactionViewByHash(xdr.LedgerCloseMetaView(raw), hash, passphrase)
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("re-read the sampled ledger %d: %w", seq, err)
 	}
-	_, found, err := sdkingest.LedgerTransactionViewByHash(xdr.LedgerCloseMetaView(raw), hash, passphrase)
-	if err != nil {
+	if err := pairErr; err != nil {
 		return fmt.Errorf(
 			"transaction %x does not pair with an envelope in ledger %d, the ledger it was sampled from: "+
 				"--network-passphrase=%q is wrong for this dataset (%w)", hash, seq, passphrase, err)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/store"
 )
 
 // This file builds the corpora the per-type bodies draw their work from. Every
@@ -85,15 +84,14 @@ func (c *txHashCorpus) pick(rng *rand.Rand) ([32]byte, bool) {
 }
 
 // buildTxHashCorpus samples transaction hashes from the fixture's ledger range
-// and verifies the network passphrase against them.
+// and checks that one of them resolves before any leg runs.
 //
-// The passphrase check is not ceremony. Resolving a hash to a transaction pairs
-// each TxSet envelope to its result by hashing the envelope, which needs the
-// passphrase; with the wrong one nothing pairs, every lookup reports not-found,
-// and the benchmark would publish the miss path's latency under the hit path's
-// name. Since ExtractLedgerTxParts derives hashes without a passphrase, a hash
-// it just produced must resolve — so if it does not, the passphrase is wrong and
-// the run stops here saying so.
+// The check is not ceremony. Resolving a hash to a transaction pairs each TxSet
+// envelope to its result by hashing the envelope, which needs the passphrase;
+// with the wrong one nothing pairs and the benchmark would publish the failed
+// path's latency under the hit path's name. Since ExtractLedgerTxParts derives
+// hashes without a passphrase, a hash it just produced must resolve — so if it
+// does not, the run stops here.
 func buildTxHashCorpus(
 	ctx context.Context, logger *supportlog.Entry, f *queryFixture, missFraction float64, seed int64,
 ) (*txHashCorpus, error) {
@@ -114,7 +112,8 @@ func buildTxHashCorpus(
 		return nil, fmt.Errorf("%w: chunks %v, ledgers [%d, %d]",
 			errNoTransactions, f.Chunks, f.FirstLedger, f.LastLedger)
 	}
-	if err := verifyPassphrase(ctx, view, f, s.hashes[0]); err != nil {
+	hash, seq := s.first()
+	if err := verifySampledHashResolves(ctx, view, f, hash, seq); err != nil {
 		return nil, err
 	}
 	s.logCoverage(logger, missFraction)
@@ -142,6 +141,14 @@ type txHashSampler struct {
 
 func newTxHashSampler(rng *rand.Rand) *txHashSampler {
 	return &txHashSampler{rng: rng, read: map[uint32]struct{}{}}
+}
+
+// first returns the pool's first hash and the ledger it came from. sampleChunk
+// appends to hashes and to ledgers in the same step, so the first ledger it
+// recorded is the one the first hashes were drawn from. The caller must have
+// checked the pool is not empty.
+func (s *txHashSampler) first() ([32]byte, uint32) {
+	return s.hashes[0], s.ledgers[0]
 }
 
 // sampleChunk reads randomly chosen ledgers of chunk c — within the fixture's
@@ -220,20 +227,57 @@ func sampleHashesFromLedger(rng *rand.Rand, parts []sdkingest.LedgerTxParts) [][
 	return out
 }
 
-// verifyPassphrase confirms the configured network passphrase resolves a hash
-// the sampler just read out of a ledger, through the same served by-hash path
-// the benchmark measures. See buildTxHashCorpus for why a wrong passphrase would
-// otherwise pass silently.
-func verifyPassphrase(ctx context.Context, view *query.ReadView, f *queryFixture, hash [32]byte) error {
-	reader := adapters.NewTransactionReader(f.Passphrase, nil)
-	_, err := reader.GetTransaction(adapters.WithView(ctx, view), xdr.Hash(hash))
-	if errors.Is(err, store.ErrNoTransaction) {
-		return fmt.Errorf(
-			"a transaction hash sampled straight from a ledger does not resolve: "+
-				"--network-passphrase=%q is wrong for this dataset", f.Passphrase)
+// verifySampledHashResolves checks a hash the sampler read out of ledger seq
+// two ways, in the order that tells the operator what to fix.
+//
+// The passphrase comes first, checked against that one ledger. Pairing the
+// transaction's envelope to its result there is the only step the passphrase
+// feeds, so a failure names --network-passphrase and nothing else.
+//
+// The served by-hash path comes second: the same hash has to resolve through
+// the tx-hash indexes and the routing the benchmark measures. That path can
+// fail for reasons the passphrase has no part in — an index the fixture never
+// committed, an .idx that will not open, a ledger read that fails — so its
+// error is reported as the probe failure it is.
+func verifySampledHashResolves(
+	ctx context.Context, view *query.ReadView, f *queryFixture, hash [32]byte, seq uint32,
+) error {
+	if err := verifyEnvelopePairing(view, f.Passphrase, hash, seq); err != nil {
+		return err
 	}
+	reader := adapters.NewTransactionReader(f.Passphrase, nil)
+	if _, err := reader.GetTransaction(adapters.WithView(ctx, view), xdr.Hash(hash)); err != nil {
+		return fmt.Errorf("probe of a known transaction hash failed: %w "+
+			"(the fixture's tx-hash index may be missing or unreadable)", err)
+	}
+	return nil
+}
+
+// verifyEnvelopePairing re-reads ledger seq and materializes hash out of it with
+// the configured passphrase, which is what pairs each TxSet envelope to its
+// TxProcessing entry. The hash came from that ledger's own results and meta, so
+// the transaction is there and the pairing is the only thing that can go wrong;
+// a failure therefore reports the passphrase, carrying the underlying error for
+// the rarer case of a ledger that really is malformed.
+func verifyEnvelopePairing(view *query.ReadView, passphrase string, hash [32]byte, seq uint32) error {
+	reader, err := view.Ledgers(chunk.IDFromLedger(seq))
 	if err != nil {
-		return fmt.Errorf("verify --network-passphrase: %w", err)
+		return fmt.Errorf("resolve ledgers of the sampled ledger %d: %w", seq, err)
+	}
+	raw, err := reader.GetLedgerRaw(seq)
+	if err != nil {
+		return fmt.Errorf("re-read the sampled ledger %d: %w", seq, err)
+	}
+	_, found, err := sdkingest.LedgerTransactionViewByHash(xdr.LedgerCloseMetaView(raw), hash, passphrase)
+	if err != nil {
+		return fmt.Errorf(
+			"transaction %x does not pair with an envelope in ledger %d, the ledger it was sampled from: "+
+				"--network-passphrase=%q is wrong for this dataset (%w)", hash, seq, passphrase, err)
+	}
+	if !found {
+		return fmt.Errorf(
+			"transaction %x is not in ledger %d, the ledger it was sampled from: "+
+				"--network-passphrase=%q is wrong for this dataset", hash, seq, passphrase)
 	}
 	return nil
 }

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
@@ -22,15 +22,15 @@ import (
 )
 
 // This file builds the corpora the per-type bodies draw their work from. Every
-// read here happens once, before any measurement, and is never timed: a
-// benchmark that sampled inside the measured pass would report its own setup.
+// read here happens once, before any measurement, and is never timed, so the
+// measured pass reports the query and not the corpus build.
 
 // The tx-hash sampler's stopping rule. It aims for a pool large enough that a
-// leg's requests do not keep asking for the same few hashes, and it counts
-// hashes rather than ledgers because how many transactions a ledger carries is
-// a property of the dataset: a loaded one fills the pool in a handful of reads,
-// while a sparse one would otherwise stop with an unusably small pool. The read
-// cap ends the sample on a dataset too sparse to reach the target at all.
+// leg's requests draw from many hashes, and it counts hashes because how many
+// transactions a ledger carries is a property of the dataset: a loaded one
+// fills the pool in a handful of reads, and a sparse one keeps reading until
+// the pool is big enough. The read cap ends the sample on a dataset too sparse
+// to reach the target at all.
 const (
 	corpusTargetHashes   = 512
 	corpusMaxLedgerReads = 512

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
@@ -1,0 +1,366 @@
+package bench
+
+import (
+	"cmp"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"slices"
+
+	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
+)
+
+// This file builds the corpora the per-type bodies draw their work from. Every
+// read here happens once, before any measurement, and is never timed: a
+// benchmark that sampled inside the measured pass would report its own setup.
+
+// The tx-hash sampler's stopping rule. It aims for a pool large enough that a
+// cell's iterations do not keep asking for the same few hashes, and it counts
+// hashes rather than ledgers because how many transactions a ledger carries is
+// a property of the dataset: a loaded one fills the pool in a handful of reads,
+// while a sparse one would otherwise stop with an unusably small pool. The read
+// cap ends the sample on a dataset too sparse to reach the target at all.
+const (
+	corpusTargetHashes   = 512
+	corpusMaxLedgerReads = 512
+)
+
+// eventScanCap bounds how many stored events the filter builder reads while
+// looking for the chunk's busiest contracts. A full chunk scan would dominate
+// the run's wall-clock for a corpus that only needs the top few contracts.
+const eventScanCap = 20_000
+
+// eventFilterSets is how many filter sets the events corpus offers, including
+// the unfiltered one.
+const eventFilterSets = 4
+
+// errNoTransactions means the sampled ledgers carried no transactions, so
+// neither the by-hash nor the transaction-page benchmark has anything to read.
+var errNoTransactions = errors.New("the sampled ledgers carry no transactions")
+
+// txHashCorpus is the by-hash benchmark's work: a pool of hashes that really
+// landed in the fixture's ledger range, and the fraction of lookups that should
+// instead ask for a hash that never landed.
+//
+// Both halves are needed for an honest number. A hit resolves at the first
+// index that knows the hash and stops; a miss is the worst case — every hot
+// index and then every cold window index, each cold probe paying its MPHF query
+// and, on a fingerprint false positive, a ledger read that fails verification.
+// A hit-only corpus therefore reports the cheap half of what getTransaction
+// serves.
+type txHashCorpus struct {
+	hashes       [][32]byte
+	missFraction float64
+}
+
+// pick returns one hash to look up and whether it is expected to be found. A
+// miss is 32 random bytes: the odds of colliding with a real transaction hash
+// are negligible, and what matters is that no index holds it.
+func (c *txHashCorpus) pick(rng *rand.Rand) ([32]byte, bool) {
+	if c.missFraction > 0 && rng.Float64() < c.missFraction {
+		var h [32]byte
+		for i := 0; i < len(h); i += 8 {
+			binary.LittleEndian.PutUint64(h[i:], rng.Uint64())
+		}
+		return h, false
+	}
+	return c.hashes[rng.IntN(len(c.hashes))], true
+}
+
+// buildTxHashCorpus samples transaction hashes from the fixture's ledger range
+// and verifies the network passphrase against them.
+//
+// The passphrase check is not ceremony. Resolving a hash to a transaction pairs
+// each TxSet envelope to its result by hashing the envelope, which needs the
+// passphrase; with the wrong one nothing pairs, every lookup reports not-found,
+// and the benchmark would publish the miss path's latency under the hit path's
+// name. Since ExtractLedgerTxParts derives hashes without a passphrase, a hash
+// it just produced must resolve — so if it does not, the passphrase is wrong and
+// the run stops here saying so.
+func buildTxHashCorpus(
+	logger *supportlog.Entry, f *queryFixture, missFraction float64, seed int64,
+) (*txHashCorpus, error) {
+	view, err := f.view()
+	if err != nil {
+		return nil, fmt.Errorf("acquire read view: %w", err)
+	}
+	defer view.Release()
+
+	rng := rand.New(rand.NewPCG(uint64(seed), uint64(seed*31+7))) //nolint:gosec // seed mixing
+	var hashes [][32]byte
+	for _, c := range f.Chunks {
+		got, err := sampleChunkTxHashes(view, c, f.FirstLedger, f.LastLedger, rng)
+		if err != nil {
+			return nil, err
+		}
+		hashes = append(hashes, got...)
+	}
+	if len(hashes) == 0 {
+		return nil, fmt.Errorf("%w: chunks %v, ledgers [%d, %d]",
+			errNoTransactions, f.Chunks, f.FirstLedger, f.LastLedger)
+	}
+	if err := verifyPassphrase(view, f, hashes[0]); err != nil {
+		return nil, err
+	}
+	logger.Infof("txhash corpus: %d hashes sampled, miss fraction %.2f", len(hashes), missFraction)
+	return &txHashCorpus{hashes: hashes, missFraction: missFraction}, nil
+}
+
+// sampleChunkTxHashes reads randomly chosen ledgers of chunk c — within the
+// fixture's servable range — and returns every transaction hash it finds,
+// stopping once the pool reaches corpusTargetHashes or the read cap runs out.
+//
+// A sequence with no stored ledger is skipped rather than failing the sample: a
+// capped hot ingest leaves the chunk's tail empty, which is a known state, not
+// an error. The hashes come from ExtractLedgerTxParts, which derives them from
+// each transaction's own result and meta and needs no passphrase — so they are
+// authoritative, which is what makes them usable to check the passphrase.
+func sampleChunkTxHashes(
+	view *query.ReadView, c chunk.ID, first, last uint32, rng *rand.Rand,
+) ([][32]byte, error) {
+	lo := max(c.FirstLedger(), first)
+	hi := min(c.LastLedger(), last)
+	if lo > hi {
+		return nil, nil
+	}
+	reader, err := view.Ledgers(c)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ledgers of chunk %s: %w", c, err)
+	}
+
+	span := int(hi - lo + 1)
+	var hashes [][32]byte
+	for reads := 0; reads < corpusMaxLedgerReads && len(hashes) < corpusTargetHashes; reads++ {
+		seq := lo + uint32(rng.IntN(span)) //nolint:gosec // span <= LedgersPerChunk
+		raw, err := reader.GetLedgerRaw(seq)
+		if errors.Is(err, stores.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read ledger %d: %w", seq, err)
+		}
+		parts, err := sdkingest.ExtractLedgerTxParts(xdr.LedgerCloseMetaView(raw))
+		if err != nil {
+			return nil, fmt.Errorf("extract tx parts of ledger %d: %w", seq, err)
+		}
+		for _, p := range parts {
+			hashes = append(hashes, p.Hash)
+		}
+	}
+	return hashes, nil
+}
+
+// verifyPassphrase confirms the configured network passphrase resolves a hash
+// the sampler just read out of a ledger. See buildTxHashCorpus for why a wrong
+// passphrase would otherwise pass silently.
+func verifyPassphrase(view *query.ReadView, f *queryFixture, hash [32]byte) error {
+	probe, release, err := f.txReader(view)
+	if err != nil {
+		return err
+	}
+	defer release()
+	_, found, err := probe.GetTransaction(hash)
+	if err != nil {
+		return fmt.Errorf("verify --network-passphrase: %w", err)
+	}
+	if !found {
+		return fmt.Errorf(
+			"a transaction hash sampled straight from a ledger does not resolve: "+
+				"--network-passphrase=%q is wrong for this dataset", f.Passphrase)
+	}
+	return nil
+}
+
+// eventFilterCorpus is the events benchmark's work: a handful of filter sets,
+// one of which is unfiltered.
+//
+// Filters change the shape of the read, not just its size: an unfiltered page
+// streams the chunk's events in order, while a filtered one intersects the
+// index's term postings first. Rotating a fixed set over the run keeps both
+// shapes in the number without turning it into a selectivity sweep.
+type eventFilterCorpus struct {
+	sets [][]event.Filter
+}
+
+// pick returns one filter set to page with. A nil set is the unfiltered read.
+func (c *eventFilterCorpus) pick(rng *rand.Rand) []event.Filter {
+	return c.sets[rng.IntN(len(c.sets))]
+}
+
+// buildEventFilterCorpus derives filter sets from the events actually stored in
+// the fixture's chunks: the busiest contracts, and the busiest contract narrowed
+// by its most common first topic. It always includes the unfiltered set, so a
+// dataset whose events carry no contract ID still gives the benchmark something
+// to read.
+func buildEventFilterCorpus(
+	ctx context.Context, logger *supportlog.Entry, f *queryFixture,
+) (*eventFilterCorpus, error) {
+	view, err := f.view()
+	if err != nil {
+		return nil, fmt.Errorf("acquire read view: %w", err)
+	}
+	defer view.Release()
+
+	contracts, topics, err := scanEventTerms(ctx, view, f.Chunks)
+	if err != nil {
+		return nil, err
+	}
+	sets := [][]event.Filter{nil} // the unfiltered read
+	for _, cid := range contracts {
+		if len(sets) >= eventFilterSets-1 {
+			break
+		}
+		sets = append(sets, []event.Filter{{ContractID: cid}})
+	}
+	if len(contracts) > 0 && len(topics) > 0 {
+		f := event.Filter{ContractID: contracts[0]}
+		f.Topics[0] = topics[0]
+		sets = append(sets, []event.Filter{f})
+	}
+	if err := validateFilterSets(sets); err != nil {
+		return nil, err
+	}
+	logger.Infof("events corpus: %d filter sets (%d contracts, %d topic values seen)",
+		len(sets), len(contracts), len(topics))
+	return &eventFilterCorpus{sets: sets}, nil
+}
+
+// validateFilterSets runs the engine's own filter check over every set, so a
+// malformed filter fails at build time rather than on every measured page.
+func validateFilterSets(sets [][]event.Filter) error {
+	for _, set := range sets {
+		if err := event.ValidateFilters(set); err != nil {
+			return fmt.Errorf("derived event filter is invalid: %w", err)
+		}
+	}
+	return nil
+}
+
+// scanEventTerms reads up to eventScanCap stored events across the chunks and
+// returns the contract IDs and first-topic values by descending frequency. The
+// values are the store's canonical term bytes — a topic's raw XDR — read off the
+// event through the same views the indexer uses, so a filter built from them
+// keys the same terms the events were indexed under.
+func scanEventTerms(
+	ctx context.Context, view *query.ReadView, chunks []chunk.ID,
+) ([][]byte, [][]byte, error) {
+	contractCounts := map[string]int{}
+	topicCounts := map[string]int{}
+	scanned := 0
+
+	for _, c := range chunks {
+		reader, rerr := view.Events(c)
+		if rerr != nil {
+			// A chunk with no events store is not an error for this corpus: the
+			// unfiltered set still works, and the caller logs what was found.
+			continue
+		}
+		for payload, perr := range reader.All(ctx) {
+			if perr != nil {
+				return nil, nil, fmt.Errorf("scan events of chunk %s: %w", c, perr)
+			}
+			cid, topic0, terr := eventTerms(payload.ContractEventBytes)
+			if terr != nil {
+				return nil, nil, fmt.Errorf("read event terms in chunk %s: %w", c, terr)
+			}
+			if cid != nil {
+				contractCounts[string(cid)]++
+			}
+			if topic0 != nil {
+				topicCounts[string(topic0)]++
+			}
+			scanned++
+			if scanned >= eventScanCap {
+				break
+			}
+		}
+		if scanned >= eventScanCap {
+			break
+		}
+	}
+	return byDescendingCount(contractCounts), byDescendingCount(topicCounts), nil
+}
+
+// eventTerms reads one stored event's contract ID and first topic through the
+// XDR views, mirroring how the events indexer derives its terms. Either is nil
+// when the event carries none.
+func eventTerms(eventBytes []byte) ([]byte, []byte, error) {
+	var cid []byte
+	ev := xdr.ContractEventView(eventBytes)
+	cidOpt, err := ev.ContractId()
+	if err != nil {
+		return nil, nil, fmt.Errorf("view ContractId: %w", err)
+	}
+	cidView, present, err := cidOpt.Unwrap()
+	if err != nil {
+		return nil, nil, fmt.Errorf("view ContractId unwrap: %w", err)
+	}
+	if present {
+		v, verr := cidView.Value()
+		if verr != nil {
+			return nil, nil, fmt.Errorf("view ContractId value: %w", verr)
+		}
+		cid = slices.Clone(v[:])
+	}
+
+	body, err := ev.Body()
+	if err != nil {
+		return nil, nil, fmt.Errorf("view Body: %w", err)
+	}
+	v, err := body.V()
+	if err != nil {
+		return nil, nil, fmt.Errorf("view Body.V: %w", err)
+	}
+	if v != 0 {
+		// Only body version 0 carries topics; a later version has no topic
+		// filter to derive, which is not a reason to fail the corpus.
+		return cid, nil, nil
+	}
+	v0, err := body.V0()
+	if err != nil {
+		return nil, nil, fmt.Errorf("view Body.V0: %w", err)
+	}
+	topicList, err := v0.Topics()
+	if err != nil {
+		return nil, nil, fmt.Errorf("view Body.V0.Topics: %w", err)
+	}
+	all, err := topicList.All()
+	if err != nil {
+		return nil, nil, fmt.Errorf("view Body.V0.Topics.All: %w", err)
+	}
+	if len(all) == 0 {
+		return cid, nil, nil
+	}
+	// All returns each element trimmed to size, so the view's bytes already are
+	// the topic's raw XDR — the exact form the index keys on.
+	return cid, slices.Clone([]byte(all[0])), nil
+}
+
+// byDescendingCount returns the keys of counts, most frequent first, with ties
+// broken by value so a run is reproducible.
+func byDescendingCount(counts map[string]int) [][]byte {
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	slices.SortFunc(keys, func(a, b string) int {
+		if counts[a] != counts[b] {
+			return counts[b] - counts[a]
+		}
+		return cmp.Compare(a, b)
+	})
+	out := make([][]byte, len(keys))
+	for i, k := range keys {
+		out[i] = []byte(k)
+	}
+	return out
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
@@ -163,11 +163,10 @@ func sampleChunkTxHashes(
 // the sampler just read out of a ledger. See buildTxHashCorpus for why a wrong
 // passphrase would otherwise pass silently.
 func verifyPassphrase(view *query.ReadView, f *queryFixture, hash [32]byte) error {
-	probe, release, err := f.txReader(view)
+	probe, err := f.txReader(view)
 	if err != nil {
 		return err
 	}
-	defer release()
 	_, found, err := probe.GetTransaction(hash)
 	if err != nil {
 		return fmt.Errorf("verify --network-passphrase: %w", err)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
@@ -13,10 +13,12 @@ import (
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/adapters"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/store"
 )
 
 // This file builds the corpora the per-type bodies draw their work from. Every
@@ -87,7 +89,7 @@ func (c *txHashCorpus) pick(rng *rand.Rand) ([32]byte, bool) {
 // it just produced must resolve — so if it does not, the passphrase is wrong and
 // the run stops here saying so.
 func buildTxHashCorpus(
-	logger *supportlog.Entry, f *queryFixture, missFraction float64, seed int64,
+	ctx context.Context, logger *supportlog.Entry, f *queryFixture, missFraction float64, seed int64,
 ) (*txHashCorpus, error) {
 	view, err := f.view()
 	if err != nil {
@@ -108,7 +110,7 @@ func buildTxHashCorpus(
 		return nil, fmt.Errorf("%w: chunks %v, ledgers [%d, %d]",
 			errNoTransactions, f.Chunks, f.FirstLedger, f.LastLedger)
 	}
-	if err := verifyPassphrase(view, f, hashes[0]); err != nil {
+	if err := verifyPassphrase(ctx, view, f, hashes[0]); err != nil {
 		return nil, err
 	}
 	logger.Infof("txhash corpus: %d hashes sampled, miss fraction %.2f", len(hashes), missFraction)
@@ -160,21 +162,19 @@ func sampleChunkTxHashes(
 }
 
 // verifyPassphrase confirms the configured network passphrase resolves a hash
-// the sampler just read out of a ledger. See buildTxHashCorpus for why a wrong
-// passphrase would otherwise pass silently.
-func verifyPassphrase(view *query.ReadView, f *queryFixture, hash [32]byte) error {
-	probe, err := f.txReader(view)
-	if err != nil {
-		return err
-	}
-	_, found, err := probe.GetTransaction(hash)
-	if err != nil {
-		return fmt.Errorf("verify --network-passphrase: %w", err)
-	}
-	if !found {
+// the sampler just read out of a ledger, through the same served by-hash path
+// the benchmark measures. See buildTxHashCorpus for why a wrong passphrase would
+// otherwise pass silently.
+func verifyPassphrase(ctx context.Context, view *query.ReadView, f *queryFixture, hash [32]byte) error {
+	reader := adapters.NewTransactionReader(f.Passphrase, nil)
+	_, err := reader.GetTransaction(adapters.WithView(ctx, view), xdr.Hash(hash))
+	if errors.Is(err, store.ErrNoTransaction) {
 		return fmt.Errorf(
 			"a transaction hash sampled straight from a ledger does not resolve: "+
 				"--network-passphrase=%q is wrong for this dataset", f.Passphrase)
+	}
+	if err != nil {
+		return fmt.Errorf("verify --network-passphrase: %w", err)
 	}
 	return nil
 }

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
@@ -26,7 +26,7 @@ import (
 // benchmark that sampled inside the measured pass would report its own setup.
 
 // The tx-hash sampler's stopping rule. It aims for a pool large enough that a
-// cell's iterations do not keep asking for the same few hashes, and it counts
+// leg's requests do not keep asking for the same few hashes, and it counts
 // hashes rather than ledgers because how many transactions a ledger carries is
 // a property of the dataset: a loaded one fills the pool in a handful of reads,
 // while a sparse one would otherwise stop with an unusably small pool. The read

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus.go
@@ -25,15 +25,21 @@ import (
 // read here happens once, before any measurement, and is never timed, so the
 // measured pass reports the query and not the corpus build.
 
-// The tx-hash sampler's stopping rule. It aims for a pool large enough that a
-// leg's requests draw from many hashes, and it counts hashes because how many
-// transactions a ledger carries is a property of the dataset: a loaded one
-// fills the pool in a handful of reads, and a sparse one keeps reading until
-// the pool is big enough. The read cap ends the sample on a dataset too sparse
-// to reach the target at all.
+// The tx-hash sampler's rule: read randomly chosen ledgers, take at most
+// corpusMaxHashesPerLedger hashes from each, and stop once the pool holds
+// corpusTargetHashes of them or the read cap runs out.
+//
+// The per-ledger cap is what spreads the pool over ledgers. Looking a hash up
+// reads the ledger it landed in, so a pool drawn from one ledger measures the
+// same decompressed blob over and over, which is not what a served by-hash mix
+// does. With these values a dataset dense enough to fill the pool covers
+// corpusTargetHashes/corpusMaxHashesPerLedger ledgers; a sparser one never
+// reaches the cap and contributes each ledger's whole transaction set. The read
+// cap ends the sample on a dataset too sparse to reach the target at all.
 const (
-	corpusTargetHashes   = 512
-	corpusMaxLedgerReads = 512
+	corpusTargetHashes       = 512
+	corpusMaxLedgerReads     = 512
+	corpusMaxHashesPerLedger = 16
 )
 
 // eventScanCap bounds how many stored events the filter builder reads while
@@ -98,67 +104,120 @@ func buildTxHashCorpus(
 	defer view.Release()
 
 	rng := rand.New(rand.NewPCG(uint64(seed), uint64(seed*31+7))) //nolint:gosec // seed mixing
-	var hashes [][32]byte
+	s := newTxHashSampler(rng)
 	for _, c := range f.Chunks {
-		got, err := sampleChunkTxHashes(view, c, f.FirstLedger, f.LastLedger, rng)
-		if err != nil {
+		if err := s.sampleChunk(view, c, f.FirstLedger, f.LastLedger); err != nil {
 			return nil, err
 		}
-		hashes = append(hashes, got...)
 	}
-	if len(hashes) == 0 {
+	if len(s.hashes) == 0 {
 		return nil, fmt.Errorf("%w: chunks %v, ledgers [%d, %d]",
 			errNoTransactions, f.Chunks, f.FirstLedger, f.LastLedger)
 	}
-	if err := verifyPassphrase(ctx, view, f, hashes[0]); err != nil {
+	if err := verifyPassphrase(ctx, view, f, s.hashes[0]); err != nil {
 		return nil, err
 	}
-	logger.Infof("txhash corpus: %d hashes sampled, miss fraction %.2f", len(hashes), missFraction)
-	return &txHashCorpus{hashes: hashes, missFraction: missFraction}, nil
+	s.logCoverage(logger, missFraction)
+	return &txHashCorpus{hashes: s.hashes, missFraction: missFraction}, nil
 }
 
-// sampleChunkTxHashes reads randomly chosen ledgers of chunk c — within the
-// fixture's servable range — and returns every transaction hash it finds,
-// stopping once the pool reaches corpusTargetHashes or the read cap runs out.
+// txHashSampler draws transaction hashes from a fixture's ledgers and records
+// which ledgers they came from, so the corpus can report how many it covers.
+//
+// It reads each sequence at most once. A ledger therefore contributes at most
+// corpusMaxHashesPerLedger hashes to the pool, and the ledgers list holds
+// exactly the ledgers whose hashes are in the pool.
+type txHashSampler struct {
+	rng *rand.Rand
+
+	// hashes is the pool.
+	hashes [][32]byte
+
+	// ledgers lists every ledger that contributed a hash, in sample order, and
+	// read holds every sequence the sampler has already drawn — including the
+	// ones that held no stored ledger, which are not worth drawing twice.
+	ledgers []uint32
+	read    map[uint32]struct{}
+}
+
+func newTxHashSampler(rng *rand.Rand) *txHashSampler {
+	return &txHashSampler{rng: rng, read: map[uint32]struct{}{}}
+}
+
+// sampleChunk reads randomly chosen ledgers of chunk c — within the fixture's
+// servable range — and adds a random subset of each one's transaction hashes to
+// the pool, stopping once the pool reaches corpusTargetHashes or the read cap
+// runs out.
 //
 // A sequence with no stored ledger is skipped rather than failing the sample: a
 // capped hot ingest leaves the chunk's tail empty, which is a known state, not
 // an error. The hashes come from ExtractLedgerTxParts, which derives them from
 // each transaction's own result and meta and needs no passphrase — so they are
 // authoritative, which is what makes them usable to check the passphrase.
-func sampleChunkTxHashes(
-	view *query.ReadView, c chunk.ID, first, last uint32, rng *rand.Rand,
-) ([][32]byte, error) {
+func (s *txHashSampler) sampleChunk(view *query.ReadView, c chunk.ID, first, last uint32) error {
 	lo := max(c.FirstLedger(), first)
 	hi := min(c.LastLedger(), last)
 	if lo > hi {
-		return nil, nil
+		return nil
 	}
 	reader, err := view.Ledgers(c)
 	if err != nil {
-		return nil, fmt.Errorf("resolve ledgers of chunk %s: %w", c, err)
+		return fmt.Errorf("resolve ledgers of chunk %s: %w", c, err)
 	}
 
 	span := int(hi - lo + 1)
-	var hashes [][32]byte
-	for reads := 0; reads < corpusMaxLedgerReads && len(hashes) < corpusTargetHashes; reads++ {
-		seq := lo + uint32(rng.IntN(span)) //nolint:gosec // span <= LedgersPerChunk
+	for reads := 0; reads < corpusMaxLedgerReads && len(s.hashes) < corpusTargetHashes; reads++ {
+		seq := lo + uint32(s.rng.IntN(span)) //nolint:gosec // span <= LedgersPerChunk
+		if _, drawn := s.read[seq]; drawn {
+			continue
+		}
+		s.read[seq] = struct{}{}
 		raw, err := reader.GetLedgerRaw(seq)
 		if errors.Is(err, stores.ErrNotFound) {
 			continue
 		}
 		if err != nil {
-			return nil, fmt.Errorf("read ledger %d: %w", seq, err)
+			return fmt.Errorf("read ledger %d: %w", seq, err)
 		}
 		parts, err := sdkingest.ExtractLedgerTxParts(xdr.LedgerCloseMetaView(raw))
 		if err != nil {
-			return nil, fmt.Errorf("extract tx parts of ledger %d: %w", seq, err)
+			return fmt.Errorf("extract tx parts of ledger %d: %w", seq, err)
 		}
-		for _, p := range parts {
-			hashes = append(hashes, p.Hash)
+		picked := sampleHashesFromLedger(s.rng, parts)
+		if len(picked) == 0 {
+			continue
 		}
+		s.hashes = append(s.hashes, picked...)
+		s.ledgers = append(s.ledgers, seq)
 	}
-	return hashes, nil
+	return nil
+}
+
+// logCoverage reports what the pool covers: how many hashes it holds, how many
+// ledgers they came from, and the range those ledgers span. A pool drawn from
+// one ledger is legitimate on a dataset that holds one, and still worth a
+// warning, because every found lookup in the run then reads that one ledger.
+func (s *txHashSampler) logCoverage(logger *supportlog.Entry, missFraction float64) {
+	logger.Infof("txhash corpus: %d hashes over %d ledgers spanning %d..%d, miss fraction %.2f",
+		len(s.hashes), len(s.ledgers), slices.Min(s.ledgers), slices.Max(s.ledgers), missFraction)
+	if len(s.ledgers) == 1 {
+		logger.Warnf("txhash corpus came from ledger %d alone: every found lookup reads that "+
+			"one ledger, so this run's found rows measure a warm read", s.ledgers[0])
+	}
+}
+
+// sampleHashesFromLedger returns at most corpusMaxHashesPerLedger of the
+// transactions' hashes, drawn uniformly without replacement. The draw is random
+// rather than the ledger's first transactions because apply order is a property
+// of the ordering rule, not of the ledger's traffic, so the opening
+// transactions do not stand in for the rest.
+func sampleHashesFromLedger(rng *rand.Rand, parts []sdkingest.LedgerTxParts) [][32]byte {
+	take := min(len(parts), corpusMaxHashesPerLedger)
+	out := make([][32]byte, 0, take)
+	for _, i := range rng.Perm(len(parts))[:take] {
+		out = append(out, parts[i].Hash)
+	}
+	return out
 }
 
 // verifyPassphrase confirms the configured network passphrase resolves a hash

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus_test.go
@@ -1,0 +1,255 @@
+package bench
+
+import (
+	"context"
+	"math/rand/v2"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/adapters"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
+)
+
+// TestCorpusSpansManyLedgersOnADenseDataset pins the property the per-ledger cap
+// exists for. On a dataset whose ledgers each carry more transactions than the
+// cap, the pool still covers corpusTargetHashes/corpusMaxHashesPerLedger
+// ledgers: without the cap it fills from the first few ledgers it reads, and
+// every found lookup of the run then resolves against one of those few blobs.
+func TestCorpusSpansManyLedgersOnADenseDataset(t *testing.T) {
+	const txPerLedger = 4 * corpusMaxHashesPerLedger
+	f, release := openDenseHotFixture(t, 64, txPerLedger)
+	defer release()
+
+	view, err := f.view()
+	require.NoError(t, err)
+	defer view.Release()
+
+	s := newTxHashSampler(testRNG())
+	require.NoError(t, s.sampleChunk(view, f.Chunks[0], f.FirstLedger, f.LastLedger))
+
+	assert.GreaterOrEqual(t, len(s.hashes), corpusTargetHashes, "the pool did not fill")
+	assert.GreaterOrEqual(t, len(s.ledgers), corpusTargetHashes/corpusMaxHashesPerLedger,
+		"the pool covers too few ledgers")
+
+	perLedger := hashesPerLedger(t, f, view, s.hashes)
+	for seq, n := range perLedger {
+		assert.LessOrEqual(t, n, corpusMaxHashesPerLedger, "ledger %d is over the per-ledger cap", seq)
+	}
+	assert.Len(t, perLedger, len(s.ledgers), "ledgers lists exactly the ledgers that contributed")
+	assert.Len(t, uniqueHashes(s.hashes), len(s.hashes), "a hash is sampled at most once")
+}
+
+// TestCorpusPairsEachHashWithItsLedger checks the sampler's bookkeeping against
+// the served by-hash path: every hash resolves to a ledger the sampler listed,
+// and the ledgers it listed are exactly the ones the hashes resolve to. The
+// draw picks hashes out of apply order, so a hash taken from one ledger and
+// recorded against another would otherwise go unnoticed.
+func TestCorpusPairsEachHashWithItsLedger(t *testing.T) {
+	f, release := openDenseHotFixture(t, 64, 4*corpusMaxHashesPerLedger)
+	defer release()
+
+	view, err := f.view()
+	require.NoError(t, err)
+	defer view.Release()
+
+	s := newTxHashSampler(testRNG())
+	require.NoError(t, s.sampleChunk(view, f.Chunks[0], f.FirstLedger, f.LastLedger))
+	require.NotEmpty(t, s.hashes)
+
+	resolved := hashesPerLedger(t, f, view, s.hashes)
+	seqs := make([]uint32, 0, len(resolved))
+	for seq := range resolved {
+		seqs = append(seqs, seq)
+	}
+	assert.ElementsMatch(t, s.ledgers, seqs, "the pool's hashes come from the ledgers the sampler listed")
+}
+
+// TestCorpusTakesEveryHashOfALedgerBelowTheCap pins what the cap does not do. A
+// dataset whose ledgers hold fewer transactions than the cap contributes every
+// one of them, and fills the pool by reading more ledgers instead.
+func TestCorpusTakesEveryHashOfALedgerBelowTheCap(t *testing.T) {
+	const txPerLedger = 4
+	f, release := openDenseHotFixture(t, 256, txPerLedger)
+	defer release()
+
+	view, err := f.view()
+	require.NoError(t, err)
+	defer view.Release()
+
+	s := newTxHashSampler(testRNG())
+	require.NoError(t, s.sampleChunk(view, f.Chunks[0], f.FirstLedger, f.LastLedger))
+
+	assert.GreaterOrEqual(t, len(s.hashes), corpusTargetHashes, "the pool did not fill")
+	for seq, n := range hashesPerLedger(t, f, view, s.hashes) {
+		assert.Equal(t, txPerLedger, n, "ledger %d did not contribute its whole transaction set", seq)
+	}
+	assert.Len(t, uniqueHashes(s.hashes), len(s.hashes), "a hash is sampled at most once")
+}
+
+// TestCorpusSkipsLedgersWithoutTransactions pins that a ledger carrying no
+// transaction contributes nothing and counts as no coverage, so a dataset of
+// mostly empty ledgers cannot report a wider corpus than it has.
+func TestCorpusSkipsLedgersWithoutTransactions(t *testing.T) {
+	const numLedgers = 400
+	packDir, txLedgers := writeSourcePack(t, t.TempDir(), chunk.ID(0), numLedgers)
+	f, release := openHotFixtureOverPack(t, packDir, numLedgers)
+	defer release()
+
+	view, err := f.view()
+	require.NoError(t, err)
+	defer view.Release()
+
+	s := newTxHashSampler(testRNG())
+	require.NoError(t, s.sampleChunk(view, f.Chunks[0], f.FirstLedger, f.LastLedger))
+
+	require.NotEmpty(t, s.hashes)
+	assert.LessOrEqual(t, len(s.ledgers), txLedgers, "only tx-bearing ledgers may contribute")
+	assert.Len(t, s.hashes, len(s.ledgers), "each of these ledgers holds one transaction")
+	for _, seq := range s.ledgers {
+		assert.Zero(t, (seq-f.FirstLedger)%eventEvery, "ledger %d carries no transaction", seq)
+	}
+}
+
+// TestSampleHashesFromLedgerDrawsARandomSubset pins the per-ledger draw: a
+// random subset of the cap's size, not the ledger's opening transactions, and
+// the whole set when the ledger holds fewer than the cap.
+func TestSampleHashesFromLedgerDrawsARandomSubset(t *testing.T) {
+	parts := make([]sdkingest.LedgerTxParts, 64)
+	for i := range parts {
+		parts[i].Hash[0] = byte(i)
+	}
+
+	first := sampleHashesFromLedger(rand.New(rand.NewPCG(1, 1)), parts)
+	second := sampleHashesFromLedger(rand.New(rand.NewPCG(2, 2)), parts)
+	require.Len(t, first, corpusMaxHashesPerLedger)
+	require.Len(t, second, corpusMaxHashesPerLedger)
+	assert.NotEqual(t, first, second, "two seeds must draw different subsets")
+	assert.Len(t, uniqueHashes(first), len(first), "a draw takes each transaction at most once")
+
+	inOrder := make([][32]byte, 0, corpusMaxHashesPerLedger)
+	for _, p := range parts[:corpusMaxHashesPerLedger] {
+		inOrder = append(inOrder, p.Hash)
+	}
+	assert.NotEqual(t, inOrder, first, "the draw is not the ledger's first transactions")
+
+	few := parts[:3]
+	whole := [][32]byte{few[0].Hash, few[1].Hash, few[2].Hash}
+	assert.ElementsMatch(t, whole, sampleHashesFromLedger(testRNG(), few))
+}
+
+// TestCorpusLogsItsLedgerCoverage pins what the corpus build reports about
+// itself: the hash count, the ledger count and the ledger range it spans, plus
+// a warning when the whole pool came from one ledger, which makes every found
+// lookup of the run read that ledger.
+func TestCorpusLogsItsLedgerCoverage(t *testing.T) {
+	t.Run("many ledgers", func(t *testing.T) {
+		f, release := openDenseHotFixture(t, 8, 20)
+		defer release()
+
+		info, warnings := buildCorpusCapturingLogs(t, f)
+		assert.Contains(t, info, "hashes over 8 ledgers spanning 2..9")
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("one ledger", func(t *testing.T) {
+		f, release := openDenseHotFixture(t, 1, 20)
+		defer release()
+
+		info, warnings := buildCorpusCapturingLogs(t, f)
+		assert.Contains(t, info, "hashes over 1 ledgers spanning 2..2")
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "came from ledger 2 alone")
+	})
+}
+
+// buildCorpusCapturingLogs builds the tx-hash corpus over f and returns the
+// coverage line it logged and every warning it raised.
+func buildCorpusCapturingLogs(t *testing.T, f *queryFixture) (string, []string) {
+	t.Helper()
+	logger := testLogger()
+	done := logger.StartTest(logrus.InfoLevel)
+	_, err := buildTxHashCorpus(context.Background(), logger, f, 0.1, defaultSeed)
+	entries := done()
+	require.NoError(t, err)
+
+	var coverage string
+	var warnings []string
+	for _, e := range entries {
+		if e.Level == logrus.WarnLevel {
+			warnings = append(warnings, e.Message)
+		}
+		if strings.HasPrefix(e.Message, "txhash corpus:") {
+			coverage = e.Message
+		}
+	}
+	require.NotEmpty(t, coverage, "the corpus build logs its coverage")
+	return coverage, warnings
+}
+
+// hashesPerLedger resolves every hash through the served by-hash path and
+// counts how many of them landed in each ledger.
+func hashesPerLedger(
+	t *testing.T, f *queryFixture, view *query.ReadView, hashes [][32]byte,
+) map[uint32]int {
+	t.Helper()
+	reader := adapters.NewTransactionReader(f.Passphrase, nil)
+	ctx := adapters.WithView(context.Background(), view)
+	counts := map[uint32]int{}
+	for _, h := range hashes {
+		tx, err := reader.GetTransaction(ctx, xdr.Hash(h))
+		require.NoError(t, err, "sampled hash %x does not resolve", h)
+		counts[tx.Ledger.Sequence]++
+	}
+	return counts
+}
+
+// uniqueHashes returns the distinct hashes of the slice.
+func uniqueHashes(hashes [][32]byte) map[[32]byte]struct{} {
+	set := make(map[[32]byte]struct{}, len(hashes))
+	for _, h := range hashes {
+		set[h] = struct{}{}
+	}
+	return set
+}
+
+// openDenseHotFixture ingests a pack whose ledgers each carry txPerLedger
+// transactions into a hot database and opens the query fixture over it.
+func openDenseHotFixture(t *testing.T, numLedgers uint32, txPerLedger int) (*queryFixture, func()) {
+	t.Helper()
+	packDir := writeDenseSourcePack(t, t.TempDir(), chunk.ID(0), numLedgers, txPerLedger)
+	return openHotFixtureOverPack(t, packDir, numLedgers)
+}
+
+// openHotFixtureOverPack ingests numLedgers ledgers of chunk 0 from packDir
+// into a fresh hot database and returns the query fixture over it, with the
+// passphrase the fixture builders sign under.
+func openHotFixtureOverPack(t *testing.T, packDir string, numLedgers uint32) (*queryFixture, func()) {
+	t.Helper()
+	chunkID := chunk.ID(0)
+	hotRoot := t.TempDir()
+	require.NoError(t, runHot(context.Background(), testLogger(), hotOptions{
+		Source:     sourceConfig{Kind: sourcePack, PackDir: packDir},
+		StartChunk: chunkID,
+		NumChunks:  1,
+		NumLedgers: numLedgers,
+		HotRoot:    hotRoot,
+		OutDir:     filepath.Join(t.TempDir(), "csv"),
+	}))
+	f, release, err := openHotFixture(testLogger(), hotQueryOptions{
+		HotRoot: hotRoot,
+		Chunk:   chunkID,
+		Plan:    queryPlan{Passphrase: network.PublicNetworkPassphrase},
+	})
+	require.NoError(t, err)
+	return f, release
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus_test.go
@@ -3,6 +3,7 @@ package bench
 import (
 	"context"
 	"math/rand/v2"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/adapters"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 )
 
@@ -194,6 +196,74 @@ func buildCorpusCapturingLogs(t *testing.T, f *queryFixture) (string, []string) 
 	}
 	require.NotEmpty(t, coverage, "the corpus build logs its coverage")
 	return coverage, warnings
+}
+
+// TestVerifySampledHashReportsThePassphrase pins which of the two checks reports a
+// failure, since they send the operator to different places. A passphrase the
+// dataset was not signed under fails the envelope pairing, inside the very
+// ledger the hash was sampled from, and names --network-passphrase. A fixture
+// whose tx-hash index cannot resolve the hash pairs fine and fails the served
+// probe, which must not name the passphrase.
+func TestVerifySampledHashReportsThePassphrase(t *testing.T) {
+	f, release := openDenseHotFixture(t, 4, 4)
+	defer release()
+
+	view, err := f.view()
+	require.NoError(t, err)
+	defer view.Release()
+
+	s := newTxHashSampler(testRNG())
+	require.NoError(t, s.sampleChunk(view, f.Chunks[0], f.FirstLedger, f.LastLedger))
+	require.NotEmpty(t, s.hashes)
+	hash, seq := s.first()
+
+	t.Run("the configured passphrase resolves it", func(t *testing.T) {
+		require.NoError(t, verifySampledHashResolves(context.Background(), view, f, hash, seq))
+	})
+
+	t.Run("wrong passphrase", func(t *testing.T) {
+		wrong := *f
+		wrong.Passphrase = network.TestNetworkPassphrase
+		err := verifySampledHashResolves(context.Background(), view, &wrong, hash, seq)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--network-passphrase")
+		assert.NotContains(t, err.Error(), "probe of a known transaction hash failed")
+	})
+}
+
+// TestVerifySampledHashReportsAProbeFailure covers the other side of the split:
+// a cold fixture whose tx-hash window index is gone still pairs the envelope,
+// because the passphrase is right, and fails on the served lookup. The report
+// must name the probe and leave the passphrase out of it.
+func TestVerifySampledHashReportsAProbeFailure(t *testing.T) {
+	chunkID := chunk.ID(0)
+	coldRoot := ingestColdChunk(t, chunkID)
+	require.NoError(t, os.RemoveAll(geometry.NewLayout(coldRoot).TxHashIndexRoot()))
+
+	// The types exclude txhash, so the open only warns about the absent index
+	// and leaves the fixture to be probed here.
+	f, release, err := openColdFixture(testLogger(), coldQueryOptions{
+		ColdRoot:   coldRoot,
+		StartChunk: chunkID,
+		NumChunks:  1,
+		Plan:       queryPlan{Types: []string{queryTypeLedgers}, Passphrase: network.PublicNetworkPassphrase},
+	})
+	require.NoError(t, err)
+	defer release()
+
+	view, err := f.view()
+	require.NoError(t, err)
+	defer view.Release()
+
+	s := newTxHashSampler(testRNG())
+	require.NoError(t, s.sampleChunk(view, chunkID, f.FirstLedger, f.LastLedger))
+	require.NotEmpty(t, s.hashes)
+	hash, seq := s.first()
+
+	err = verifySampledHashResolves(context.Background(), view, f, hash, seq)
+	require.ErrorContains(t, err, "probe of a known transaction hash failed")
+	assert.Contains(t, err.Error(), "tx-hash index may be missing")
+	assert.NotContains(t, err.Error(), "--network-passphrase")
 }
 
 // hashesPerLedger resolves every hash through the served by-hash path and

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_corpus_test.go
@@ -273,7 +273,7 @@ func hashesPerLedger(
 ) map[uint32]int {
 	t.Helper()
 	reader := adapters.NewTransactionReader(f.Passphrase, nil)
-	ctx := adapters.WithView(context.Background(), view)
+	ctx := query.WithView(context.Background(), view)
 	counts := map[uint32]int{}
 	for _, h := range hashes {
 		tx, err := reader.GetTransaction(ctx, xdr.Hash(h))

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_dispatch.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_dispatch.go
@@ -10,15 +10,13 @@ import (
 )
 
 // This file is the query bench's dispatcher: it issues a per-request closure at
-// a fixed arrival rate and collects what every request observed. It is
-// deliberately ignorant of what the requests do — the per-type bodies in
-// query_types.go own that — and it does no I/O of its own, so the only thing
+// a fixed arrival rate and collects what every request observed. What a request
+// does is the business of the per-type bodies in query_types.go; the dispatcher
+// only paces, times and counts, and it does no I/O of its own, so the only thing
 // between the timer and the store is the query itself.
 
-// cellSample is one measured request: how long it took, the number of items the
-// response carried, and the sub-stage it belongs to. An empty stage means the
-// sample belongs only to the type's blended row; txhash sets it so found and
-// not-found lookups are also reported apart (see recordLeg).
+// cellSample is one measured request: what it cost, what its response carried,
+// and which sub-stage of its query type it belongs to.
 type cellSample struct {
 	// service is how long the request body itself ran, measured by timed.
 	service time.Duration
@@ -27,8 +25,13 @@ type cellSample struct {
 	// schedule on top of the service time, so it is the latency a client
 	// sending at the target rate observes.
 	scheduled time.Duration
-	items     int
-	stage     string
+	// items counts what the response carried: ledgers, transactions or
+	// events, depending on the query type.
+	items int
+	// stage names a sub-stage of the query type, so these samples are also
+	// reported apart from the type's blended row. Only txhash sets it,
+	// splitting found lookups from not-found ones (see recordLeg).
+	stage string
 }
 
 // queryRequest issues one request against the fixture and reports what the
@@ -37,15 +40,13 @@ type cellSample struct {
 // not share mutable state between concurrent requests.
 //
 // The whole request is inside the caller's timer, read-view acquisition
-// included: a served request pays for its own view, and leaving that out would
-// flatter every number.
+// included, because a served request pays for its own view.
 type queryRequest func(rng *rand.Rand) (cellSample, error)
 
 // maxInFlight is the number of requests a paced leg may have outstanding at
 // once. A request that arrives while the cap is full is shed and counted, so a
-// target rate the store cannot keep up with shows as a shed count rather than
-// as an unbounded pile of goroutines that would measure the machine's scheduler
-// instead of the store.
+// target rate the store cannot keep up with shows up as a shed count and the
+// leg's goroutine count stays bounded — what it measures stays the store.
 const maxInFlight = 512
 
 // Mixing constants for the per-request seeds. They are odd and mutually prime
@@ -59,8 +60,7 @@ const (
 // legResult is one paced leg's outcome.
 type legResult struct {
 	// samples holds the measured requests that answered. A request that
-	// failed contributes no sample: a latency for a request that did not
-	// answer is not a latency.
+	// failed contributes no sample, since it has no latency to report.
 	samples []cellSample
 	// lags holds one dispatch lag per measured position, in schedule order,
 	// shed positions included. A zero is a real observation — a dispatch that
@@ -118,7 +118,8 @@ func (c *legCollector) recordShed() {
 	c.shed++
 }
 
-// recordSample stores a measured request's sample and its completion time.
+// recordSample stores a measured request's sample and keeps the leg's latest
+// completion time, which is where its wall ends.
 func (c *legCollector) recordSample(s cellSample, done time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -129,7 +130,8 @@ func (c *legCollector) recordSample(s cellSample, done time.Time) {
 }
 
 // recordError notes that a measured request failed at the given time. A failed
-// request still occupied the leg, so its completion counts toward the wall.
+// request occupied the leg like any other, so its completion counts toward the
+// wall.
 func (c *legCollector) recordError(done time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -170,9 +172,9 @@ func (c *legCollector) result(firstDue time.Time) legResult {
 // request runs on its own goroutine with its own RNG, and the in-flight count
 // is capped at maxInFlight.
 //
-// The returned error is a context error: it means the leg was cut short and its
-// result is not a measurement. A request that fails is counted in errs and does
-// not end the leg.
+// The returned error is a context error: it means the leg was cut short, so
+// discard its result. A request that fails is counted in errs and does not end
+// the leg.
 func runPacedLeg(
 	ctx context.Context, rps float64, duration time.Duration, warmup int, seed int64, req queryRequest,
 ) (legResult, error) {

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_dispatch.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_dispatch.go
@@ -10,10 +10,10 @@ import (
 )
 
 // This file is the query bench's dispatcher: it issues a per-request closure at
-// a fixed arrival rate and collects every request's latency. It is deliberately
-// ignorant of what the requests do — the per-type bodies in query_types.go own
-// that — and it does no I/O of its own, so the only thing between the timer and
-// the store is the query itself.
+// a fixed arrival rate and collects what every request observed. It is
+// deliberately ignorant of what the requests do — the per-type bodies in
+// query_types.go own that — and it does no I/O of its own, so the only thing
+// between the timer and the store is the query itself.
 
 // cellSample is one measured request: how long it took, the number of items the
 // response carried, and the sub-stage it belongs to. An empty stage means the
@@ -58,15 +58,21 @@ const (
 
 // legResult is one paced leg's outcome.
 type legResult struct {
-	// samples holds the measured requests that answered, in completion order.
-	// A request that failed contributes no sample: a latency for a request
-	// that did not answer is not a latency.
+	// samples holds the measured requests that answered. A request that
+	// failed contributes no sample: a latency for a request that did not
+	// answer is not a latency.
 	samples []cellSample
-	// lags holds the dispatch lag of every dispatched measured request in
-	// dispatch order. A zero is a real observation — a dispatch that was on
-	// time — so zeros are kept.
+	// lags holds one dispatch lag per measured position, in schedule order,
+	// shed positions included. A zero is a real observation — a dispatch that
+	// was on time — so zeros are kept, and a shed position's lag shows how far
+	// behind schedule the dispatcher ran while it was shedding.
 	lags []time.Duration
-	// wall spans the first measured due time to the last measured completion.
+	// offered is the span of arrivals the leg offered the store: its measured
+	// positions times the arrival interval. It is the denominator of the
+	// leg's achieved rate.
+	offered time.Duration
+	// wall spans the first measured due time to the last measured completion,
+	// so it includes the tail the leg spent draining its last requests.
 	wall time.Duration
 	// dispatched counts the measured requests that got a slot and ran.
 	dispatched int
@@ -88,13 +94,20 @@ type legCollector struct {
 	errs       int
 }
 
-// recordDispatch notes that a measured request got a slot and started, lag
-// behind its due time.
-func (c *legCollector) recordDispatch(lag time.Duration) {
+// recordLag notes how far behind its due time a measured position was reached.
+// Every measured position is charged one lag, whether its request ran or was
+// shed.
+func (c *legCollector) recordLag(lag time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lags = append(c.lags, lag)
+}
+
+// recordDispatch notes that a measured request got a slot and started.
+func (c *legCollector) recordDispatch() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.dispatched++
-	c.lags = append(c.lags, lag)
 }
 
 // recordShed notes that a measured request was dropped because the in-flight
@@ -151,9 +164,11 @@ func (c *legCollector) result(firstDue time.Time) legResult {
 // the leg keeps its rate whatever the store does with it.
 //
 // Positions 0 to warmup-1 run at the leg's rate and record nothing; the
-// round(rps × duration) positions after them are measured, so a leg's schedule
-// spans exactly duration. Each request runs on its own goroutine with its own
-// RNG, and the in-flight count is capped at maxInFlight.
+// round(rps × duration) positions after them are measured. Their due times run
+// from warmup×interval to (warmup+measured-1)×interval, one interval short of
+// duration, and the leg offers the store measured×interval of arrivals. Each
+// request runs on its own goroutine with its own RNG, and the in-flight count
+// is capped at maxInFlight.
 //
 // The returned error is a context error: it means the leg was cut short and its
 // result is not a measurement. A request that fails is counted in errs and does
@@ -169,31 +184,42 @@ func runPacedLeg(
 	}
 	warmup = max(warmup, 0)
 	measured := measuredRequests(rps, duration)
-	schedule := newPaceSchedule(time.Duration(float64(time.Second)/rps), 0)
+	interval := time.Duration(float64(time.Second) / rps)
+	schedule := newPaceSchedule(interval, 0)
 
 	collector := &legCollector{}
 	slots := make(chan struct{}, maxInFlight)
 	var wg sync.WaitGroup
 	for pos := range warmup + measured {
+		if err := ctx.Err(); err != nil {
+			wg.Wait()
+			return legResult{}, err
+		}
 		due := schedule.dueForPos(pos)
-		if err := contextSleep(ctx, time.Until(due)); err != nil {
+		if err := contextSleep(ctx, due.Sub(schedule.clock())); err != nil {
 			wg.Wait()
 			return legResult{}, err
 		}
 		launchPacedRequest(&wg, slots, collector, req, legRNG(seed, pos, rps), due, pos >= warmup)
 	}
 	wg.Wait()
-	return collector.result(schedule.dueForPos(warmup)), nil
+	res := collector.result(schedule.dueForPos(warmup))
+	res.offered = time.Duration(measured) * interval
+	return res, nil
 }
 
 // launchPacedRequest starts one request of a paced leg on its own goroutine,
 // taking a slot from slots first. With no slot free the request is shed: it is
-// counted and nothing else about it is recorded. A warmup request runs in full
-// and records nothing either way.
+// counted and it runs nothing. A measured position is charged its dispatch lag
+// either way, so the lag distribution covers the whole leg. A warmup request
+// runs in full and records nothing.
 func launchPacedRequest(
 	wg *sync.WaitGroup, slots chan struct{}, collector *legCollector,
 	req queryRequest, rng *rand.Rand, due time.Time, measured bool,
 ) {
+	if measured {
+		collector.recordLag(max(time.Since(due), 0))
+	}
 	select {
 	case slots <- struct{}{}:
 	default:
@@ -203,7 +229,7 @@ func launchPacedRequest(
 		return
 	}
 	if measured {
-		collector.recordDispatch(max(time.Since(due), 0))
+		collector.recordDispatch()
 	}
 	wg.Go(func() {
 		defer func() { <-slots }()

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_dispatch_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_dispatch_test.go
@@ -14,26 +14,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// countingRequest is a queryRequest that answers immediately and counts every
-// call, so a test can tell how many requests a leg actually issued — warmup
-// requests included, which leave no sample behind.
+// countingRequest is a queryRequest that counts every call, so a test can tell
+// how many requests a leg actually issued — warmup requests included, which
+// leave no sample behind. Its body sleeps for countingRequestService so that
+// the service time it reports is never zero: an empty body can start and finish
+// inside one clock tick, and timed would then read the same value twice.
 type countingRequest struct {
 	calls atomic.Int64
 }
 
+// countingRequestService is the work countingRequest does, long enough for the
+// clock to move and short enough to leave the leg's pacing alone.
+const countingRequestService = 50 * time.Microsecond
+
 func (c *countingRequest) run(*rand.Rand) (cellSample, error) {
 	c.calls.Add(1)
-	return timed("", func() (int, error) { return 1, nil })
+	return timed("", func() (int, error) {
+		time.Sleep(countingRequestService)
+		return 1, nil
+	})
 }
 
 // TestRunPacedLegMeasuredCount pins the shape of a clean leg: the number of
 // measured requests is round(rps × duration), warmup requests run at the leg's
-// rate but leave no sample, every measured request that answered carries a
+// rate but leave no sample, the offered window is the measured positions times
+// the arrival interval, every measured request that answered carries a
 // scheduled latency at least as long as its service time, and nothing is shed
 // or fails.
 func TestRunPacedLegMeasuredCount(t *testing.T) {
+	const rps = 200.0
 	fake := &countingRequest{}
-	res, err := runPacedLeg(t.Context(), 200, 100*time.Millisecond, 5, 42, fake.run)
+	res, err := runPacedLeg(t.Context(), rps, 100*time.Millisecond, 5, 42, fake.run)
 	require.NoError(t, err)
 
 	assert.Equal(t, 20, res.dispatched)
@@ -43,6 +54,7 @@ func TestRunPacedLegMeasuredCount(t *testing.T) {
 	assert.Equal(t, 0, res.errs)
 	assert.Equal(t, int64(25), fake.calls.Load(), "warmup requests run at the leg's rate")
 	assert.Positive(t, res.wall)
+	assert.Equal(t, offeredWindow(rps, res), res.offered)
 
 	for i, s := range res.samples {
 		assert.Positive(t, s.service, "sample %d", i)
@@ -113,7 +125,8 @@ func (b *blockingRequest) run(*rand.Rand) (cellSample, error) {
 
 // TestRunPacedLegSheds pins what a leg does when the store cannot keep up: the
 // first maxInFlight measured requests get a slot and every later one is shed,
-// no position is silently skipped, and the shed requests leave no sample.
+// no position is silently skipped, the shed requests leave no sample, and the
+// lag row still covers every measured position.
 func TestRunPacedLegSheds(t *testing.T) {
 	fake := &blockingRequest{release: make(chan struct{})}
 	// The leg's schedule spans 100ms and a shed position costs nothing, so the
@@ -129,14 +142,16 @@ func TestRunPacedLegSheds(t *testing.T) {
 	assert.Equal(t, 1000-maxInFlight, res.shed)
 	assert.Equal(t, 1000, res.dispatched+res.shed)
 	assert.Len(t, res.samples, maxInFlight)
-	assert.Len(t, res.lags, maxInFlight)
+	assert.Len(t, res.lags, 1000, "every measured position is charged a dispatch lag")
 	assert.Equal(t, int64(maxInFlight), fake.calls.Load())
 	assert.Equal(t, int64(0), fake.inFlight.Load())
 }
 
 // TestRunPacedLegCountsErrors pins that a failed request is counted and leaves
-// no sample, and that it does not end the leg.
+// no sample, that it does not end the leg, and that a failure does not change
+// the window the leg offered.
 func TestRunPacedLegCountsErrors(t *testing.T) {
+	const rps = 200.0
 	var ordinal atomic.Int64
 	fail := errors.New("request failed")
 	req := func(*rand.Rand) (cellSample, error) {
@@ -146,7 +161,7 @@ func TestRunPacedLegCountsErrors(t *testing.T) {
 		return timed("", func() (int, error) { return 1, nil })
 	}
 
-	res, err := runPacedLeg(t.Context(), 200, 100*time.Millisecond, 0, 11, req)
+	res, err := runPacedLeg(t.Context(), rps, 100*time.Millisecond, 0, 11, req)
 	require.NoError(t, err)
 
 	assert.Equal(t, 20, res.dispatched)
@@ -154,6 +169,13 @@ func TestRunPacedLegCountsErrors(t *testing.T) {
 	assert.Len(t, res.samples, 10)
 	assert.Len(t, res.lags, 20)
 	assert.Equal(t, 0, res.shed)
+	assert.Equal(t, offeredWindow(rps, res), res.offered)
+}
+
+// offeredWindow is the span of arrivals a leg at rate rps offered: one arrival
+// interval per measured position, shed positions included.
+func offeredWindow(rps float64, res legResult) time.Duration {
+	return time.Duration(res.dispatched+res.shed) * time.Duration(float64(time.Second)/rps)
 }
 
 // TestRunPacedLegContextCancel pins that a canceled context ends the leg at its
@@ -214,6 +236,33 @@ func TestRunPacedLegLagStaysSmall(t *testing.T) {
 	// A serialized leg would run 50 requests of 20ms back to back, so it could
 	// not finish inside half a second.
 	assert.Less(t, res.wall, 500*time.Millisecond, "leg wall")
+}
+
+// TestLaunchPacedRequestChargesLateDispatch pins that a dispatch the loop
+// reached late is charged to the scheduled latency a client sees rather than
+// hidden in the service time, which is the property the open-loop mode exists
+// for. The request itself answers immediately, so everything the scheduled
+// latency holds beyond it is the dispatcher's own lateness.
+func TestLaunchPacedRequestChargesLateDispatch(t *testing.T) {
+	const late = 50 * time.Millisecond
+	req := func(*rand.Rand) (cellSample, error) {
+		return timed("", func() (int, error) { return 1, nil })
+	}
+
+	collector := &legCollector{}
+	slots := make(chan struct{}, 1)
+	var wg sync.WaitGroup
+	due := time.Now().Add(-late)
+	launchPacedRequest(&wg, slots, collector, req, legRNG(1, 0, 1), due, true)
+	wg.Wait()
+
+	res := collector.result(due)
+	require.Len(t, res.samples, 1)
+	require.Len(t, res.lags, 1)
+	assert.GreaterOrEqual(t, res.samples[0].scheduled, late, "the client waited from the due time")
+	assert.Less(t, res.samples[0].service, res.samples[0].scheduled-40*time.Millisecond,
+		"the request itself took almost none of that wait")
+	assert.GreaterOrEqual(t, res.lags[0], late, "the dispatch lag is charged too")
 }
 
 // TestRunPacedLegRejectsBadArguments pins that a leg with no rate or no

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
@@ -111,16 +111,16 @@ func runQueryHot(ctx context.Context, logger *supportlog.Entry, opts hotQueryOpt
 // rebuilds the catalog state they imply: the chunk's hot key runs the ready
 // bracket (transient then ready) and its database is opened through
 // OpenReadyWrite — the same must-exist, never-creating open ingestion resumes a
-// chunk with, so a missing or gutted database fails here instead of being healed
-// into an empty one. query.OpenRegistry then publishes the handle as the live
-// chunk, which is what makes routing resolve it hot; nothing is frozen, so the
-// hot tier is the only one that can serve it.
+// chunk with, so a missing or gutted database fails the open here.
+// query.OpenRegistry then publishes the handle as the live chunk, which is what
+// makes routing resolve it hot; nothing is frozen, so the hot tier is the only
+// one that can serve it.
 //
 // The registry's latest ledger is what the database actually holds
 // (MaxCommittedSeq), never the chunk's nominal last: a capped ingest stops
-// mid-chunk, and a view claiming ledgers that were never ingested would turn
-// every query past the cap into a miss. --sample-ledgers narrows the sampled
-// range further, and a cap past what was ingested is clamped, not trusted.
+// mid-chunk, so the view claims only the ledgers that were ingested and no
+// query lands past the cap. --sample-ledgers narrows the sampled range further,
+// and a cap past what was ingested is clamped.
 func openHotFixture(logger *supportlog.Entry, opts hotQueryOptions) (*queryFixture, func(), error) {
 	layout := geometry.NewLayout(opts.HotRoot)
 	cat, releaseCat, err := openScratchCatalog(opts.HotRoot, scratchPrefixQuery, layout, logger)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
@@ -35,7 +35,7 @@ func newQueryHotCommand() *cobra.Command {
 	cmd := newBenchCommand("hot",
 		"Benchmark hot reads: queries served from one chunk's hot database",
 		&prof,
-		func(ctx context.Context, logger *supportlog.Entry, outDir string) error {
+		func(ctx context.Context, logger *supportlog.Entry, env runEnv) error {
 			plan, err := qf.plan()
 			if err != nil {
 				return err
@@ -45,7 +45,7 @@ func newQueryHotCommand() *cobra.Command {
 				Chunk:         chunk.ID(chunkID),
 				SampleLedgers: sampleLedgers,
 				Plan:          plan,
-				OutDir:        outDir,
+				OutDir:        env.OutDir,
 			})
 		}, &qf)
 	fs := cmd.Flags()
@@ -175,6 +175,9 @@ func openHotFixture(logger *supportlog.Entry, opts hotQueryOptions) (*queryFixtu
 	}
 	f := &queryFixture{
 		registry:    registry,
+		Logger:      logger,
+		Layout:      layout,
+		Passphrase:  opts.Plan.Passphrase,
 		Chunks:      []chunk.ID{opts.Chunk},
 		FirstLedger: first,
 		LastLedger:  last,

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
@@ -164,7 +164,7 @@ func openHotFixture(logger *supportlog.Entry, opts hotQueryOptions) (*queryFixtu
 		release()
 		return nil, nil, fmt.Errorf("hot chunk %s holds no committed ledger: ingest it before querying it", opts.Chunk)
 	}
-	registry.SetLatestLedger(committed)
+	registry.SetLatestLedger(committed, 0)
 
 	first := opts.Chunk.FirstLedger()
 	last := committed
@@ -175,8 +175,6 @@ func openHotFixture(logger *supportlog.Entry, opts hotQueryOptions) (*queryFixtu
 	}
 	f := &queryFixture{
 		registry:    registry,
-		Logger:      logger,
-		Layout:      layout,
 		Passphrase:  opts.Plan.Passphrase,
 		Chunks:      []chunk.ID{opts.Chunk},
 		FirstLedger: first,

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
@@ -115,11 +115,11 @@ func runQueryHot(ctx context.Context, logger *supportlog.Entry, opts hotQueryOpt
 // bracket (transient then ready) and its database is opened through
 // OpenReadyWrite — the same must-exist, never-creating open ingestion resumes a
 // chunk with, so a missing or gutted database fails here instead of being healed
-// into an empty one. The handle is published, which is what makes routing
-// resolve the chunk hot; nothing is frozen, so the hot tier is the only one that
-// can serve it.
+// into an empty one. query.OpenRegistry then publishes the handle as the live
+// chunk, which is what makes routing resolve it hot; nothing is frozen, so the
+// hot tier is the only one that can serve it.
 //
-// The read view's latest ledger is what the database actually holds
+// The registry's latest ledger is what the database actually holds
 // (MaxCommittedSeq), never the chunk's nominal last: a capped ingest stops
 // mid-chunk, and a view claiming ledgers that were never ingested would turn
 // every query past the cap into a miss. --sample-ledgers narrows the sampled
@@ -146,25 +146,30 @@ func openHotFixture(logger *supportlog.Entry, opts hotQueryOptions) (*queryFixtu
 		return nil, nil, fmt.Errorf("open hot chunk %s at %s: %w", opts.Chunk, path, err)
 	}
 
-	registry := query.NewRegistry(cat, geometry.NewRetention(0, opts.Chunk))
-	registry.PublishHandle(opts.Chunk, db)
+	committed, ok, err := db.MaxCommittedSeq()
+	if err != nil {
+		_ = db.Close()
+		releaseCat()
+		return nil, nil, fmt.Errorf("read hot chunk %s last committed ledger: %w", opts.Chunk, err)
+	}
+	if !ok {
+		_ = db.Close()
+		releaseCat()
+		return nil, nil, fmt.Errorf("hot chunk %s holds no committed ledger: ingest it before querying it", opts.Chunk)
+	}
+
+	registry, err := query.OpenRegistry(cat, geometry.NewRetention(0, opts.Chunk), db, committed)
+	if err != nil {
+		_ = db.Close()
+		releaseCat()
+		return nil, nil, fmt.Errorf("open the read registry over hot chunk %s: %w", opts.Chunk, err)
+	}
 	// Registry.Close closes every published handle, so releasing the registry
 	// releases the database.
 	release := func() {
 		registry.Close()
 		releaseCat()
 	}
-
-	committed, ok, err := db.MaxCommittedSeq()
-	if err != nil {
-		release()
-		return nil, nil, fmt.Errorf("read hot chunk %s last committed ledger: %w", opts.Chunk, err)
-	}
-	if !ok {
-		release()
-		return nil, nil, fmt.Errorf("hot chunk %s holds no committed ledger: ingest it before querying it", opts.Chunk)
-	}
-	registry.SetLatestLedger(committed, 0)
 
 	first := opts.Chunk.FirstLedger()
 	last := committed

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
@@ -15,17 +15,14 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk"
 )
 
-// Defaults for the hot sweep. Hot queries are the fast tier, so more of them
-// fit in the same leg budget, and each cell warms the store's caches first —
-// the hot tier's steady state is warm.
-const (
-	defaultHotIters  = 200
-	defaultHotWarmup = 20
-)
+// defaultHotWarmup is --warmup's default: the unmeasured requests a hot leg
+// dispatches at its rate before it starts measuring. The hot tier's steady
+// state is a warm cache, so a hot leg warms one first.
+const defaultHotWarmup = 20
 
 func newQueryHotCommand() *cobra.Command {
 	var (
-		qf   = queryFlags{iters: defaultHotIters, warmup: defaultHotWarmup, warmupBound: true}
+		qf   = queryFlags{warmup: defaultHotWarmup, warmupBound: true}
 		prof profileFlags
 
 		chunkID       uint32
@@ -76,7 +73,7 @@ type hotQueryOptions struct {
 	// so the corpora stay inside what was ingested.
 	SampleLedgers uint32
 
-	// Plan is the validated --types × --query-concurrency sweep.
+	// Plan is the validated --types × --target-rps ladder.
 	Plan queryPlan
 
 	// OutDir receives the CSV report.

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_hot.go
@@ -1,0 +1,187 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk"
+)
+
+// Defaults for the hot sweep. Hot queries are the fast tier, so more of them
+// fit in the same leg budget, and each cell warms the store's caches first —
+// the hot tier's steady state is warm.
+const (
+	defaultHotIters  = 200
+	defaultHotWarmup = 20
+)
+
+func newQueryHotCommand() *cobra.Command {
+	var (
+		qf   = queryFlags{iters: defaultHotIters, warmup: defaultHotWarmup, warmupBound: true}
+		prof profileFlags
+
+		chunkID       uint32
+		hotDir        string
+		sampleLedgers uint32
+	)
+	cmd := newBenchCommand("hot",
+		"Benchmark hot reads: queries served from one chunk's hot database",
+		&prof,
+		func(ctx context.Context, logger *supportlog.Entry, outDir string) error {
+			plan, err := qf.plan()
+			if err != nil {
+				return err
+			}
+			return runQueryHot(ctx, logger, hotQueryOptions{
+				HotRoot:       hotDir,
+				Chunk:         chunk.ID(chunkID),
+				SampleLedgers: sampleLedgers,
+				Plan:          plan,
+				OutDir:        outDir,
+			})
+		}, &qf)
+	fs := cmd.Flags()
+	fs.Uint32Var(&chunkID, "chunk", 0, "the chunk to query (required)")
+	fs.StringVar(&hotDir, "hot-dir", "",
+		"root holding the hot chunk databases, as bench-ingest hot's --hot-dir laid it out (required)")
+	fs.Uint32Var(&sampleLedgers, "sample-ledgers", 0,
+		"cap the sampled ledgers to this many from the chunk's start (0 = every ledger the database holds); "+
+			"match a capped ingest so the corpora stay inside what was ingested")
+	markRequired(cmd, "chunk", "hot-dir")
+	return cmd
+}
+
+// hotQueryOptions configures one hot read benchmark run.
+type hotQueryOptions struct {
+	// HotRoot is the layout root the hot chunk databases live under, at
+	// geometry.NewLayout(HotRoot).HotChunkPath(chunk) — as a bench-ingest hot
+	// run left it. The database is opened read-write, so the run needs write
+	// access to it, but the benchmark only reads.
+	HotRoot string
+
+	// Chunk is the chunk whose hot database is queried.
+	Chunk chunk.ID
+
+	// SampleLedgers caps the sampled ledgers to this many from the chunk's
+	// first (0 = every ledger the database holds). A capped bench-ingest hot run
+	// leaves a truncated database, and the campaign runner passes its cap here
+	// so the corpora stay inside what was ingested.
+	SampleLedgers uint32
+
+	// Plan is the validated --types × --query-concurrency sweep.
+	Plan queryPlan
+
+	// OutDir receives the CSV report.
+	OutDir string
+}
+
+// validate checks the flags before runQueryHot touches the filesystem.
+func (o hotQueryOptions) validate() error {
+	if o.HotRoot == "" {
+		return errors.New("--hot-dir is required")
+	}
+	if o.Chunk > maxChunkID {
+		return fmt.Errorf("--chunk=%d is past the last valid chunk ID %d", uint32(o.Chunk), uint32(maxChunkID))
+	}
+	return nil
+}
+
+// runQueryHot benchmarks the hot read path: queries against one chunk's hot
+// database under --hot-dir, routed through a read view exactly as a served
+// request is.
+func runQueryHot(ctx context.Context, logger *supportlog.Entry, opts hotQueryOptions) error {
+	if err := opts.validate(); err != nil {
+		return err
+	}
+	return runQueryBench(ctx, logger, opts.Plan, opts.OutDir, func() (*queryFixture, func(), error) {
+		return openHotFixture(logger, opts)
+	})
+}
+
+// openHotFixture opens one chunk's hot database and returns the read fixture
+// over it, plus the release that closes the handle and tears the catalog down.
+//
+// bench-ingest hot writes its databases under a SCRATCH catalog it then throws
+// away, so the tree arrives with the RocksDBs but no catalog naming them. This
+// rebuilds the catalog state they imply: the chunk's hot key runs the ready
+// bracket (transient then ready) and its database is opened through
+// OpenReadyWrite — the same must-exist, never-creating open ingestion resumes a
+// chunk with, so a missing or gutted database fails here instead of being healed
+// into an empty one. The handle is published, which is what makes routing
+// resolve the chunk hot; nothing is frozen, so the hot tier is the only one that
+// can serve it.
+//
+// The read view's latest ledger is what the database actually holds
+// (MaxCommittedSeq), never the chunk's nominal last: a capped ingest stops
+// mid-chunk, and a view claiming ledgers that were never ingested would turn
+// every query past the cap into a miss. --sample-ledgers narrows the sampled
+// range further, and a cap past what was ingested is clamped, not trusted.
+func openHotFixture(logger *supportlog.Entry, opts hotQueryOptions) (*queryFixture, func(), error) {
+	layout := geometry.NewLayout(opts.HotRoot)
+	cat, releaseCat, err := openScratchCatalog(opts.HotRoot, scratchPrefixQuery, layout, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cat.PutHotTransient(opts.Chunk); err != nil {
+		releaseCat()
+		return nil, nil, fmt.Errorf("mark hot chunk %s transient: %w", opts.Chunk, err)
+	}
+	if err := cat.FlipHotReady(opts.Chunk); err != nil {
+		releaseCat()
+		return nil, nil, fmt.Errorf("mark hot chunk %s ready: %w", opts.Chunk, err)
+	}
+
+	path := layout.HotChunkPath(opts.Chunk)
+	db, err := hotchunk.OpenReadyWrite(geometry.HotReady, path, opts.Chunk, logger)
+	if err != nil {
+		releaseCat()
+		return nil, nil, fmt.Errorf("open hot chunk %s at %s: %w", opts.Chunk, path, err)
+	}
+
+	registry := query.NewRegistry(cat, geometry.NewRetention(0, opts.Chunk))
+	registry.PublishHandle(opts.Chunk, db)
+	// Registry.Close closes every published handle, so releasing the registry
+	// releases the database.
+	release := func() {
+		registry.Close()
+		releaseCat()
+	}
+
+	committed, ok, err := db.MaxCommittedSeq()
+	if err != nil {
+		release()
+		return nil, nil, fmt.Errorf("read hot chunk %s last committed ledger: %w", opts.Chunk, err)
+	}
+	if !ok {
+		release()
+		return nil, nil, fmt.Errorf("hot chunk %s holds no committed ledger: ingest it before querying it", opts.Chunk)
+	}
+	registry.SetLatestLedger(committed)
+
+	first := opts.Chunk.FirstLedger()
+	last := committed
+	// Overflow-safe cap: compare against the committed span rather than adding a
+	// flag-supplied count to a ledger sequence.
+	if span := committed - first + 1; opts.SampleLedgers > 0 && opts.SampleLedgers < span {
+		last = first + opts.SampleLedgers - 1
+	}
+	f := &queryFixture{
+		registry:    registry,
+		Chunks:      []chunk.ID{opts.Chunk},
+		FirstLedger: first,
+		LastLedger:  last,
+	}
+	if err := f.verifyServes(); err != nil {
+		release()
+		return nil, nil, err
+	}
+	return f, release, nil
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_sweep.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_sweep.go
@@ -1,0 +1,144 @@
+package bench
+
+import (
+	"math/rand/v2"
+	"sync"
+	"time"
+)
+
+// This file is the query bench's fan-out core: it runs one (query type,
+// concurrency) cell by fanning a per-request closure across W goroutines and
+// collecting every request's latency. It is deliberately ignorant of what the
+// requests do — the per-type bodies in query_types.go own that — and it does no
+// I/O of its own, so the only thing between the timer and the store is the
+// query itself.
+
+// cellSample is one measured request: its latency, the number of items the
+// response carried, and the sub-stage it belongs to. An empty stage means the
+// sample belongs only to the type's blended row; txhash sets it so found and
+// not-found lookups are also reported apart (see recordCell).
+type cellSample struct {
+	d     time.Duration
+	items int
+	stage string
+}
+
+// queryRequest issues one request against the fixture and reports what the
+// response carried. It runs on a sweep worker's goroutine with that worker's
+// RNG, so an implementation must treat its corpus as read-only and must not
+// share mutable state between workers.
+//
+// The whole request is inside the caller's timer, read-view acquisition
+// included: a served request pays for its own view, and leaving that out would
+// flatter every number.
+type queryRequest func(rng *rand.Rand) (cellSample, error)
+
+// sweepResult is one cell's outcome: every measured request in completion
+// order, the wall-clock the measured pass took, and how many requests failed.
+// Failed requests contribute no sample — a latency for a request that did not
+// answer is not a latency — but they do consume wall-clock, so a cell with
+// errors reports a throughput below what a clean run would.
+type sweepResult struct {
+	samples []cellSample
+	wall    time.Duration
+	errs    int
+}
+
+// runSweep fans req out across workers goroutines, each issuing itersPerWorker
+// measured requests after warmup unmeasured ones. Each worker draws from its
+// own RNG so the workers pick independent work, and the warmup and measured
+// passes share that RNG rather than reseeding: reseeding would replay the
+// warmup's draws and the measured pass would read what it just warmed.
+//
+// A cell's total request count is workers × itersPerWorker. Iterations are
+// split evenly up front rather than pulled off a shared queue, which keeps the
+// hot loop free of coordination — the point is to measure the store, not a work
+// queue.
+//
+// Warmup matters for the hot tier, whose steady state is a warm RocksDB block
+// cache. A cold cell passes warmup 0 and evicts the page cache before the pass
+// instead (see evictColdArtifacts): warming it would measure the opposite of
+// what a cold read is.
+func runSweep(workers, warmup, itersPerWorker int, seed int64, req queryRequest) sweepResult {
+	rngs := workerRNGs(workers, seed)
+	if warmup > 0 {
+		runSweepPass(rngs, warmup, false, req)
+	}
+	return runSweepPass(rngs, itersPerWorker, true, req)
+}
+
+// workerRNGs seeds one RNG per worker, mixing the worker count into the seed
+// alongside the worker id. Without the worker count, worker 0 of the c1 cell
+// and worker 0 of the c16 cell would draw the same sequence, so the c16 cell
+// would re-read exactly what c1 just read and inherit its page-cache state —
+// the sweep would measure a warming curve instead of a concurrency curve.
+func workerRNGs(workers int, seed int64) []*rand.Rand {
+	rngs := make([]*rand.Rand, workers)
+	for id := range workers {
+		//nolint:gosec // seed mixing, not cryptography
+		rngs[id] = rand.New(rand.NewPCG(
+			uint64(seed)+uint64(id)+uint64(workers)*1000003,
+			uint64(seed*7919)+uint64(id)+uint64(workers)*73,
+		))
+	}
+	return rngs
+}
+
+// runSweepPass is the fan-out itself: one goroutine per RNG, each issuing iters
+// requests. An unmeasured pass discards its samples but still runs every
+// request, which is the whole point of a warmup.
+func runSweepPass(rngs []*rand.Rand, iters int, measured bool, req queryRequest) sweepResult {
+	type workerResult struct {
+		samples []cellSample
+		errs    int
+	}
+	results := make([]workerResult, len(rngs))
+
+	var wg sync.WaitGroup
+	wg.Add(len(rngs))
+	start := time.Now()
+	for id, rng := range rngs {
+		go func(id int, rng *rand.Rand) {
+			defer wg.Done()
+			var r workerResult
+			if measured {
+				r.samples = make([]cellSample, 0, iters)
+			}
+			for range iters {
+				s, err := req(rng)
+				if err != nil {
+					r.errs++
+					continue
+				}
+				if measured {
+					r.samples = append(r.samples, s)
+				}
+			}
+			results[id] = r
+		}(id, rng)
+	}
+	wg.Wait()
+	wall := time.Since(start)
+
+	out := sweepResult{wall: wall}
+	if measured {
+		out.samples = make([]cellSample, 0, len(rngs)*iters)
+	}
+	for _, r := range results {
+		out.samples = append(out.samples, r.samples...)
+		out.errs += r.errs
+	}
+	return out
+}
+
+// timed runs fn and returns a sample carrying its latency, so a per-type body
+// times exactly the request and nothing around it.
+func timed(stage string, fn func() (int, error)) (cellSample, error) {
+	start := time.Now()
+	items, err := fn()
+	d := time.Since(start)
+	if err != nil {
+		return cellSample{}, err
+	}
+	return cellSample{d: d, items: items, stage: stage}, nil
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_sweep.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_sweep.go
@@ -18,7 +18,7 @@ import (
 // cellSample is one measured request: how long it took, the number of items the
 // response carried, and the sub-stage it belongs to. An empty stage means the
 // sample belongs only to the type's blended row; txhash sets it so found and
-// not-found lookups are also reported apart (see recordCell).
+// not-found lookups are also reported apart (see recordLeg).
 type cellSample struct {
 	// service is how long the request body itself ran, measured by timed.
 	service time.Duration
@@ -168,7 +168,7 @@ func runPacedLeg(
 		return legResult{}, fmt.Errorf("paced leg needs a positive duration, got %v", duration)
 	}
 	warmup = max(warmup, 0)
-	measured := max(1, int(math.Round(rps*duration.Seconds())))
+	measured := measuredRequests(rps, duration)
 	schedule := newPaceSchedule(time.Duration(float64(time.Second)/rps), 0)
 
 	collector := &legCollector{}
@@ -233,102 +233,12 @@ func legRNG(seed int64, pos int, rps float64) *rand.Rand {
 	))
 }
 
-// sweepResult is one cell's outcome: every measured request in completion
-// order, the wall-clock the measured pass took, and how many requests failed.
-// Failed requests contribute no sample — a latency for a request that did not
-// answer is not a latency — but they do consume wall-clock, so a cell with
-// errors reports a throughput below what a clean run would.
-type sweepResult struct {
-	samples []cellSample
-	wall    time.Duration
-	errs    int
-}
-
-// runSweep fans req out across workers goroutines, each issuing itersPerWorker
-// measured requests after warmup unmeasured ones. Each worker draws from its
-// own RNG so the workers pick independent work, and the warmup and measured
-// passes share that RNG rather than reseeding: reseeding would replay the
-// warmup's draws and the measured pass would read what it just warmed.
-//
-// A cell's total request count is workers × itersPerWorker. Iterations are
-// split evenly up front rather than pulled off a shared queue, which keeps the
-// hot loop free of coordination — the point is to measure the store, not a work
-// queue.
-//
-// Warmup matters for the hot tier, whose steady state is a warm RocksDB block
-// cache. A cold cell passes warmup 0 and evicts the page cache before the pass
-// instead (see evictColdArtifacts): warming it would measure the opposite of
-// what a cold read is.
-func runSweep(workers, warmup, itersPerWorker int, seed int64, req queryRequest) sweepResult {
-	rngs := workerRNGs(workers, seed)
-	if warmup > 0 {
-		runSweepPass(rngs, warmup, false, req)
-	}
-	return runSweepPass(rngs, itersPerWorker, true, req)
-}
-
-// workerRNGs seeds one RNG per worker, mixing the worker count into the seed
-// alongside the worker id. Without the worker count, worker 0 of the c1 cell
-// and worker 0 of the c16 cell would draw the same sequence, so the c16 cell
-// would re-read exactly what c1 just read and inherit its page-cache state —
-// the sweep would measure a warming curve instead of a concurrency curve.
-func workerRNGs(workers int, seed int64) []*rand.Rand {
-	rngs := make([]*rand.Rand, workers)
-	for id := range workers {
-		//nolint:gosec // seed mixing, not cryptography
-		rngs[id] = rand.New(rand.NewPCG(
-			uint64(seed)+uint64(id)+uint64(workers)*1000003,
-			uint64(seed*7919)+uint64(id)+uint64(workers)*73,
-		))
-	}
-	return rngs
-}
-
-// runSweepPass is the fan-out itself: one goroutine per RNG, each issuing iters
-// requests. An unmeasured pass discards its samples but still runs every
-// request, which is the whole point of a warmup.
-func runSweepPass(rngs []*rand.Rand, iters int, measured bool, req queryRequest) sweepResult {
-	type workerResult struct {
-		samples []cellSample
-		errs    int
-	}
-	results := make([]workerResult, len(rngs))
-
-	var wg sync.WaitGroup
-	wg.Add(len(rngs))
-	start := time.Now()
-	for id, rng := range rngs {
-		go func(id int, rng *rand.Rand) {
-			defer wg.Done()
-			var r workerResult
-			if measured {
-				r.samples = make([]cellSample, 0, iters)
-			}
-			for range iters {
-				s, err := req(rng)
-				if err != nil {
-					r.errs++
-					continue
-				}
-				if measured {
-					r.samples = append(r.samples, s)
-				}
-			}
-			results[id] = r
-		}(id, rng)
-	}
-	wg.Wait()
-	wall := time.Since(start)
-
-	out := sweepResult{wall: wall}
-	if measured {
-		out.samples = make([]cellSample, 0, len(rngs)*iters)
-	}
-	for _, r := range results {
-		out.samples = append(out.samples, r.samples...)
-		out.errs += r.errs
-	}
-	return out
+// measuredRequests returns how many measured requests a leg at rate rps issues
+// over duration: the rounded product of the two, and never fewer than one, so a
+// rate slow enough to schedule less than one request in the leg still measures
+// something.
+func measuredRequests(rps float64, duration time.Duration) int {
+	return max(1, int(math.Round(rps*duration.Seconds())))
 }
 
 // timed runs fn and returns a sample carrying how long fn took as its service

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_sweep.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_sweep.go
@@ -1,37 +1,237 @@
 package bench
 
 import (
+	"context"
+	"fmt"
+	"math"
 	"math/rand/v2"
 	"sync"
 	"time"
 )
 
-// This file is the query bench's fan-out core: it runs one (query type,
-// concurrency) cell by fanning a per-request closure across W goroutines and
-// collecting every request's latency. It is deliberately ignorant of what the
-// requests do — the per-type bodies in query_types.go own that — and it does no
-// I/O of its own, so the only thing between the timer and the store is the
-// query itself.
+// This file is the query bench's dispatcher: it issues a per-request closure at
+// a fixed arrival rate and collects every request's latency. It is deliberately
+// ignorant of what the requests do — the per-type bodies in query_types.go own
+// that — and it does no I/O of its own, so the only thing between the timer and
+// the store is the query itself.
 
-// cellSample is one measured request: its latency, the number of items the
+// cellSample is one measured request: how long it took, the number of items the
 // response carried, and the sub-stage it belongs to. An empty stage means the
 // sample belongs only to the type's blended row; txhash sets it so found and
 // not-found lookups are also reported apart (see recordCell).
 type cellSample struct {
-	d     time.Duration
-	items int
-	stage string
+	// service is how long the request body itself ran, measured by timed.
+	service time.Duration
+	// scheduled is the span from the request's due time to its completion,
+	// stamped by the dispatcher. It carries the dispatcher's lag behind
+	// schedule on top of the service time, so it is the latency a client
+	// sending at the target rate observes.
+	scheduled time.Duration
+	items     int
+	stage     string
 }
 
 // queryRequest issues one request against the fixture and reports what the
-// response carried. It runs on a sweep worker's goroutine with that worker's
-// RNG, so an implementation must treat its corpus as read-only and must not
-// share mutable state between workers.
+// response carried. It runs on its own goroutine with an RNG the dispatcher
+// hands it, so an implementation must treat its corpus as read-only and must
+// not share mutable state between concurrent requests.
 //
 // The whole request is inside the caller's timer, read-view acquisition
 // included: a served request pays for its own view, and leaving that out would
 // flatter every number.
 type queryRequest func(rng *rand.Rand) (cellSample, error)
+
+// maxInFlight is the number of requests a paced leg may have outstanding at
+// once. A request that arrives while the cap is full is shed and counted, so a
+// target rate the store cannot keep up with shows as a shed count rather than
+// as an unbounded pile of goroutines that would measure the machine's scheduler
+// instead of the store.
+const maxInFlight = 512
+
+// Mixing constants for the per-request seeds. They are odd and mutually prime
+// so that the seed, the position and the rate each move both PCG words.
+const (
+	legSeedRateHi = 1000003
+	legSeedRateLo = 73
+	legSeedStride = 7919
+)
+
+// legResult is one paced leg's outcome.
+type legResult struct {
+	// samples holds the measured requests that answered, in completion order.
+	// A request that failed contributes no sample: a latency for a request
+	// that did not answer is not a latency.
+	samples []cellSample
+	// lags holds the dispatch lag of every dispatched measured request in
+	// dispatch order. A zero is a real observation — a dispatch that was on
+	// time — so zeros are kept.
+	lags []time.Duration
+	// wall spans the first measured due time to the last measured completion.
+	wall time.Duration
+	// dispatched counts the measured requests that got a slot and ran.
+	dispatched int
+	// shed counts the measured requests dropped because maxInFlight was full.
+	shed int
+	// errs counts the measured requests that returned an error.
+	errs int
+}
+
+// legCollector gathers a paced leg's outcome from the dispatch loop and the
+// request goroutines, which write to it concurrently.
+type legCollector struct {
+	mu         sync.Mutex
+	samples    []cellSample
+	lags       []time.Duration
+	lastDone   time.Time
+	dispatched int
+	shed       int
+	errs       int
+}
+
+// recordDispatch notes that a measured request got a slot and started, lag
+// behind its due time.
+func (c *legCollector) recordDispatch(lag time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.dispatched++
+	c.lags = append(c.lags, lag)
+}
+
+// recordShed notes that a measured request was dropped because the in-flight
+// cap was full.
+func (c *legCollector) recordShed() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.shed++
+}
+
+// recordSample stores a measured request's sample and its completion time.
+func (c *legCollector) recordSample(s cellSample, done time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.samples = append(c.samples, s)
+	if done.After(c.lastDone) {
+		c.lastDone = done
+	}
+}
+
+// recordError notes that a measured request failed at the given time. A failed
+// request still occupied the leg, so its completion counts toward the wall.
+func (c *legCollector) recordError(done time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.errs++
+	if done.After(c.lastDone) {
+		c.lastDone = done
+	}
+}
+
+// result assembles the leg's outcome, measuring the wall from firstDue. A leg
+// in which nothing completed reports a zero wall.
+func (c *legCollector) result(firstDue time.Time) legResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := legResult{
+		samples:    c.samples,
+		lags:       c.lags,
+		dispatched: c.dispatched,
+		shed:       c.shed,
+		errs:       c.errs,
+	}
+	if !c.lastDone.IsZero() {
+		out.wall = c.lastDone.Sub(firstDue)
+	}
+	return out
+}
+
+// runPacedLeg issues req at a fixed arrival rate of rps requests per second and
+// reports what the leg observed. Position i is due at anchor + i×interval, where
+// interval is one second divided by rps and the anchor is the first position's
+// dispatch. Due times are absolute, so a slow request delays no later one and
+// the leg keeps its rate whatever the store does with it.
+//
+// Positions 0 to warmup-1 run at the leg's rate and record nothing; the
+// round(rps × duration) positions after them are measured, so a leg's schedule
+// spans exactly duration. Each request runs on its own goroutine with its own
+// RNG, and the in-flight count is capped at maxInFlight.
+//
+// The returned error is a context error: it means the leg was cut short and its
+// result is not a measurement. A request that fails is counted in errs and does
+// not end the leg.
+func runPacedLeg(
+	ctx context.Context, rps float64, duration time.Duration, warmup int, seed int64, req queryRequest,
+) (legResult, error) {
+	if rps <= 0 || math.IsNaN(rps) || math.IsInf(rps, 0) {
+		return legResult{}, fmt.Errorf("paced leg needs a positive finite rate, got %v", rps)
+	}
+	if duration <= 0 {
+		return legResult{}, fmt.Errorf("paced leg needs a positive duration, got %v", duration)
+	}
+	warmup = max(warmup, 0)
+	measured := max(1, int(math.Round(rps*duration.Seconds())))
+	schedule := newPaceSchedule(time.Duration(float64(time.Second)/rps), 0)
+
+	collector := &legCollector{}
+	slots := make(chan struct{}, maxInFlight)
+	var wg sync.WaitGroup
+	for pos := range warmup + measured {
+		due := schedule.dueForPos(pos)
+		if err := contextSleep(ctx, time.Until(due)); err != nil {
+			wg.Wait()
+			return legResult{}, err
+		}
+		launchPacedRequest(&wg, slots, collector, req, legRNG(seed, pos, rps), due, pos >= warmup)
+	}
+	wg.Wait()
+	return collector.result(schedule.dueForPos(warmup)), nil
+}
+
+// launchPacedRequest starts one request of a paced leg on its own goroutine,
+// taking a slot from slots first. With no slot free the request is shed: it is
+// counted and nothing else about it is recorded. A warmup request runs in full
+// and records nothing either way.
+func launchPacedRequest(
+	wg *sync.WaitGroup, slots chan struct{}, collector *legCollector,
+	req queryRequest, rng *rand.Rand, due time.Time, measured bool,
+) {
+	select {
+	case slots <- struct{}{}:
+	default:
+		if measured {
+			collector.recordShed()
+		}
+		return
+	}
+	if measured {
+		collector.recordDispatch(max(time.Since(due), 0))
+	}
+	wg.Go(func() {
+		defer func() { <-slots }()
+		s, err := req(rng)
+		done := time.Now()
+		switch {
+		case !measured:
+		case err != nil:
+			collector.recordError(done)
+		default:
+			s.scheduled = done.Sub(due)
+			collector.recordSample(s, done)
+		}
+	})
+}
+
+// legRNG returns the random source for the request at position pos of the leg
+// at rate rps, mixing the rate and the position into the run's seed. The rate
+// keeps two legs of one query type drawing different sequences, and the
+// position keeps two requests of one leg drawing different work.
+func legRNG(seed int64, pos int, rps float64) *rand.Rand {
+	rateBits := math.Float64bits(rps)
+	//nolint:gosec // seed mixing, not cryptography
+	return rand.New(rand.NewPCG(
+		uint64(seed)+uint64(pos)+rateBits*legSeedRateHi,
+		uint64(seed*legSeedStride)+uint64(pos)+rateBits*legSeedRateLo,
+	))
+}
 
 // sweepResult is one cell's outcome: every measured request in completion
 // order, the wall-clock the measured pass took, and how many requests failed.
@@ -131,14 +331,14 @@ func runSweepPass(rngs []*rand.Rand, iters int, measured bool, req queryRequest)
 	return out
 }
 
-// timed runs fn and returns a sample carrying its latency, so a per-type body
-// times exactly the request and nothing around it.
+// timed runs fn and returns a sample carrying how long fn took as its service
+// time, so a per-type body times exactly the request and nothing around it.
 func timed(stage string, fn func() (int, error)) (cellSample, error) {
 	start := time.Now()
 	items, err := fn()
-	d := time.Since(start)
+	service := time.Since(start)
 	if err != nil {
 		return cellSample{}, err
 	}
-	return cellSample{d: d, items: items, stage: stage}, nil
+	return cellSample{service: service, items: items, stage: stage}, nil
 }

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_sweep_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_sweep_test.go
@@ -1,0 +1,229 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingRequest is a queryRequest that answers immediately and counts every
+// call, so a test can tell how many requests a leg actually issued — warmup
+// requests included, which leave no sample behind.
+type countingRequest struct {
+	calls atomic.Int64
+}
+
+func (c *countingRequest) run(*rand.Rand) (cellSample, error) {
+	c.calls.Add(1)
+	return timed("", func() (int, error) { return 1, nil })
+}
+
+// TestRunPacedLegMeasuredCount pins the shape of a clean leg: the number of
+// measured requests is round(rps × duration), warmup requests run at the leg's
+// rate but leave no sample, every measured request that answered carries a
+// scheduled latency at least as long as its service time, and nothing is shed
+// or fails.
+func TestRunPacedLegMeasuredCount(t *testing.T) {
+	fake := &countingRequest{}
+	res, err := runPacedLeg(t.Context(), 200, 100*time.Millisecond, 5, 42, fake.run)
+	require.NoError(t, err)
+
+	assert.Equal(t, 20, res.dispatched)
+	assert.Len(t, res.samples, 20)
+	assert.Len(t, res.lags, 20)
+	assert.Equal(t, 0, res.shed)
+	assert.Equal(t, 0, res.errs)
+	assert.Equal(t, int64(25), fake.calls.Load(), "warmup requests run at the leg's rate")
+	assert.Positive(t, res.wall)
+
+	for i, s := range res.samples {
+		assert.Positive(t, s.service, "sample %d", i)
+		assert.GreaterOrEqual(t, s.scheduled, s.service, "sample %d", i)
+		assert.Equal(t, 1, s.items, "sample %d", i)
+	}
+	for i, lag := range res.lags {
+		assert.GreaterOrEqual(t, lag, time.Duration(0), "lag %d", i)
+	}
+}
+
+// drawRecorder is a queryRequest that answers immediately and records the first
+// value each request draws from the RNG it was handed.
+type drawRecorder struct {
+	mu    sync.Mutex
+	draws []uint64
+}
+
+func (d *drawRecorder) run(rng *rand.Rand) (cellSample, error) {
+	v := rng.Uint64()
+	d.mu.Lock()
+	d.draws = append(d.draws, v)
+	d.mu.Unlock()
+	return timed("", func() (int, error) { return 1, nil })
+}
+
+// TestRunPacedLegRNGIndependence pins that every request of a leg draws its own
+// sequence and that two legs of one seed at different rates draw different
+// sequences, so a later leg does not repeat the work an earlier one warmed.
+func TestRunPacedLegRNGIndependence(t *testing.T) {
+	first := &drawRecorder{}
+	_, err := runPacedLeg(t.Context(), 500, 40*time.Millisecond, 0, 7, first.run)
+	require.NoError(t, err)
+	require.Len(t, first.draws, 20)
+
+	seen := make(map[uint64]bool, len(first.draws))
+	for _, v := range first.draws {
+		assert.False(t, seen[v], "two requests of one leg drew %d", v)
+		seen[v] = true
+	}
+
+	second := &drawRecorder{}
+	_, err = runPacedLeg(t.Context(), 250, 80*time.Millisecond, 0, 7, second.run)
+	require.NoError(t, err)
+	require.Len(t, second.draws, 20)
+	for _, v := range second.draws {
+		assert.False(t, seen[v], "a leg at another rate redrew %d", v)
+	}
+}
+
+// blockingRequest is a queryRequest that holds its slot until release is
+// closed, so a test can fill the in-flight cap and keep it full.
+type blockingRequest struct {
+	release  chan struct{}
+	inFlight atomic.Int64
+	calls    atomic.Int64
+}
+
+func (b *blockingRequest) run(*rand.Rand) (cellSample, error) {
+	b.calls.Add(1)
+	b.inFlight.Add(1)
+	defer b.inFlight.Add(-1)
+	return timed("", func() (int, error) {
+		<-b.release
+		return 1, nil
+	})
+}
+
+// TestRunPacedLegSheds pins what a leg does when the store cannot keep up: the
+// first maxInFlight measured requests get a slot and every later one is shed,
+// no position is silently skipped, and the shed requests leave no sample.
+func TestRunPacedLegSheds(t *testing.T) {
+	fake := &blockingRequest{release: make(chan struct{})}
+	// The leg's schedule spans 100ms and a shed position costs nothing, so the
+	// dispatch loop is over well before the release fires. Releasing only then
+	// keeps every slot occupied for the whole loop.
+	timer := time.AfterFunc(500*time.Millisecond, func() { close(fake.release) })
+	defer timer.Stop()
+
+	res, err := runPacedLeg(t.Context(), 10000, 100*time.Millisecond, 0, 3, fake.run)
+	require.NoError(t, err)
+
+	assert.Equal(t, maxInFlight, res.dispatched)
+	assert.Equal(t, 1000-maxInFlight, res.shed)
+	assert.Equal(t, 1000, res.dispatched+res.shed)
+	assert.Len(t, res.samples, maxInFlight)
+	assert.Len(t, res.lags, maxInFlight)
+	assert.Equal(t, int64(maxInFlight), fake.calls.Load())
+	assert.Equal(t, int64(0), fake.inFlight.Load())
+}
+
+// TestRunPacedLegCountsErrors pins that a failed request is counted and leaves
+// no sample, and that it does not end the leg.
+func TestRunPacedLegCountsErrors(t *testing.T) {
+	var ordinal atomic.Int64
+	fail := errors.New("request failed")
+	req := func(*rand.Rand) (cellSample, error) {
+		if ordinal.Add(1)%2 == 0 {
+			return cellSample{}, fail
+		}
+		return timed("", func() (int, error) { return 1, nil })
+	}
+
+	res, err := runPacedLeg(t.Context(), 200, 100*time.Millisecond, 0, 11, req)
+	require.NoError(t, err)
+
+	assert.Equal(t, 20, res.dispatched)
+	assert.Equal(t, 10, res.errs)
+	assert.Len(t, res.samples, 10)
+	assert.Len(t, res.lags, 20)
+	assert.Equal(t, 0, res.shed)
+}
+
+// TestRunPacedLegContextCancel pins that a canceled context ends the leg at its
+// next due time, reports the context's error, and leaves no request running.
+func TestRunPacedLegContextCancel(t *testing.T) {
+	fake := &countingRequest{}
+	inFlight := &atomic.Int64{}
+	req := func(rng *rand.Rand) (cellSample, error) {
+		inFlight.Add(1)
+		defer inFlight.Add(-1)
+		return fake.run(rng)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	timer := time.AfterFunc(100*time.Millisecond, cancel)
+	defer timer.Stop()
+
+	start := time.Now()
+	_, err := runPacedLeg(ctx, 2, 10*time.Second, 0, 5, req)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, time.Second, "the leg ends at the cancel, not at its full duration")
+	assert.Equal(t, int64(0), inFlight.Load())
+}
+
+// TestRunPacedLegLagStaysSmall pins that the dispatcher keeps its schedule when
+// requests take longer than the arrival interval. Requests run concurrently, so
+// a slow request holds up no later dispatch: the leg reports one lag per
+// dispatched request, the typical lag is a small fraction of the service time,
+// and the whole leg finishes in about its scheduled span rather than in the sum
+// of its requests.
+//
+// The assertions are on the median lag and the wall rather than on the worst
+// lag, because a single dispatch can lose the CPU for tens of milliseconds on a
+// busy machine while the dispatcher is still on schedule overall.
+func TestRunPacedLegLagStaysSmall(t *testing.T) {
+	const service = 20 * time.Millisecond
+	req := func(*rand.Rand) (cellSample, error) {
+		return timed("", func() (int, error) {
+			time.Sleep(service)
+			return 1, nil
+		})
+	}
+
+	res, err := runPacedLeg(t.Context(), 1000, 50*time.Millisecond, 0, 13, req)
+	require.NoError(t, err)
+
+	assert.Equal(t, 50, res.dispatched)
+	assert.Len(t, res.lags, res.dispatched)
+	for i, lag := range res.lags {
+		assert.GreaterOrEqual(t, lag, time.Duration(0), "lag %d", i)
+	}
+
+	sorted := slices.Clone(res.lags)
+	slices.Sort(sorted)
+	assert.Less(t, sorted[len(sorted)/2], service, "median dispatch lag")
+	// A serialized leg would run 50 requests of 20ms back to back, so it could
+	// not finish inside half a second.
+	assert.Less(t, res.wall, 500*time.Millisecond, "leg wall")
+}
+
+// TestRunPacedLegRejectsBadArguments pins that a leg with no rate or no
+// duration is refused rather than run as an empty measurement.
+func TestRunPacedLegRejectsBadArguments(t *testing.T) {
+	req := func(*rand.Rand) (cellSample, error) {
+		return timed("", func() (int, error) { return 1, nil })
+	}
+	_, err := runPacedLeg(t.Context(), 0, time.Second, 0, 1, req)
+	assert.Error(t, err)
+	_, err = runPacedLeg(t.Context(), 10, 0, 0, 1, req)
+	assert.Error(t, err)
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
@@ -3,12 +3,15 @@ package bench
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/network"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 )
@@ -138,11 +141,23 @@ func TestQuerySpecs(t *testing.T) {
 	require.Equal(t, []string{"total_c1", "total_c4"}, byName["ledgers"])
 	require.Equal(t, []string{"total_c1", "total_c4"}, byName["events"])
 	require.Equal(t, []string{
-		"open",
+		"open", "evict",
 		"ledgers_c1", "ledgers_c4",
 		"events_c1", "events_c4",
 		"peak_rss_bytes",
 	}, byName["driver"])
+}
+
+// TestQuerySpecsTxHashStages pins the found/miss rows the txhash file carries
+// beside the blended cell the converter reads.
+func TestQuerySpecsTxHashStages(t *testing.T) {
+	specs := querySpecs([]string{queryTypeTxHash}, []int{1, 4})
+	require.Equal(t, queryTypeTxHash, specs[0].name)
+	require.Equal(t, []string{
+		"total_c1", "total_c4",
+		"found_c1", "found_c4",
+		"miss_c1", "miss_c4",
+	}, specs[0].rowOrder)
 }
 
 // TestQuerySinkWritesContractRows records one cell per type and checks the
@@ -236,14 +251,135 @@ func TestOpenColdFixtureServesFrozenChunks(t *testing.T) {
 	assert.Equal(t, chunkID, coverages[0].Hi)
 }
 
-// TestRunQueryColdWritesSetupReport drives runQueryCold over a real frozen
-// chunk with the sweep the campaign runner asks for. The per-type bodies are
-// #856 B2, so the sweep stops at the first cell and the run writes the PARTIAL
-// report: this pins that the setup rows still land and that the error names the
-// type. Replace the unimplemented assertions with the per-cell rows when B2
-// fills the bodies in.
-func TestRunQueryColdWritesSetupReport(t *testing.T) {
+// testQueryPlan is the sweep the end-to-end tests run: every type, two
+// concurrency levels, few enough iterations to stay quick. The spans are small
+// because the fixture chunk is synthetic, and the miss fraction is high enough
+// that a short cell reliably produces both a found and a not-found lookup.
+func testQueryPlan(iters int) queryPlan {
+	return queryPlan{
+		Types:        allQueryTypes,
+		Concurrency:  []int{1, 2},
+		Iters:        iters,
+		LedgersSpan:  4,
+		TxPageSpan:   2,
+		TxPageLimit:  10,
+		EventsLimit:  10,
+		MissFraction: 0.5,
+		Passphrase:   network.PublicNetworkPassphrase,
+		Seed:         defaultSeed,
+	}
+}
+
+// TestRunQueryCold is the cold end-to-end: ingest a chunk, then sweep every
+// query type over its frozen artifacts and check the report the results
+// converter will read — one CSV per type carrying a total_c<W> row per
+// concurrency level, and driver.csv carrying the matching cell walls plus the
+// setup rows.
+func TestRunQueryCold(t *testing.T) {
+	const iters = 5
 	chunkID := chunk.ID(0)
+	coldRoot := ingestColdChunk(t, chunkID)
+
+	csvDir := filepath.Join(t.TempDir(), "csv")
+	plan := testQueryPlan(iters)
+	plan.Evict = true
+	require.NoError(t, runQueryCold(context.Background(), testLogger(), coldQueryOptions{
+		ColdRoot:   coldRoot,
+		StartChunk: chunkID,
+		NumChunks:  1,
+		Plan:       plan,
+		OutDir:     csvDir,
+	}))
+
+	assertQueryReport(t, csvDir, plan, iters)
+
+	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
+	require.Contains(t, driver, "open")
+	assert.EqualValues(t, 1, driver["open"]["n_items"], "one chunk opened")
+	// One eviction pass runs per cell, but the sink drops zero-duration samples
+	// and off Linux the pass is a no-op that finishes inside a timer tick — so
+	// the row's presence and the artifacts it named are what can be asserted
+	// everywhere, not the sample count.
+	require.Contains(t, driver, "evict", "a cold cell evicts before it measures")
+	assert.LessOrEqual(t, driver["evict"]["n"], int64(len(plan.Types)*len(plan.Concurrency)),
+		"at most one eviction pass per cell")
+	assert.Positive(t, driver["evict"]["n_items"], "the eviction pass named some artifacts")
+}
+
+// TestRunQueryHot is the hot end-to-end: ingest a chunk into a hot database,
+// then sweep every query type against it. It also covers the warmup pass, which
+// only the hot tier runs.
+func TestRunQueryHot(t *testing.T) {
+	const (
+		ingested = 400
+		iters    = 5
+	)
+	chunkID := chunk.ID(0)
+	packDir, _ := writeSourcePack(t, t.TempDir(), chunkID, ingested)
+	hotRoot := t.TempDir()
+	require.NoError(t, runHot(context.Background(), testLogger(), hotOptions{
+		Source:     sourceConfig{Kind: sourcePack, PackDir: packDir},
+		StartChunk: chunkID,
+		NumChunks:  1,
+		NumLedgers: ingested,
+		HotRoot:    hotRoot,
+		OutDir:     filepath.Join(t.TempDir(), "csv"),
+	}))
+
+	csvDir := filepath.Join(t.TempDir(), "csv")
+	plan := testQueryPlan(iters)
+	plan.Warmup = 2
+	require.NoError(t, runQueryHot(context.Background(), testLogger(), hotQueryOptions{
+		HotRoot: hotRoot,
+		Chunk:   chunkID,
+		Plan:    plan,
+		OutDir:  csvDir,
+	}))
+
+	assertQueryReport(t, csvDir, plan, iters)
+
+	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
+	assert.NotContains(t, driver, "evict", "a hot run has no page-cache artifacts to evict")
+}
+
+// assertQueryReport checks a finished run's CSVs against the converter's
+// contract: every swept cell present, its sample count exactly what the sweep
+// promised (workers × iters), and every cell wall recorded in driver.csv. It
+// also checks txhash's found/miss rows partition the blended row, which is the
+// property that lets the split be reported without touching the cell the
+// converter reads.
+func assertQueryReport(t *testing.T, csvDir string, plan queryPlan, iters int) {
+	t.Helper()
+	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
+
+	for _, qtype := range plan.Types {
+		rows := readCSV(t, filepath.Join(csvDir, qtype+".csv"))
+		for _, w := range plan.Concurrency {
+			cell := queryCellRow(w)
+			require.Contains(t, rows, cell, "%s is missing its c%d cell", qtype, w)
+			assert.EqualValues(t, w*iters, rows[cell]["n"],
+				"%s c%d must hold one sample per request", qtype, w)
+
+			wall := queryDriverRow(qtype, w)
+			require.Contains(t, driver, wall, "driver.csv is missing %s", wall)
+			assert.Positive(t, driver[wall]["total_ns"], "%s took no time", wall)
+		}
+		if qtype != queryTypeTxHash {
+			continue
+		}
+		for _, w := range plan.Concurrency {
+			found := rows[txHashStageFound+"_c"+strconv.Itoa(w)]
+			miss := rows[txHashStageMiss+"_c"+strconv.Itoa(w)]
+			assert.Equal(t, rows[queryCellRow(w)]["n"], found["n"]+miss["n"],
+				"txhash c%d: the found and miss rows must partition the blended row", w)
+		}
+	}
+}
+
+// ingestColdChunk runs bench-ingest cold over a synthetic pack and returns the
+// frozen artifact root, which is what a cold query run reads.
+func ingestColdChunk(t *testing.T, chunkID chunk.ID) string {
+	t.Helper()
 	packDir, _ := writeSourcePack(t, t.TempDir(), chunkID, chunk.LedgersPerChunk)
 	coldRoot := t.TempDir()
 	require.NoError(t, runCold(context.Background(), testLogger(), coldOptions{
@@ -254,22 +390,39 @@ func TestRunQueryColdWritesSetupReport(t *testing.T) {
 		ColdRoot:   coldRoot,
 		OutDir:     filepath.Join(t.TempDir(), "csv"),
 	}))
+	return coldRoot
+}
 
-	csvDir := filepath.Join(t.TempDir(), "csv")
+// TestQueryRejectsWrongPassphrase pins the corpus build failing loudly on a
+// passphrase the dataset was not signed under. Without the check every lookup
+// would report not-found and the run would publish the miss path's latency
+// under the hit path's name.
+func TestQueryRejectsWrongPassphrase(t *testing.T) {
+	chunkID := chunk.ID(0)
+	coldRoot := ingestColdChunk(t, chunkID)
+
+	plan := testQueryPlan(2)
+	plan.Types = []string{queryTypeTxHash}
+	plan.Passphrase = network.TestNetworkPassphrase
 	err := runQueryCold(context.Background(), testLogger(), coldQueryOptions{
 		ColdRoot:   coldRoot,
 		StartChunk: chunkID,
 		NumChunks:  1,
-		Plan:       queryPlan{Types: allQueryTypes, Concurrency: []int{1, 4, 16}, Iters: 100},
-		OutDir:     csvDir,
+		Plan:       plan,
+		OutDir:     filepath.Join(t.TempDir(), "csv"),
 	})
-	require.ErrorIs(t, err, errQueryTypeUnimplemented)
-	require.ErrorContains(t, err, queryTypeLedgers, "the error names the type that stopped the sweep")
+	require.ErrorContains(t, err, "--network-passphrase")
+}
 
-	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
-	require.Contains(t, driver, "open")
-	assert.EqualValues(t, 1, driver["open"]["n"])
-	assert.EqualValues(t, 1, driver["open"]["n_items"], "one chunk opened")
+// TestEvictionStateRecordsPlatform pins what invocation.json says about
+// eviction: what was asked for, and whether this platform could do it.
+func TestEvictionStateRecordsPlatform(t *testing.T) {
+	assert.Equal(t, "off", evictionState(false))
+	if evictSupported {
+		assert.Equal(t, "on", evictionState(true))
+		return
+	}
+	assert.Equal(t, "unsupported-on-this-platform", evictionState(true))
 }
 
 // TestOpenColdFixtureRejectsMissingChunk pins the open failing with the chunk

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
@@ -117,6 +117,27 @@ func TestQueryCommandAcceptsRunnerArgv(t *testing.T) {
 	}
 }
 
+// TestQueryDefaultShapesMatchSLA pins the two read shapes the team SLA fixes:
+// getLedgers reads 10 ledgers per call and getEvents reads a small page of 10
+// matches. The campaign runner passes neither flag, so the defaults are the
+// shapes the SLA rows are measured at.
+func TestQueryDefaultShapesMatchSLA(t *testing.T) {
+	for _, name := range []string{"cold", "hot"} {
+		t.Run(name, func(t *testing.T) {
+			sub := querySubcommands(t, NewQueryCommand())[name]
+			require.NotNil(t, sub)
+
+			ledgersSpan, err := sub.Flags().GetUint32("ledgers-span")
+			require.NoError(t, err)
+			require.Equal(t, uint32(10), ledgersSpan, "SLA: getLedgers max=10")
+
+			eventsLimit, err := sub.Flags().GetInt("events-limit")
+			require.NoError(t, err)
+			require.Equal(t, 10, eventsLimit, "SLA: getEvents small page, 10 matches")
+		})
+	}
+}
+
 // TestParseQueryTypes pins the accepted and rejected --types values.
 func TestParseQueryTypes(t *testing.T) {
 	got, err := parseQueryTypes("events,ledgers")

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
@@ -46,7 +46,8 @@ func TestNewQueryCommand(t *testing.T) {
 // verbatim and in its own order, through both subcommands. The runner is the
 // only caller in the campaign, so this argv IS the flag surface's contract: a
 // renamed flag, a dropped one, or a value format the flag cannot parse breaks a
-// campaign leg, not a local invocation.
+// campaign leg, not a local invocation. It also pins which tier binds --warmup,
+// since the runner passes it to the hot subcommand alone.
 func TestQueryCommandAcceptsRunnerArgv(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -90,7 +91,7 @@ func TestQueryCommandAcceptsRunnerArgv(t *testing.T) {
 			require.NoError(t, err)
 			parsed, err := parseQueryTypes(types)
 			require.NoError(t, err)
-			require.Equal(t, allQueryTypes, parsed, "the runner sweeps every query type")
+			require.Equal(t, allQueryTypes, parsed, "the runner runs every query type")
 
 			targetRPS, err := sub.Flags().GetString("target-rps")
 			require.NoError(t, err)
@@ -101,6 +102,13 @@ func TestQueryCommandAcceptsRunnerArgv(t *testing.T) {
 			duration, err := sub.Flags().GetDuration("duration")
 			require.NoError(t, err)
 			require.Equal(t, 5*time.Second, duration)
+
+			warmup := sub.Flags().Lookup("warmup")
+			if tc.argv[0] == "cold" {
+				assert.Nil(t, warmup, "a cold leg evicts before it measures rather than warming")
+			} else {
+				assert.NotNil(t, warmup, "a hot leg warms the store's caches first")
+			}
 		})
 	}
 }
@@ -123,7 +131,7 @@ func TestParseTargetRPS(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []float64{2, 0.5, 1}, got, "the caller's order is kept")
 
-	for _, bad := range []string{"", "1,", "0", "-1", "1,1", "four", "NaN", "Inf"} {
+	for _, bad := range []string{"", "1,", "0", "-1", "1,1", "four", "NaN", "Inf", "1e7"} {
 		_, err := parseTargetRPS(bad)
 		require.Error(t, err, "--target-rps=%q must be rejected", bad)
 	}
@@ -182,9 +190,14 @@ func TestQuerySpecsTxHashStages(t *testing.T) {
 // TestQuerySinkWritesContractRows records one leg per type per rate and checks
 // the written CSVs carry the converter's row names — including the _lag and
 // _shed rows, whose samples are zero durations the ordinary filter would drop —
-// and that the _millirps row carries the leg's achieved rate times 1000.
+// and that the _millirps row carries the leg's achieved rate times 1000, which
+// is the answered requests over the window the leg offered rather than over its
+// drain-inclusive wall.
 func TestQuerySinkWritesContractRows(t *testing.T) {
-	const legWall = 2 * time.Second
+	const (
+		legWall    = 2 * time.Second
+		legOffered = 4 * time.Second
+	)
 	types := []string{queryTypeLedgers, queryTypeTxHash}
 	rates := []float64{1, 4}
 	sink := newSchemaCSVSink(querySpecs(types, rates))
@@ -195,6 +208,7 @@ func TestQuerySinkWritesContractRows(t *testing.T) {
 			{service: 2 * time.Millisecond, scheduled: 3 * time.Millisecond, items: 3},
 		},
 		lags:       []time.Duration{0, time.Millisecond},
+		offered:    legOffered,
 		wall:       legWall,
 		dispatched: 2,
 	}
@@ -210,7 +224,7 @@ func TestQuerySinkWritesContractRows(t *testing.T) {
 	require.Len(t, written, 3)
 
 	driver := readCSV(t, filepath.Join(outDir, "driver.csv"))
-	wantMilliRPS := int64(math.Round(float64(len(res.samples)) / legWall.Seconds() * 1000))
+	wantMilliRPS := int64(math.Round(float64(len(res.samples)) / legOffered.Seconds() * 1000))
 	for _, qtype := range types {
 		rows := readCSV(t, filepath.Join(outDir, qtype+".csv"))
 		for _, rps := range rates {
@@ -251,6 +265,44 @@ func TestQuerySinkWritesContractRows(t *testing.T) {
 				names, "file %s", f.name)
 		}
 	}
+}
+
+// TestRecordLegAllShed pins what a leg that answered nothing reports: its shed
+// count, a zero achieved rate rather than a missing row, and a dispatch lag per
+// measured position. Its own CSV is not written, because a leg with no request
+// to time has no latency distribution.
+func TestRecordLegAllShed(t *testing.T) {
+	const (
+		rps       = 4.0
+		shedLag   = 10 * time.Millisecond
+		shedCount = 5
+	)
+	sink := newSchemaCSVSink(querySpecs([]string{queryTypeLedgers}, []float64{rps}))
+	lags := make([]time.Duration, shedCount)
+	for i := range lags {
+		lags[i] = shedLag
+	}
+	recordLeg(sink, queryTypeLedgers, rps, legResult{lags: lags, shed: shedCount, offered: time.Second})
+
+	outDir := t.TempDir()
+	written, err := sink.writeCSVs(outDir)
+	require.NoError(t, err)
+	require.Len(t, written, 1, "only driver.csv is written")
+
+	driver := readCSV(t, filepath.Join(outDir, "driver.csv"))
+	shed := queryDriverLegRow(queryTypeLedgers, rps, driverLegShedSuffix)
+	require.Contains(t, driver, shed)
+	assert.EqualValues(t, shedCount, driver[shed]["n_items"])
+
+	millirps := queryDriverLegRow(queryTypeLedgers, rps, driverLegRPSSuffix)
+	require.Contains(t, driver, millirps, "a leg that answered nothing still reports its rate")
+	assert.EqualValues(t, 0, driver[millirps]["total_ns"])
+
+	lag := queryDriverLegRow(queryTypeLedgers, rps, driverLegLagSuffix)
+	require.Contains(t, driver, lag)
+	assert.EqualValues(t, shedCount, driver[lag]["n"], "a shed position is charged a lag")
+
+	assert.NoFileExists(t, filepath.Join(outDir, queryTypeLedgers+".csv"))
 }
 
 // TestOpenColdFixtureServesFrozenChunks runs bench-ingest cold to produce a real
@@ -447,9 +499,9 @@ func assertQueryReport(t *testing.T, csvDir string, plan queryPlan) {
 }
 
 // assertLegDriverRows checks the four driver rows one leg writes: its wall, its
-// achieved rate, its dispatch-lag distribution (one sample per dispatched
-// request, zeros kept), and its shed count, which a leg the fixture kept up
-// with reports as zero.
+// achieved rate, its dispatch-lag distribution (one sample per measured
+// position, shed positions included, zeros kept), and its shed count, which a
+// leg the fixture kept up with reports as zero.
 func assertLegDriverRows(
 	t *testing.T, driver map[string]map[string]int64, qtype string, rps float64, measured int64,
 ) {
@@ -465,7 +517,7 @@ func assertLegDriverRows(
 
 	lag := queryDriverLegRow(qtype, rps, driverLegLagSuffix)
 	require.Contains(t, driver, lag, "driver.csv is missing %s", lag)
-	assert.Equal(t, measured, driver[lag]["n"], "%s holds one sample per dispatch", lag)
+	assert.Equal(t, measured, driver[lag]["n"], "%s holds one sample per measured position", lag)
 
 	shed := queryDriverLegRow(qtype, rps, driverLegShedSuffix)
 	require.Contains(t, driver, shed, "driver.csv is missing %s", shed)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"math"
 	"math/rand/v2"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +18,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/network"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 )
 
 // TestNewQueryCommand builds the full command tree — executing every
@@ -561,6 +565,57 @@ func TestQueryRejectsWrongPassphrase(t *testing.T) {
 		OutDir:     filepath.Join(t.TempDir(), "csv"),
 	})
 	require.ErrorContains(t, err, "--network-passphrase")
+}
+
+// TestOpenColdFixtureWithoutTxHashIndex pins what a cold tree carrying no
+// tx-hash window index does to the open, which depends on what the run asked
+// for. With txhash among the types every by-hash lookup would fail once the legs
+// started, so the open fails first and names the directory the index belongs in.
+// Without txhash the open succeeds and warns: the other three types never read
+// the index.
+func TestOpenColdFixtureWithoutTxHashIndex(t *testing.T) {
+	chunkID := chunk.ID(0)
+	coldRoot := ingestColdChunk(t, chunkID)
+	indexRoot := geometry.NewLayout(coldRoot).TxHashIndexRoot()
+	require.DirExists(t, indexRoot, "the cold ingest built an index to remove")
+	require.NoError(t, os.RemoveAll(indexRoot))
+
+	t.Run("txhash requested", func(t *testing.T) {
+		_, _, err := openColdFixture(testLogger(), coldQueryOptions{
+			ColdRoot:   coldRoot,
+			StartChunk: chunkID,
+			NumChunks:  1,
+			Plan:       queryPlan{Types: []string{queryTypeLedgers, queryTypeTxHash}},
+		})
+		require.ErrorContains(t, err, indexRoot, "the error names where the index is expected")
+		assert.ErrorContains(t, err, queryTypeTxHash)
+	})
+
+	t.Run("txhash not requested", func(t *testing.T) {
+		logger := testLogger()
+		done := logger.StartTest(logrus.WarnLevel)
+		f, release, err := openColdFixture(logger, coldQueryOptions{
+			ColdRoot:   coldRoot,
+			StartChunk: chunkID,
+			NumChunks:  1,
+			Plan:       queryPlan{Types: []string{queryTypeLedgers}},
+		})
+		warnings := done()
+		require.NoError(t, err)
+		defer release()
+		assert.Equal(t, []chunk.ID{chunkID}, f.Chunks)
+		assert.Contains(t, warningMessages(warnings), "no tx-hash window index on disk")
+	})
+}
+
+// warningMessages joins a captured log's messages so a test can assert one of
+// them carries a phrase.
+func warningMessages(entries []logrus.Entry) string {
+	messages := make([]string, 0, len(entries))
+	for _, e := range entries {
+		messages = append(messages, e.Message)
+	}
+	return strings.Join(messages, "\n")
 }
 
 // TestEvictionStateRecordsPlatform pins what invocation.json says about

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
@@ -1,0 +1,366 @@
+package bench
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+)
+
+// TestNewQueryCommand builds the full command tree — executing every
+// markRequired call, whose panic on a bad flag name this test exists to catch
+// (main.go calls NewQueryCommand unconditionally at startup) — and pins each
+// subcommand's required flags.
+func TestNewQueryCommand(t *testing.T) {
+	cmd := NewQueryCommand()
+	require.Equal(t, "bench-query", cmd.Use)
+
+	requiredBySubcommand := map[string][]string{
+		"cold": {"start-chunk", "cold-dir"},
+		"hot":  {"chunk", "hot-dir"},
+	}
+	subs := querySubcommands(t, cmd)
+	for name, flags := range requiredBySubcommand {
+		sub := subs[name]
+		require.NotNil(t, sub, "subcommand %q missing", name)
+		for _, fn := range flags {
+			f := sub.Flags().Lookup(fn)
+			require.NotNil(t, f, "%s: flag --%s missing", name, fn)
+			require.Contains(t, f.Annotations, cobra.BashCompOneRequiredFlag,
+				"%s: flag --%s not marked required", name, fn)
+		}
+	}
+}
+
+// TestQueryCommandAcceptsRunnerArgv parses the argv the campaign runner emits,
+// verbatim and in its own order, through both subcommands. The runner is the
+// only caller in the campaign, so this argv IS the flag surface's contract: a
+// renamed flag, a dropped one, or a value format the flag cannot parse breaks a
+// campaign leg, not a local invocation.
+func TestQueryCommandAcceptsRunnerArgv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		argv []string
+	}{
+		{
+			name: "cold",
+			argv: []string{
+				"cold",
+				"--cold-dir=/bench/ds", "--start-chunk=7", "--num-chunks=1",
+				"--types=ledgers,txpage,txhash,events",
+				"--query-concurrency=1,4,16", "--iters=100", "--out=/bench/out",
+			},
+		},
+		{
+			name: "hot uncapped",
+			argv: []string{
+				"hot",
+				"--hot-dir=/bench/hot", "--chunk=7",
+				"--types=ledgers,txpage,txhash,events",
+				"--query-concurrency=1,4,16", "--iters=200", "--warmup=20", "--out=/bench/out",
+			},
+		},
+		{
+			name: "hot capped",
+			argv: []string{
+				"hot",
+				"--hot-dir=/bench/hot", "--chunk=7",
+				"--types=ledgers,txpage,txhash,events",
+				"--query-concurrency=1,4,16", "--iters=200", "--warmup=20",
+				"--sample-ledgers=50000", "--out=/bench/out",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sub := querySubcommands(t, NewQueryCommand())[tc.argv[0]]
+			require.NotNil(t, sub)
+			require.NoError(t, sub.ParseFlags(tc.argv[1:]))
+
+			types, err := sub.Flags().GetString("types")
+			require.NoError(t, err)
+			parsed, err := parseQueryTypes(types)
+			require.NoError(t, err)
+			require.Equal(t, allQueryTypes, parsed, "the runner sweeps every query type")
+
+			concurrency, err := sub.Flags().GetString("query-concurrency")
+			require.NoError(t, err)
+			levels, err := parseConcurrency(concurrency)
+			require.NoError(t, err)
+			require.Equal(t, []int{1, 4, 16}, levels)
+		})
+	}
+}
+
+// TestParseQueryTypes pins the accepted and rejected --types values.
+func TestParseQueryTypes(t *testing.T) {
+	got, err := parseQueryTypes("events,ledgers")
+	require.NoError(t, err)
+	require.Equal(t, []string{"events", "ledgers"}, got, "the caller's order is kept")
+
+	for _, bad := range []string{"", "ledgers,", "ledgers,ledgers", "ledger", "ledgers,txpages"} {
+		_, err := parseQueryTypes(bad)
+		require.Error(t, err, "--types=%q must be rejected", bad)
+	}
+}
+
+// TestParseConcurrency pins the accepted and rejected --query-concurrency values.
+func TestParseConcurrency(t *testing.T) {
+	got, err := parseConcurrency("16,1,4")
+	require.NoError(t, err)
+	require.Equal(t, []int{16, 1, 4}, got, "the caller's order is kept")
+
+	for _, bad := range []string{"", "1,", "0", "-1", "1,1", "four"} {
+		_, err := parseConcurrency(bad)
+		require.Error(t, err, "--query-concurrency=%q must be rejected", bad)
+	}
+}
+
+// TestQuerySpecs pins the report schema the results converter parses: one CSV
+// per swept type carrying total_c<W>, and driver.csv carrying the fixture open,
+// each cell's <qtype>_c<W> wall-clock, and the peak RSS.
+func TestQuerySpecs(t *testing.T) {
+	specs := querySpecs([]string{queryTypeLedgers, queryTypeEvents}, []int{1, 4})
+
+	names := make([]string, len(specs))
+	byName := make(map[string][]string, len(specs))
+	for i, s := range specs {
+		names[i] = s.name
+		byName[s.name] = s.rowOrder
+	}
+	require.Equal(t, []string{"ledgers", "events", "driver"}, names,
+		"the swept types come first, in sweep order, then driver.csv")
+	require.Equal(t, []string{"total_c1", "total_c4"}, byName["ledgers"])
+	require.Equal(t, []string{"total_c1", "total_c4"}, byName["events"])
+	require.Equal(t, []string{
+		"open",
+		"ledgers_c1", "ledgers_c4",
+		"events_c1", "events_c4",
+		"peak_rss_bytes",
+	}, byName["driver"])
+}
+
+// TestQuerySinkWritesContractRows records one cell per type and checks the
+// written CSVs carry the converter's header and row names.
+func TestQuerySinkWritesContractRows(t *testing.T) {
+	types := []string{queryTypeLedgers, queryTypeTxHash}
+	concurrency := []int{1, 4}
+	sink := newSchemaCSVSink(querySpecs(types, concurrency))
+	sink.observe(fileDriver, driverQueryOpen, time.Millisecond, 1)
+	for _, qtype := range types {
+		for _, w := range concurrency {
+			sink.observe(qtype, queryCellRow(w), time.Millisecond, 3)
+			sink.observe(fileDriver, queryDriverRow(qtype, w), time.Second, 3)
+		}
+	}
+
+	outDir := t.TempDir()
+	written, err := sink.writeCSVs(outDir)
+	require.NoError(t, err)
+	require.Len(t, written, 3)
+
+	for _, f := range sink.files() {
+		names := make([]string, len(f.rows))
+		for i, r := range f.rows {
+			names[i] = r.name
+		}
+		switch f.name {
+		case fileDriver:
+			require.Equal(t, []string{
+				"open", "ledgers_c1", "ledgers_c4", "txhash_c1", "txhash_c4",
+			}, names)
+		default:
+			require.Equal(t, []string{"total_c1", "total_c4"}, names, "file %s", f.name)
+		}
+	}
+}
+
+// TestOpenColdFixtureServesFrozenChunks runs bench-ingest cold to produce a real
+// frozen chunk, then opens the cold query fixture over that tree and reads
+// through it. It is the check that the fixture rebuilds the catalog state the
+// artifacts imply: bench-ingest throws its own catalog away, so a wrong
+// rebuild would leave every chunk unservable.
+func TestOpenColdFixtureServesFrozenChunks(t *testing.T) {
+	chunkID := chunk.ID(0)
+	packDir, _ := writeSourcePack(t, t.TempDir(), chunkID, chunk.LedgersPerChunk)
+	coldRoot := t.TempDir()
+	require.NoError(t, runCold(context.Background(), testLogger(), coldOptions{
+		Source:     sourceConfig{Kind: sourcePack, PackDir: packDir},
+		StartChunk: chunkID,
+		NumChunks:  1,
+		Workers:    1,
+		ColdRoot:   coldRoot,
+		OutDir:     filepath.Join(t.TempDir(), "csv"),
+	}))
+
+	f, release, err := openColdFixture(testLogger(), coldQueryOptions{
+		ColdRoot:   coldRoot,
+		StartChunk: chunkID,
+		NumChunks:  1,
+	})
+	require.NoError(t, err)
+	defer release()
+
+	require.Equal(t, []chunk.ID{chunkID}, f.Chunks)
+	assert.Equal(t, chunkID.FirstLedger(), f.FirstLedger)
+	assert.Equal(t, chunkID.LastLedger(), f.LastLedger)
+
+	view, err := f.view()
+	require.NoError(t, err)
+	defer view.Release()
+
+	// The scan is the seam the ledgers and txpage benchmarks measure; running it
+	// here proves routing resolved the chunk cold and the pack reader opened.
+	from := chunkID.FirstLedger()
+	scan, err := view.ScanLedgers(from, from+9)
+	require.NoError(t, err)
+	next := from
+	for e, serr := range scan {
+		require.NoError(t, serr)
+		assert.Equal(t, next, e.Seq)
+		next++
+	}
+	assert.Equal(t, from+10, next, "the scan yielded every ledger in the range")
+
+	// The backfill built one partial window index; the fixture must have named
+	// it, else the by-hash lookup has nothing to probe.
+	coverages, err := view.ColdTxHashIndexCoverages()
+	require.NoError(t, err)
+	require.Len(t, coverages, 1)
+	assert.Equal(t, chunkID, coverages[0].Lo)
+	assert.Equal(t, chunkID, coverages[0].Hi)
+}
+
+// TestRunQueryColdWritesSetupReport drives runQueryCold over a real frozen
+// chunk with the sweep the campaign runner asks for. The per-type bodies are
+// #856 B2, so the sweep stops at the first cell and the run writes the PARTIAL
+// report: this pins that the setup rows still land and that the error names the
+// type. Replace the unimplemented assertions with the per-cell rows when B2
+// fills the bodies in.
+func TestRunQueryColdWritesSetupReport(t *testing.T) {
+	chunkID := chunk.ID(0)
+	packDir, _ := writeSourcePack(t, t.TempDir(), chunkID, chunk.LedgersPerChunk)
+	coldRoot := t.TempDir()
+	require.NoError(t, runCold(context.Background(), testLogger(), coldOptions{
+		Source:     sourceConfig{Kind: sourcePack, PackDir: packDir},
+		StartChunk: chunkID,
+		NumChunks:  1,
+		Workers:    1,
+		ColdRoot:   coldRoot,
+		OutDir:     filepath.Join(t.TempDir(), "csv"),
+	}))
+
+	csvDir := filepath.Join(t.TempDir(), "csv")
+	err := runQueryCold(context.Background(), testLogger(), coldQueryOptions{
+		ColdRoot:   coldRoot,
+		StartChunk: chunkID,
+		NumChunks:  1,
+		Plan:       queryPlan{Types: allQueryTypes, Concurrency: []int{1, 4, 16}, Iters: 100},
+		OutDir:     csvDir,
+	})
+	require.ErrorIs(t, err, errQueryTypeUnimplemented)
+	require.ErrorContains(t, err, queryTypeLedgers, "the error names the type that stopped the sweep")
+
+	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
+	require.Contains(t, driver, "open")
+	assert.EqualValues(t, 1, driver["open"]["n"])
+	assert.EqualValues(t, 1, driver["open"]["n_items"], "one chunk opened")
+}
+
+// TestOpenColdFixtureRejectsMissingChunk pins the open failing with the chunk
+// named when the dataset does not cover the requested range, rather than
+// deferring an unreadable ErrUnavailable to every query.
+func TestOpenColdFixtureRejectsMissingChunk(t *testing.T) {
+	_, _, err := openColdFixture(testLogger(), coldQueryOptions{
+		ColdRoot:   t.TempDir(),
+		StartChunk: chunk.ID(4),
+		NumChunks:  1,
+	})
+	require.ErrorContains(t, err, "no ledger pack")
+}
+
+// TestOpenHotFixtureServesHotChunk runs bench-ingest hot to produce a real hot
+// database, then opens the hot query fixture over it and reads through it. It
+// also pins the sampled range: the fixture trusts what the database committed,
+// not the chunk's nominal span, and --sample-ledgers narrows that further.
+func TestOpenHotFixtureServesHotChunk(t *testing.T) {
+	const ingested = 50
+	chunkID := chunk.ID(0)
+	packDir, _ := writeSourcePack(t, t.TempDir(), chunkID, ingested)
+	hotRoot := t.TempDir()
+	require.NoError(t, runHot(context.Background(), testLogger(), hotOptions{
+		Source:     sourceConfig{Kind: sourcePack, PackDir: packDir},
+		StartChunk: chunkID,
+		NumChunks:  1,
+		NumLedgers: ingested,
+		HotRoot:    hotRoot,
+		OutDir:     filepath.Join(t.TempDir(), "csv"),
+	}))
+	first := chunkID.FirstLedger()
+
+	t.Run("uncapped sample", func(t *testing.T) {
+		f, release, err := openHotFixture(testLogger(), hotQueryOptions{HotRoot: hotRoot, Chunk: chunkID})
+		require.NoError(t, err)
+		defer release()
+
+		require.Equal(t, []chunk.ID{chunkID}, f.Chunks)
+		assert.Equal(t, first, f.FirstLedger)
+		assert.Equal(t, first+ingested-1, f.LastLedger, "the sampled range is what the database holds")
+
+		view, err := f.view()
+		require.NoError(t, err)
+		defer view.Release()
+
+		scan, err := view.ScanLedgers(first, f.LastLedger)
+		require.NoError(t, err)
+		seqs := 0
+		for _, serr := range scan {
+			require.NoError(t, serr)
+			seqs++
+		}
+		assert.Equal(t, ingested, seqs)
+
+		// One published handle means one hot index for the by-hash lookup.
+		assert.Len(t, view.HotTxHashIndexes(), 1)
+	})
+
+	t.Run("capped sample", func(t *testing.T) {
+		f, release, err := openHotFixture(testLogger(), hotQueryOptions{
+			HotRoot: hotRoot, Chunk: chunkID, SampleLedgers: 10,
+		})
+		require.NoError(t, err)
+		defer release()
+		assert.Equal(t, first+9, f.LastLedger)
+	})
+
+	t.Run("cap past what was ingested", func(t *testing.T) {
+		f, release, err := openHotFixture(testLogger(), hotQueryOptions{
+			HotRoot: hotRoot, Chunk: chunkID, SampleLedgers: chunk.LedgersPerChunk,
+		})
+		require.NoError(t, err)
+		defer release()
+		assert.Equal(t, first+ingested-1, f.LastLedger, "a cap past the committed span is clamped")
+	})
+}
+
+// TestOpenHotFixtureRejectsMissingDatabase pins the ready-key open refusing to
+// fabricate an empty database for a chunk that was never ingested.
+func TestOpenHotFixtureRejectsMissingDatabase(t *testing.T) {
+	_, _, err := openHotFixture(testLogger(), hotQueryOptions{HotRoot: t.TempDir(), Chunk: chunk.ID(3)})
+	require.Error(t, err)
+}
+
+// querySubcommands indexes a command's children by Use.
+func querySubcommands(t *testing.T, cmd *cobra.Command) map[string]*cobra.Command {
+	t.Helper()
+	subs := make(map[string]*cobra.Command, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		subs[sub.Use] = sub
+	}
+	return subs
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
@@ -361,8 +361,9 @@ func TestOpenColdFixtureServesFrozenChunks(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, idxs, 1)
 
-	hashes, err := sampleChunkTxHashes(view, chunkID, f.FirstLedger, f.LastLedger, testRNG())
-	require.NoError(t, err)
+	s := newTxHashSampler(testRNG())
+	require.NoError(t, s.sampleChunk(view, chunkID, f.FirstLedger, f.LastLedger))
+	hashes := s.hashes
 	require.NotEmpty(t, hashes, "the synthetic chunk holds transactions to probe")
 	seq, err := idxs[0].Get(hashes[0])
 	require.NoError(t, err)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"context"
+	"math/rand/v2"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -243,13 +244,26 @@ func TestOpenColdFixtureServesFrozenChunks(t *testing.T) {
 	assert.Equal(t, from+10, next, "the scan yielded every ledger in the range")
 
 	// The backfill built one partial window index; the fixture must have named
-	// it, else the by-hash lookup has nothing to probe.
-	coverages, err := view.ColdTxHashIndexCoverages()
+	// it, else the by-hash lookup has nothing to probe. The view opens the .idx
+	// on the first probe, not here, so resolving a hash the chunk really holds
+	// is what proves the fixture named the right window: a wrong coverage
+	// resolves to a path that does not exist and the probe fails.
+	idxs, err := view.ColdTxIndexes()
 	require.NoError(t, err)
-	require.Len(t, coverages, 1)
-	assert.Equal(t, chunkID, coverages[0].Lo)
-	assert.Equal(t, chunkID, coverages[0].Hi)
+	require.Len(t, idxs, 1)
+
+	hashes, err := sampleChunkTxHashes(view, chunkID, f.FirstLedger, f.LastLedger, testRNG())
+	require.NoError(t, err)
+	require.NotEmpty(t, hashes, "the synthetic chunk holds transactions to probe")
+	seq, err := idxs[0].Get(hashes[0])
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, seq, f.FirstLedger)
+	assert.LessOrEqual(t, seq, f.LastLedger)
 }
+
+// testRNG is a fixed-seed generator for the corpus samplers the tests drive
+// directly.
+func testRNG() *rand.Rand { return rand.New(rand.NewPCG(defaultSeed, defaultSeed)) }
 
 // testQueryPlan is the sweep the end-to-end tests run: every type, two
 // concurrency levels, few enough iterations to stay quick. The spans are small

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_test.go
@@ -2,9 +2,9 @@ package bench
 
 import (
 	"context"
+	"math"
 	"math/rand/v2"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -58,7 +58,7 @@ func TestQueryCommandAcceptsRunnerArgv(t *testing.T) {
 				"cold",
 				"--cold-dir=/bench/ds", "--start-chunk=7", "--num-chunks=1",
 				"--types=ledgers,txpage,txhash,events",
-				"--query-concurrency=1,4,16", "--iters=100", "--out=/bench/out",
+				"--target-rps=0.5,1,2", "--duration=5s", "--out=/bench/out",
 			},
 		},
 		{
@@ -67,7 +67,7 @@ func TestQueryCommandAcceptsRunnerArgv(t *testing.T) {
 				"hot",
 				"--hot-dir=/bench/hot", "--chunk=7",
 				"--types=ledgers,txpage,txhash,events",
-				"--query-concurrency=1,4,16", "--iters=200", "--warmup=20", "--out=/bench/out",
+				"--target-rps=0.5,1,2", "--duration=5s", "--warmup=20", "--out=/bench/out",
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func TestQueryCommandAcceptsRunnerArgv(t *testing.T) {
 				"hot",
 				"--hot-dir=/bench/hot", "--chunk=7",
 				"--types=ledgers,txpage,txhash,events",
-				"--query-concurrency=1,4,16", "--iters=200", "--warmup=20",
+				"--target-rps=0.5,1,2", "--duration=5s", "--warmup=20",
 				"--sample-ledgers=50000", "--out=/bench/out",
 			},
 		},
@@ -92,11 +92,15 @@ func TestQueryCommandAcceptsRunnerArgv(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, allQueryTypes, parsed, "the runner sweeps every query type")
 
-			concurrency, err := sub.Flags().GetString("query-concurrency")
+			targetRPS, err := sub.Flags().GetString("target-rps")
 			require.NoError(t, err)
-			levels, err := parseConcurrency(concurrency)
+			rates, err := parseTargetRPS(targetRPS)
 			require.NoError(t, err)
-			require.Equal(t, []int{1, 4, 16}, levels)
+			require.Equal(t, []float64{0.5, 1, 2}, rates)
+
+			duration, err := sub.Flags().GetDuration("duration")
+			require.NoError(t, err)
+			require.Equal(t, 5*time.Second, duration)
 		})
 	}
 }
@@ -113,23 +117,34 @@ func TestParseQueryTypes(t *testing.T) {
 	}
 }
 
-// TestParseConcurrency pins the accepted and rejected --query-concurrency values.
-func TestParseConcurrency(t *testing.T) {
-	got, err := parseConcurrency("16,1,4")
+// TestParseTargetRPS pins the accepted and rejected --target-rps values.
+func TestParseTargetRPS(t *testing.T) {
+	got, err := parseTargetRPS("2,0.5,1")
 	require.NoError(t, err)
-	require.Equal(t, []int{16, 1, 4}, got, "the caller's order is kept")
+	require.Equal(t, []float64{2, 0.5, 1}, got, "the caller's order is kept")
 
-	for _, bad := range []string{"", "1,", "0", "-1", "1,1", "four"} {
-		_, err := parseConcurrency(bad)
-		require.Error(t, err, "--query-concurrency=%q must be rejected", bad)
+	for _, bad := range []string{"", "1,", "0", "-1", "1,1", "four", "NaN", "Inf"} {
+		_, err := parseTargetRPS(bad)
+		require.Error(t, err, "--target-rps=%q must be rejected", bad)
 	}
 }
 
+// TestFormatRPS pins how a rate is spelled in a row label: the shortest decimal
+// that reads back as the same rate, whole rates without a trailing ".0".
+func TestFormatRPS(t *testing.T) {
+	for rps, want := range map[float64]string{0.5: "0.5", 1: "1", 1.67: "1.67", 300: "300"} {
+		assert.Equal(t, want, formatRPS(rps))
+	}
+	assert.Equal(t, "total_r0.5", queryTotalRow(0.5))
+	assert.Equal(t, "txhash_r300_lag", queryDriverLegRow(queryTypeTxHash, 300, driverLegLagSuffix))
+}
+
 // TestQuerySpecs pins the report schema the results converter parses: one CSV
-// per swept type carrying total_c<W>, and driver.csv carrying the fixture open,
-// each cell's <qtype>_c<W> wall-clock, and the peak RSS.
+// per query type carrying total_r<rate> and service_r<rate>, and driver.csv
+// carrying the fixture open, each leg's wall-clock and driver metrics, and the
+// peak RSS.
 func TestQuerySpecs(t *testing.T) {
-	specs := querySpecs([]string{queryTypeLedgers, queryTypeEvents}, []int{1, 4})
+	specs := querySpecs([]string{queryTypeLedgers, queryTypeEvents}, []float64{0.5, 2})
 
 	names := make([]string, len(specs))
 	byName := make(map[string][]string, len(specs))
@@ -138,40 +153,54 @@ func TestQuerySpecs(t *testing.T) {
 		byName[s.name] = s.rowOrder
 	}
 	require.Equal(t, []string{"ledgers", "events", "driver"}, names,
-		"the swept types come first, in sweep order, then driver.csv")
-	require.Equal(t, []string{"total_c1", "total_c4"}, byName["ledgers"])
-	require.Equal(t, []string{"total_c1", "total_c4"}, byName["events"])
+		"the query types come first, in --types order, then driver.csv")
+	require.Equal(t, []string{"total_r0.5", "total_r2", "service_r0.5", "service_r2"}, byName["ledgers"])
+	require.Equal(t, []string{"total_r0.5", "total_r2", "service_r0.5", "service_r2"}, byName["events"])
 	require.Equal(t, []string{
 		"open", "evict",
-		"ledgers_c1", "ledgers_c4",
-		"events_c1", "events_c4",
+		"ledgers_r0.5", "ledgers_r0.5_millirps", "ledgers_r0.5_lag", "ledgers_r0.5_shed",
+		"ledgers_r2", "ledgers_r2_millirps", "ledgers_r2_lag", "ledgers_r2_shed",
+		"events_r0.5", "events_r0.5_millirps", "events_r0.5_lag", "events_r0.5_shed",
+		"events_r2", "events_r2_millirps", "events_r2_lag", "events_r2_shed",
 		"peak_rss_bytes",
 	}, byName["driver"])
 }
 
 // TestQuerySpecsTxHashStages pins the found/miss rows the txhash file carries
-// beside the blended cell the converter reads.
+// beside the blended row the converter reads.
 func TestQuerySpecsTxHashStages(t *testing.T) {
-	specs := querySpecs([]string{queryTypeTxHash}, []int{1, 4})
+	specs := querySpecs([]string{queryTypeTxHash}, []float64{0.5, 2})
 	require.Equal(t, queryTypeTxHash, specs[0].name)
 	require.Equal(t, []string{
-		"total_c1", "total_c4",
-		"found_c1", "found_c4",
-		"miss_c1", "miss_c4",
+		"total_r0.5", "total_r2",
+		"service_r0.5", "service_r2",
+		"found_r0.5", "found_r2",
+		"miss_r0.5", "miss_r2",
 	}, specs[0].rowOrder)
 }
 
-// TestQuerySinkWritesContractRows records one cell per type and checks the
-// written CSVs carry the converter's header and row names.
+// TestQuerySinkWritesContractRows records one leg per type per rate and checks
+// the written CSVs carry the converter's row names — including the _lag and
+// _shed rows, whose samples are zero durations the ordinary filter would drop —
+// and that the _millirps row carries the leg's achieved rate times 1000.
 func TestQuerySinkWritesContractRows(t *testing.T) {
+	const legWall = 2 * time.Second
 	types := []string{queryTypeLedgers, queryTypeTxHash}
-	concurrency := []int{1, 4}
-	sink := newSchemaCSVSink(querySpecs(types, concurrency))
+	rates := []float64{1, 4}
+	sink := newSchemaCSVSink(querySpecs(types, rates))
 	sink.observe(fileDriver, driverQueryOpen, time.Millisecond, 1)
+	res := legResult{
+		samples: []cellSample{
+			{service: time.Millisecond, scheduled: 2 * time.Millisecond, items: 3},
+			{service: 2 * time.Millisecond, scheduled: 3 * time.Millisecond, items: 3},
+		},
+		lags:       []time.Duration{0, time.Millisecond},
+		wall:       legWall,
+		dispatched: 2,
+	}
 	for _, qtype := range types {
-		for _, w := range concurrency {
-			sink.observe(qtype, queryCellRow(w), time.Millisecond, 3)
-			sink.observe(fileDriver, queryDriverRow(qtype, w), time.Second, 3)
+		for _, rps := range rates {
+			recordLeg(sink, qtype, rps, res)
 		}
 	}
 
@@ -179,6 +208,29 @@ func TestQuerySinkWritesContractRows(t *testing.T) {
 	written, err := sink.writeCSVs(outDir)
 	require.NoError(t, err)
 	require.Len(t, written, 3)
+
+	driver := readCSV(t, filepath.Join(outDir, "driver.csv"))
+	wantMilliRPS := int64(math.Round(float64(len(res.samples)) / legWall.Seconds() * 1000))
+	for _, qtype := range types {
+		rows := readCSV(t, filepath.Join(outDir, qtype+".csv"))
+		for _, rps := range rates {
+			assert.Contains(t, rows, queryTotalRow(rps))
+			assert.Contains(t, rows, queryServiceRow(rps))
+
+			lag := queryDriverLegRow(qtype, rps, driverLegLagSuffix)
+			require.Contains(t, driver, lag, "a zero dispatch lag is a real observation")
+			assert.EqualValues(t, 2, driver[lag]["n"], "%s keeps its zero-lag sample", lag)
+
+			shed := queryDriverLegRow(qtype, rps, driverLegShedSuffix)
+			require.Contains(t, driver, shed, "a leg that shed nothing still reports a shed row")
+			assert.EqualValues(t, 0, driver[shed]["n_items"])
+
+			millirps := queryDriverLegRow(qtype, rps, driverLegRPSSuffix)
+			require.Contains(t, driver, millirps)
+			assert.Equal(t, wantMilliRPS, driver[millirps]["total_ns"])
+			assert.EqualValues(t, len(res.samples), driver[millirps]["n_items"])
+		}
+	}
 
 	for _, f := range sink.files() {
 		names := make([]string, len(f.rows))
@@ -188,10 +240,15 @@ func TestQuerySinkWritesContractRows(t *testing.T) {
 		switch f.name {
 		case fileDriver:
 			require.Equal(t, []string{
-				"open", "ledgers_c1", "ledgers_c4", "txhash_c1", "txhash_c4",
+				"open",
+				"ledgers_r1", "ledgers_r1_millirps", "ledgers_r1_lag", "ledgers_r1_shed",
+				"ledgers_r4", "ledgers_r4_millirps", "ledgers_r4_lag", "ledgers_r4_shed",
+				"txhash_r1", "txhash_r1_millirps", "txhash_r1_lag", "txhash_r1_shed",
+				"txhash_r4", "txhash_r4_millirps", "txhash_r4_lag", "txhash_r4_shed",
 			}, names)
 		default:
-			require.Equal(t, []string{"total_c1", "total_c4"}, names, "file %s", f.name)
+			require.Equal(t, []string{"total_r1", "total_r4", "service_r1", "service_r4"},
+				names, "file %s", f.name)
 		}
 	}
 }
@@ -265,15 +322,16 @@ func TestOpenColdFixtureServesFrozenChunks(t *testing.T) {
 // directly.
 func testRNG() *rand.Rand { return rand.New(rand.NewPCG(defaultSeed, defaultSeed)) }
 
-// testQueryPlan is the sweep the end-to-end tests run: every type, two
-// concurrency levels, few enough iterations to stay quick. The spans are small
-// because the fixture chunk is synthetic, and the miss fraction is high enough
-// that a short cell reliably produces both a found and a not-found lookup.
-func testQueryPlan(iters int) queryPlan {
+// testQueryPlan is the run the end-to-end tests drive: every type at two rates,
+// over legs short enough to stay quick and fast enough that each still measures
+// tens of requests (10 at 50 rps, 40 at 200 rps). The spans are small because
+// the fixture chunk is synthetic, and the miss fraction is high enough that a
+// short leg reliably produces both a found and a not-found lookup.
+func testQueryPlan() queryPlan {
 	return queryPlan{
 		Types:        allQueryTypes,
-		Concurrency:  []int{1, 2},
-		Iters:        iters,
+		TargetRPS:    []float64{50, 200},
+		Duration:     200 * time.Millisecond,
 		LedgersSpan:  4,
 		TxPageSpan:   2,
 		TxPageLimit:  10,
@@ -284,18 +342,16 @@ func testQueryPlan(iters int) queryPlan {
 	}
 }
 
-// TestRunQueryCold is the cold end-to-end: ingest a chunk, then sweep every
-// query type over its frozen artifacts and check the report the results
-// converter will read — one CSV per type carrying a total_c<W> row per
-// concurrency level, and driver.csv carrying the matching cell walls plus the
-// setup rows.
+// TestRunQueryCold is the cold end-to-end: ingest a chunk, then run every query
+// type over its frozen artifacts and check the report the results converter
+// will read — one CSV per type carrying a total_r<rate> row per leg, and
+// driver.csv carrying the matching leg walls plus the setup rows.
 func TestRunQueryCold(t *testing.T) {
-	const iters = 5
 	chunkID := chunk.ID(0)
 	coldRoot := ingestColdChunk(t, chunkID)
 
 	csvDir := filepath.Join(t.TempDir(), "csv")
-	plan := testQueryPlan(iters)
+	plan := testQueryPlan()
 	plan.Evict = true
 	require.NoError(t, runQueryCold(context.Background(), testLogger(), coldQueryOptions{
 		ColdRoot:   coldRoot,
@@ -305,29 +361,26 @@ func TestRunQueryCold(t *testing.T) {
 		OutDir:     csvDir,
 	}))
 
-	assertQueryReport(t, csvDir, plan, iters)
+	assertQueryReport(t, csvDir, plan)
 
 	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
 	require.Contains(t, driver, "open")
 	assert.EqualValues(t, 1, driver["open"]["n_items"], "one chunk opened")
-	// One eviction pass runs per cell, but the sink drops zero-duration samples
+	// One eviction pass runs per leg, but the sink drops zero-duration samples
 	// and off Linux the pass is a no-op that finishes inside a timer tick — so
 	// the row's presence and the artifacts it named are what can be asserted
 	// everywhere, not the sample count.
-	require.Contains(t, driver, "evict", "a cold cell evicts before it measures")
-	assert.LessOrEqual(t, driver["evict"]["n"], int64(len(plan.Types)*len(plan.Concurrency)),
-		"at most one eviction pass per cell")
+	require.Contains(t, driver, "evict", "a cold leg evicts before it measures")
+	assert.LessOrEqual(t, driver["evict"]["n"], int64(len(plan.Types)*len(plan.TargetRPS)),
+		"at most one eviction pass per leg")
 	assert.Positive(t, driver["evict"]["n_items"], "the eviction pass named some artifacts")
 }
 
 // TestRunQueryHot is the hot end-to-end: ingest a chunk into a hot database,
-// then sweep every query type against it. It also covers the warmup pass, which
-// only the hot tier runs.
+// then run every query type against it. It also covers the warmup requests,
+// which only the hot tier dispatches.
 func TestRunQueryHot(t *testing.T) {
-	const (
-		ingested = 400
-		iters    = 5
-	)
+	const ingested = 400
 	chunkID := chunk.ID(0)
 	packDir, _ := writeSourcePack(t, t.TempDir(), chunkID, ingested)
 	hotRoot := t.TempDir()
@@ -341,7 +394,7 @@ func TestRunQueryHot(t *testing.T) {
 	}))
 
 	csvDir := filepath.Join(t.TempDir(), "csv")
-	plan := testQueryPlan(iters)
+	plan := testQueryPlan()
 	plan.Warmup = 2
 	require.NoError(t, runQueryHot(context.Background(), testLogger(), hotQueryOptions{
 		HotRoot: hotRoot,
@@ -350,44 +403,73 @@ func TestRunQueryHot(t *testing.T) {
 		OutDir:  csvDir,
 	}))
 
-	assertQueryReport(t, csvDir, plan, iters)
+	assertQueryReport(t, csvDir, plan)
 
 	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
 	assert.NotContains(t, driver, "evict", "a hot run has no page-cache artifacts to evict")
 }
 
 // assertQueryReport checks a finished run's CSVs against the converter's
-// contract: every swept cell present, its sample count exactly what the sweep
-// promised (workers × iters), and every cell wall recorded in driver.csv. It
-// also checks txhash's found/miss rows partition the blended row, which is the
-// property that lets the split be reported without touching the cell the
-// converter reads.
-func assertQueryReport(t *testing.T, csvDir string, plan queryPlan, iters int) {
+// contract: every leg present, its sample count exactly the number of requests
+// the leg scheduled, and every leg's wall and driver metrics recorded in
+// driver.csv. It also checks txhash's found/miss rows partition the blended
+// row, which is the property that lets the split be reported without touching
+// the row the converter reads.
+func assertQueryReport(t *testing.T, csvDir string, plan queryPlan) {
 	t.Helper()
 	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
 
 	for _, qtype := range plan.Types {
 		rows := readCSV(t, filepath.Join(csvDir, qtype+".csv"))
-		for _, w := range plan.Concurrency {
-			cell := queryCellRow(w)
-			require.Contains(t, rows, cell, "%s is missing its c%d cell", qtype, w)
-			assert.EqualValues(t, w*iters, rows[cell]["n"],
-				"%s c%d must hold one sample per request", qtype, w)
+		for _, rps := range plan.TargetRPS {
+			measured := int64(measuredRequests(rps, plan.Duration))
+			total := queryTotalRow(rps)
+			require.Contains(t, rows, total, "%s is missing its %s leg", qtype, formatRPS(rps))
+			assert.Equal(t, measured, rows[total]["n"],
+				"%s at %s rps must hold one sample per request", qtype, formatRPS(rps))
 
-			wall := queryDriverRow(qtype, w)
-			require.Contains(t, driver, wall, "driver.csv is missing %s", wall)
-			assert.Positive(t, driver[wall]["total_ns"], "%s took no time", wall)
+			service := queryServiceRow(rps)
+			require.Contains(t, rows, service, "%s is missing %s", qtype, service)
+			assert.Equal(t, measured, rows[service]["n"])
+
+			assertLegDriverRows(t, driver, qtype, rps, measured)
 		}
 		if qtype != queryTypeTxHash {
 			continue
 		}
-		for _, w := range plan.Concurrency {
-			found := rows[txHashStageFound+"_c"+strconv.Itoa(w)]
-			miss := rows[txHashStageMiss+"_c"+strconv.Itoa(w)]
-			assert.Equal(t, rows[queryCellRow(w)]["n"], found["n"]+miss["n"],
-				"txhash c%d: the found and miss rows must partition the blended row", w)
+		for _, rps := range plan.TargetRPS {
+			found := rows[queryStageRow(txHashStageFound, rps)]
+			miss := rows[queryStageRow(txHashStageMiss, rps)]
+			assert.Equal(t, rows[queryTotalRow(rps)]["n"], found["n"]+miss["n"],
+				"txhash at %s rps: the found and miss rows must partition the blended row", formatRPS(rps))
 		}
 	}
+}
+
+// assertLegDriverRows checks the four driver rows one leg writes: its wall, its
+// achieved rate, its dispatch-lag distribution (one sample per dispatched
+// request, zeros kept), and its shed count, which a leg the fixture kept up
+// with reports as zero.
+func assertLegDriverRows(
+	t *testing.T, driver map[string]map[string]int64, qtype string, rps float64, measured int64,
+) {
+	t.Helper()
+	wall := queryDriverRow(qtype, rps)
+	require.Contains(t, driver, wall, "driver.csv is missing %s", wall)
+	assert.Positive(t, driver[wall]["total_ns"], "%s took no time", wall)
+
+	millirps := queryDriverLegRow(qtype, rps, driverLegRPSSuffix)
+	require.Contains(t, driver, millirps, "driver.csv is missing %s", millirps)
+	assert.Positive(t, driver[millirps]["total_ns"], "%s served nothing", millirps)
+	assert.Equal(t, driver[wall]["n_items"], driver[millirps]["n_items"])
+
+	lag := queryDriverLegRow(qtype, rps, driverLegLagSuffix)
+	require.Contains(t, driver, lag, "driver.csv is missing %s", lag)
+	assert.Equal(t, measured, driver[lag]["n"], "%s holds one sample per dispatch", lag)
+
+	shed := queryDriverLegRow(qtype, rps, driverLegShedSuffix)
+	require.Contains(t, driver, shed, "driver.csv is missing %s", shed)
+	assert.EqualValues(t, 0, driver[shed]["n_items"], "%s: the fixture kept up", shed)
 }
 
 // ingestColdChunk runs bench-ingest cold over a synthetic pack and returns the
@@ -415,7 +497,7 @@ func TestQueryRejectsWrongPassphrase(t *testing.T) {
 	chunkID := chunk.ID(0)
 	coldRoot := ingestColdChunk(t, chunkID)
 
-	plan := testQueryPlan(2)
+	plan := testQueryPlan()
 	plan.Types = []string{queryTypeTxHash}
 	plan.Passphrase = network.TestNetworkPassphrase
 	err := runQueryCold(context.Background(), testLogger(), coldQueryOptions{

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
@@ -65,8 +65,8 @@ func newQueryRequest(
 //
 // The span is a flag because a point read is simply a span of one, and a leg
 // measures one shape at a time, so its percentiles describe a single
-// distribution. The default is the endpoint's page cap, which is what a client
-// actually asks for.
+// distribution. The default is the request shape fixed by the team SLA
+// (getLedgers max=10).
 func ledgersRequest(f *queryFixture, p queryPlan) queryRequest {
 	return func(rng *rand.Rand) (cellSample, error) {
 		lo := f.pickStart(rng, p.LedgersSpan)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/txhash"
@@ -20,9 +19,7 @@ import (
 // one models a served endpoint: it takes its own read view, issues the read
 // through query.ReadView, and returns how many items came back. None of them
 // touches a store reader that ReadView did not hand over, so the p99-campaign
-// refactor of the readers moves these numbers without moving this code — except
-// for the cold tx-hash index open, which ReadView does not expose yet (see
-// coldTxIndexes).
+// refactor of the readers moves these numbers without moving this code.
 
 // Sub-stage labels for the tx-hash distribution. The blended total_c<W> row is
 // what the results converter reads; these two additionally split it, since a
@@ -172,11 +169,10 @@ func txHashRequest(f *queryFixture, corpus *txHashCorpus) queryRequest {
 			}
 			defer view.Release()
 
-			probe, release, err := f.txReader(view)
+			probe, err := f.txReader(view)
 			if err != nil {
 				return 0, err
 			}
-			defer release()
 			_, found, err := probe.GetTransaction(hash)
 			if err != nil {
 				return 0, fmt.Errorf("look up transaction %x: %w", hash, err)
@@ -240,124 +236,32 @@ func (f *queryFixture) pickStart(rng *rand.Rand, span uint32) uint32 {
 	return f.FirstLedger + uint32(rng.IntN(int(room-span+1))) //nolint:gosec // room fits a chunk range
 }
 
-// txReader assembles the two-tier by-hash probe for one read view: the hot
-// indexes of every published chunk, then one reader per frozen cold window
-// index, with both tiers gated to the view's servable ledger range and the
-// candidate ledgers read back through the view. The returned release closes
-// whatever window indexes the probe actually opened; the caller MUST run it
-// when the request completes.
+// txReader assembles the two-tier by-hash probe for one read view, the way the
+// serving adapter does: the hot indexes of every published chunk, then the
+// frozen cold window indexes on demand, with the candidate ledgers read back
+// through the view.
 //
-// The gate has to sit between the index and the ledger read. A frozen cold
-// index covers a thousand chunks, but each chunk's ledger file is deleted once
-// that chunk falls below the retention floor, so for most of its life the index
-// names transactions whose ledgers are gone. Ungated, those become read
-// failures; gated, they are what they should be — not found.
-func (f *queryFixture) txReader(view *query.ReadView) (*txhash.TxReader, func(), error) {
-	cold, release, err := f.coldTxIndexes(view)
-	if err != nil {
-		return nil, nil, err
-	}
+// The view owns both tiers. It hands over each index already gated to the
+// servable ledger range, and it opens a cold .idx only on that index's first
+// probe and closes it on Release. Both properties are load-bearing for these
+// numbers, so the bench states what it depends on:
+//
+//   - The gate sits between the index probe and the ledger read. A frozen cold
+//     index covers a thousand chunks, but each chunk's ledger file goes as soon
+//     as that chunk falls below the retention floor, so for most of its life the
+//     index names transactions whose ledgers are gone. Ungated, those reads
+//     fail; gated, they are the not-found they should be.
+//   - Cold indexes open lazily, and the probe asks for them only after every hot
+//     index missed. A hot hit therefore pays no file open — which is the whole
+//     shape of the hot/cold split this benchmark reports.
+func (f *queryFixture) txReader(view *query.ReadView) (*txhash.TxReader, error) {
 	probe, err := txhash.NewTxReader(
-		gateIndexes(view, view.HotTxHashIndexes()), cold,
+		view.HotTxHashIndexes(), view.ColdTxIndexes,
 		&viewLedgerSource{view: view}, f.Passphrase)
 	if err != nil {
-		release()
-		return nil, nil, fmt.Errorf("assemble the by-hash probe: %w", err)
+		return nil, fmt.Errorf("assemble the by-hash probe: %w", err)
 	}
-	return probe, release, nil
-}
-
-// coldTxIndexes returns one gated, lazily opened reader per frozen window index
-// in the view's snapshot, newest coverage first, plus the release that closes
-// the ones a probe opened.
-//
-// Opening is deferred to the first probe because the common lookup resolves in
-// the hot tier and never reaches the cold one: opening every window index up
-// front would charge each hot hit for file opens a served request never makes.
-//
-// This composes what the read facade does not expose yet. The adapters branch
-// moves the same logic behind a query.ReadView method (ColdTxIndexes), where it
-// belongs — the layout and the view's closers are the view's own. Replace this
-// with that method once it lands, and the bench stops reaching for the layout.
-func (f *queryFixture) coldTxIndexes(view *query.ReadView) ([]txhash.HashIndex, func(), error) {
-	covs, err := view.ColdTxHashIndexCoverages()
-	if err != nil {
-		return nil, nil, fmt.Errorf("read the frozen tx-hash index coverages: %w", err)
-	}
-	idxs := make([]txhash.HashIndex, 0, len(covs))
-	lazies := make([]*lazyColdTxIndex, 0, len(covs))
-	for _, cov := range covs {
-		l := &lazyColdTxIndex{path: f.Layout.TxHashIndexFilePath(cov), cov: cov}
-		lazies = append(lazies, l)
-		idxs = append(idxs, gateIndex(view, l))
-	}
-	release := func() {
-		for _, l := range lazies {
-			if err := l.close(); err != nil {
-				f.Logger.WithError(err).Warn("bench-query: close cold tx-hash index")
-			}
-		}
-	}
-	return idxs, release, nil
-}
-
-// lazyColdTxIndex opens its window index on the first probe and keeps it for
-// the rest of the request. One request runs on one goroutine, as a read view
-// does, so it needs no locking.
-type lazyColdTxIndex struct {
-	path   string
-	cov    geometry.TxHashIndexCoverage
-	reader *txhash.ColdReader
-}
-
-func (l *lazyColdTxIndex) Get(hash [32]byte) (uint32, error) {
-	if l.reader == nil {
-		r, err := txhash.OpenColdReader(l.path)
-		if err != nil {
-			return 0, fmt.Errorf("open the cold tx-hash index [%s, %s]: %w", l.cov.Lo, l.cov.Hi, err)
-		}
-		l.reader = r
-	}
-	return l.reader.Get(hash)
-}
-
-// close releases the window index if a probe ever opened it.
-func (l *lazyColdTxIndex) close() error {
-	if l.reader == nil {
-		return nil
-	}
-	return l.reader.Close()
-}
-
-// gateIndexes wraps every index so a hit outside the view's servable ledger
-// range reads as a miss. See queryFixture.txReader for why.
-func gateIndexes(view *query.ReadView, idxs []txhash.HashIndex) []txhash.HashIndex {
-	gated := make([]txhash.HashIndex, 0, len(idxs))
-	for _, idx := range idxs {
-		gated = append(gated, gateIndex(view, idx))
-	}
-	return gated
-}
-
-func gateIndex(view *query.ReadView, idx txhash.HashIndex) txhash.HashIndex {
-	return &windowGatedIndex{inner: idx, view: view}
-}
-
-// windowGatedIndex drops a hit naming a ledger the view cannot serve.
-type windowGatedIndex struct {
-	inner txhash.HashIndex
-	view  *query.ReadView
-}
-
-func (g *windowGatedIndex) Get(hash [32]byte) (uint32, error) {
-	seq, err := g.inner.Get(hash)
-	if err != nil {
-		return 0, err
-	}
-	if seq < g.view.OldestLedger() || seq > g.view.LatestLedger() {
-		return 0, stores.ErrNotFound
-	}
-	return seq, nil
+	return probe, nil
 }
 
 // viewLedgerSource reads a candidate ledger through the read view, so the

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
@@ -172,7 +172,7 @@ func txHashRequest(ctx context.Context, f *queryFixture, corpus *txHashCorpus) q
 			}
 			defer view.Release()
 
-			_, err = reader.GetTransaction(adapters.WithView(ctx, view), xdr.Hash(hash))
+			_, err = reader.GetTransaction(query.WithView(ctx, view), xdr.Hash(hash))
 			found := err == nil
 			if errors.Is(err, store.ErrNoTransaction) {
 				err = nil

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
@@ -1,0 +1,380 @@
+package bench
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+
+	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/txhash"
+)
+
+// This file holds the four measured request bodies, one per query type. Each
+// one models a served endpoint: it takes its own read view, issues the read
+// through query.ReadView, and returns how many items came back. None of them
+// touches a store reader that ReadView did not hand over, so the p99-campaign
+// refactor of the readers moves these numbers without moving this code — except
+// for the cold tx-hash index open, which ReadView does not expose yet (see
+// coldTxIndexes).
+
+// Sub-stage labels for the tx-hash distribution. The blended total_c<W> row is
+// what the results converter reads; these two additionally split it, since a
+// hit and a miss are different amounts of work and a blended p99 hides which
+// one moved (see recordCell).
+const (
+	txHashStageFound = "found"
+	txHashStageMiss  = "miss"
+)
+
+// newQueryRequest builds one query type's measured request, sampling whatever
+// corpus it needs first. The corpus build reads the dataset and is deliberately
+// outside every timer; the returned closure is what the sweep measures.
+func newQueryRequest(
+	ctx context.Context, logger *supportlog.Entry, f *queryFixture, p queryPlan, qtype string,
+) (queryRequest, error) {
+	switch qtype {
+	case queryTypeLedgers:
+		return ledgersRequest(f, p), nil
+	case queryTypeTxPage:
+		return txPageRequest(f, p), nil
+	case queryTypeTxHash:
+		corpus, err := buildTxHashCorpus(logger, f, p.MissFraction, p.Seed)
+		if err != nil {
+			return nil, err
+		}
+		return txHashRequest(f, corpus), nil
+	case queryTypeEvents:
+		corpus, err := buildEventFilterCorpus(ctx, logger, f)
+		if err != nil {
+			return nil, err
+		}
+		return eventsRequest(ctx, f, p, corpus), nil
+	default:
+		// Unreachable: parseQueryTypes rejects anything else.
+		return nil, fmt.Errorf("unknown query type %q", qtype)
+	}
+}
+
+// ledgersRequest measures getLedgers' read: one range scan of --ledgers-span
+// ledgers from a random point in the fixture's range, through
+// ReadView.ScanLedgers.
+//
+// The span is a flag rather than two hard-coded shapes because a point read is
+// simply a span of one: mixing both into a single cell would blend two very
+// different distributions under one percentile. The default is the endpoint's
+// page cap, which is what a client actually asks for.
+func ledgersRequest(f *queryFixture, p queryPlan) queryRequest {
+	return func(rng *rand.Rand) (cellSample, error) {
+		lo := f.pickStart(rng, p.LedgersSpan)
+		hi := lo + p.LedgersSpan - 1
+		return timed("", func() (int, error) {
+			view, err := f.view()
+			if err != nil {
+				return 0, fmt.Errorf("acquire read view: %w", err)
+			}
+			defer view.Release()
+
+			scan, err := view.ScanLedgers(lo, hi)
+			if err != nil {
+				return 0, fmt.Errorf("scan ledgers [%d, %d]: %w", lo, hi, err)
+			}
+			read := 0
+			for entry, serr := range scan {
+				if serr != nil {
+					return 0, fmt.Errorf("scan ledgers [%d, %d]: %w", lo, hi, serr)
+				}
+				// Touch the borrowed bytes so the read is not optimized into a
+				// seek: a served request decodes them.
+				if len(entry.Bytes) == 0 {
+					return 0, fmt.Errorf("ledger %d decoded to zero bytes", entry.Seq)
+				}
+				read++
+			}
+			return read, nil
+		})
+	}
+}
+
+// txPageRequest measures getTransactions' read: walk --txpage-span ledgers and
+// materialize each one's transactions in apply order, stopping at
+// --txpage-limit transactions the way a page does.
+//
+// It materializes full transaction views rather than the cheaper hash-and-result
+// walk, because that is what the endpoint serves — envelopes included, which
+// costs a TxSet re-hash per transaction. Each ledger's transactions are counted
+// inside the loop body: ScanLedgers lends its ledger bytes only until the
+// iterator steps, and every byte field of a transaction view aliases them, so
+// carrying views out of the loop would need a copy the endpoint does not pay
+// here.
+func txPageRequest(f *queryFixture, p queryPlan) queryRequest {
+	return func(rng *rand.Rand) (cellSample, error) {
+		lo := f.pickStart(rng, p.TxPageSpan)
+		hi := lo + p.TxPageSpan - 1
+		return timed("", func() (int, error) {
+			view, err := f.view()
+			if err != nil {
+				return 0, fmt.Errorf("acquire read view: %w", err)
+			}
+			defer view.Release()
+
+			scan, err := view.ScanLedgers(lo, hi)
+			if err != nil {
+				return 0, fmt.Errorf("scan ledgers [%d, %d]: %w", lo, hi, err)
+			}
+			txs := 0
+			for entry, serr := range scan {
+				if serr != nil {
+					return 0, fmt.Errorf("scan ledgers [%d, %d]: %w", lo, hi, serr)
+				}
+				remaining := p.TxPageLimit - txs
+				if remaining <= 0 {
+					break
+				}
+				views, verr := sdkingest.LedgerTransactionViewRange(
+					xdr.LedgerCloseMetaView(entry.Bytes), 0, remaining, f.Passphrase)
+				if verr != nil {
+					return 0, fmt.Errorf("materialize transactions of ledger %d: %w", entry.Seq, verr)
+				}
+				txs += len(views)
+			}
+			return txs, nil
+		})
+	}
+}
+
+// txHashRequest measures getTransaction's read: the full by-hash lookup —
+// every hot index, then every frozen cold window index, each cold candidate
+// verified by reading its ledger and finding the transaction in it.
+//
+// It drives txhash.TxReader rather than probing an index directly. That
+// distinction is the whole point: an index probe answers "which ledger", while
+// the endpoint must also read that ledger and prove the transaction is in it,
+// and on the cold tier roughly one in 256 unseen hashes survives the
+// fingerprint and forces exactly that work for nothing.
+func txHashRequest(f *queryFixture, corpus *txHashCorpus) queryRequest {
+	return func(rng *rand.Rand) (cellSample, error) {
+		hash, wantFound := corpus.pick(rng)
+		stage := txHashStageFound
+		if !wantFound {
+			stage = txHashStageMiss
+		}
+		return timed(stage, func() (int, error) {
+			view, err := f.view()
+			if err != nil {
+				return 0, fmt.Errorf("acquire read view: %w", err)
+			}
+			defer view.Release()
+
+			probe, release, err := f.txReader(view)
+			if err != nil {
+				return 0, err
+			}
+			defer release()
+			_, found, err := probe.GetTransaction(hash)
+			if err != nil {
+				return 0, fmt.Errorf("look up transaction %x: %w", hash, err)
+			}
+			if found != wantFound {
+				return 0, fmt.Errorf("transaction %x: found=%t, expected %t", hash, found, wantFound)
+			}
+			if found {
+				return 1, nil
+			}
+			return 0, nil
+		})
+	}
+}
+
+// eventsRequest measures getEvents' read: one page of at most --events-limit
+// events over the fixture's ledger range, under a filter set drawn from the
+// corpus.
+//
+// One page, not a full drain: a page is what the endpoint serves, and a drain
+// would fold an unbounded number of them into one sample. A page can come back
+// empty and still be real work — the engine bounds each page's scan window, so a
+// filter matching nothing walks the window and returns nothing — which is why
+// the sample's item count can be zero without being an error.
+func eventsRequest(
+	ctx context.Context, f *queryFixture, p queryPlan, corpus *eventFilterCorpus,
+) queryRequest {
+	return func(rng *rand.Rand) (cellSample, error) {
+		filters := corpus.pick(rng)
+		hi := f.LastLedger
+		cursor := query.EventCursor{Scope: query.EventScope{
+			MinLedger: f.FirstLedger,
+			MaxLedger: &hi,
+			Dir:       query.Ascending,
+			Filters:   filters,
+		}}
+		return timed("", func() (int, error) {
+			view, err := f.view()
+			if err != nil {
+				return 0, fmt.Errorf("acquire read view: %w", err)
+			}
+			defer view.Release()
+
+			page, err := view.QueryEvents(ctx, cursor, p.EventsLimit)
+			if err != nil {
+				return 0, fmt.Errorf("query events over [%d, %d]: %w", f.FirstLedger, hi, err)
+			}
+			return len(page.Events), nil
+		})
+	}
+}
+
+// pickStart returns a random first ledger for a span-long read that stays
+// inside the fixture's servable range. A span wider than the range is clamped
+// to the range's start, so a small fixture still reads rather than erroring.
+func (f *queryFixture) pickStart(rng *rand.Rand, span uint32) uint32 {
+	room := f.LastLedger - f.FirstLedger + 1
+	if span >= room {
+		return f.FirstLedger
+	}
+	return f.FirstLedger + uint32(rng.IntN(int(room-span+1))) //nolint:gosec // room fits a chunk range
+}
+
+// txReader assembles the two-tier by-hash probe for one read view: the hot
+// indexes of every published chunk, then one reader per frozen cold window
+// index, with both tiers gated to the view's servable ledger range and the
+// candidate ledgers read back through the view. The returned release closes
+// whatever window indexes the probe actually opened; the caller MUST run it
+// when the request completes.
+//
+// The gate has to sit between the index and the ledger read. A frozen cold
+// index covers a thousand chunks, but each chunk's ledger file is deleted once
+// that chunk falls below the retention floor, so for most of its life the index
+// names transactions whose ledgers are gone. Ungated, those become read
+// failures; gated, they are what they should be — not found.
+func (f *queryFixture) txReader(view *query.ReadView) (*txhash.TxReader, func(), error) {
+	cold, release, err := f.coldTxIndexes(view)
+	if err != nil {
+		return nil, nil, err
+	}
+	probe, err := txhash.NewTxReader(
+		gateIndexes(view, view.HotTxHashIndexes()), cold,
+		&viewLedgerSource{view: view}, f.Passphrase)
+	if err != nil {
+		release()
+		return nil, nil, fmt.Errorf("assemble the by-hash probe: %w", err)
+	}
+	return probe, release, nil
+}
+
+// coldTxIndexes returns one gated, lazily opened reader per frozen window index
+// in the view's snapshot, newest coverage first, plus the release that closes
+// the ones a probe opened.
+//
+// Opening is deferred to the first probe because the common lookup resolves in
+// the hot tier and never reaches the cold one: opening every window index up
+// front would charge each hot hit for file opens a served request never makes.
+//
+// This composes what the read facade does not expose yet. The adapters branch
+// moves the same logic behind a query.ReadView method (ColdTxIndexes), where it
+// belongs — the layout and the view's closers are the view's own. Replace this
+// with that method once it lands, and the bench stops reaching for the layout.
+func (f *queryFixture) coldTxIndexes(view *query.ReadView) ([]txhash.HashIndex, func(), error) {
+	covs, err := view.ColdTxHashIndexCoverages()
+	if err != nil {
+		return nil, nil, fmt.Errorf("read the frozen tx-hash index coverages: %w", err)
+	}
+	idxs := make([]txhash.HashIndex, 0, len(covs))
+	lazies := make([]*lazyColdTxIndex, 0, len(covs))
+	for _, cov := range covs {
+		l := &lazyColdTxIndex{path: f.Layout.TxHashIndexFilePath(cov), cov: cov}
+		lazies = append(lazies, l)
+		idxs = append(idxs, gateIndex(view, l))
+	}
+	release := func() {
+		for _, l := range lazies {
+			if err := l.close(); err != nil {
+				f.Logger.WithError(err).Warn("bench-query: close cold tx-hash index")
+			}
+		}
+	}
+	return idxs, release, nil
+}
+
+// lazyColdTxIndex opens its window index on the first probe and keeps it for
+// the rest of the request. One request runs on one goroutine, as a read view
+// does, so it needs no locking.
+type lazyColdTxIndex struct {
+	path   string
+	cov    geometry.TxHashIndexCoverage
+	reader *txhash.ColdReader
+}
+
+func (l *lazyColdTxIndex) Get(hash [32]byte) (uint32, error) {
+	if l.reader == nil {
+		r, err := txhash.OpenColdReader(l.path)
+		if err != nil {
+			return 0, fmt.Errorf("open the cold tx-hash index [%s, %s]: %w", l.cov.Lo, l.cov.Hi, err)
+		}
+		l.reader = r
+	}
+	return l.reader.Get(hash)
+}
+
+// close releases the window index if a probe ever opened it.
+func (l *lazyColdTxIndex) close() error {
+	if l.reader == nil {
+		return nil
+	}
+	return l.reader.Close()
+}
+
+// gateIndexes wraps every index so a hit outside the view's servable ledger
+// range reads as a miss. See queryFixture.txReader for why.
+func gateIndexes(view *query.ReadView, idxs []txhash.HashIndex) []txhash.HashIndex {
+	gated := make([]txhash.HashIndex, 0, len(idxs))
+	for _, idx := range idxs {
+		gated = append(gated, gateIndex(view, idx))
+	}
+	return gated
+}
+
+func gateIndex(view *query.ReadView, idx txhash.HashIndex) txhash.HashIndex {
+	return &windowGatedIndex{inner: idx, view: view}
+}
+
+// windowGatedIndex drops a hit naming a ledger the view cannot serve.
+type windowGatedIndex struct {
+	inner txhash.HashIndex
+	view  *query.ReadView
+}
+
+func (g *windowGatedIndex) Get(hash [32]byte) (uint32, error) {
+	seq, err := g.inner.Get(hash)
+	if err != nil {
+		return 0, err
+	}
+	if seq < g.view.OldestLedger() || seq > g.view.LatestLedger() {
+		return 0, stores.ErrNotFound
+	}
+	return seq, nil
+}
+
+// viewLedgerSource reads a candidate ledger through the read view, so the
+// verification step routes to the same tier a served request would.
+type viewLedgerSource struct {
+	view *query.ReadView
+}
+
+func (s *viewLedgerSource) GetLedgerRaw(seq uint32) ([]byte, error) {
+	// A sub-genesis sequence would panic the chunk arithmetic. An index naming
+	// one is corrupt data, and it must fail the candidate, not the process.
+	if seq < chunk.FirstLedgerSeq {
+		return nil, stores.ErrNotFound
+	}
+	reader, err := s.view.Ledgers(chunk.IDFromLedger(seq))
+	if err != nil {
+		return nil, err
+	}
+	return reader.GetLedgerRaw(seq)
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
@@ -2,6 +2,7 @@ package bench
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 
@@ -9,10 +10,9 @@ import (
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/adapters"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/txhash"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/store"
 )
 
 // This file holds the four measured request bodies, one per query type. Each
@@ -42,11 +42,11 @@ func newQueryRequest(
 	case queryTypeTxPage:
 		return txPageRequest(f, p), nil
 	case queryTypeTxHash:
-		corpus, err := buildTxHashCorpus(logger, f, p.MissFraction, p.Seed)
+		corpus, err := buildTxHashCorpus(ctx, logger, f, p.MissFraction, p.Seed)
 		if err != nil {
 			return nil, err
 		}
-		return txHashRequest(f, corpus), nil
+		return txHashRequest(ctx, f, corpus), nil
 	case queryTypeEvents:
 		corpus, err := buildEventFilterCorpus(ctx, logger, f)
 		if err != nil {
@@ -146,16 +146,21 @@ func txPageRequest(f *queryFixture, p queryPlan) queryRequest {
 	}
 }
 
-// txHashRequest measures getTransaction's read: the full by-hash lookup —
-// every hot index, then every frozen cold window index, each cold candidate
-// verified by reading its ledger and finding the transaction in it.
+// txHashRequest measures getTransaction's read: the served by-hash path,
+// adapters.TransactionReader. It probes the view's hot tx-hash indexes, then
+// its cold window indexes, verifies each candidate by reading the candidate's
+// ledger, and copies the transaction's bytes out of that ledger buffer the way
+// the endpoint does.
 //
-// It drives txhash.TxReader rather than probing an index directly. That
-// distinction is the whole point: an index probe answers "which ledger", while
-// the endpoint must also read that ledger and prove the transaction is in it,
-// and on the cold tier roughly one in 256 unseen hashes survives the
-// fingerprint and forces exactly that work for nothing.
-func txHashRequest(f *queryFixture, corpus *txHashCorpus) queryRequest {
+// The view owns both index tiers, and the query package tests them. It hands
+// over each index already gated to the servable ledger range, so an index hit
+// below the retention floor reads as not-found instead of as a failed ledger
+// read, and it opens a cold index on that index's first probe, so a hot hit
+// pays no file open.
+//
+// The reader is stateless, so one serves every iteration of the cell.
+func txHashRequest(ctx context.Context, f *queryFixture, corpus *txHashCorpus) queryRequest {
+	reader := adapters.NewTransactionReader(f.Passphrase, nil)
 	return func(rng *rand.Rand) (cellSample, error) {
 		hash, wantFound := corpus.pick(rng)
 		stage := txHashStageFound
@@ -169,11 +174,11 @@ func txHashRequest(f *queryFixture, corpus *txHashCorpus) queryRequest {
 			}
 			defer view.Release()
 
-			probe, err := f.txReader(view)
-			if err != nil {
-				return 0, err
+			_, err = reader.GetTransaction(adapters.WithView(ctx, view), xdr.Hash(hash))
+			found := err == nil
+			if errors.Is(err, store.ErrNoTransaction) {
+				err = nil
 			}
-			_, found, err := probe.GetTransaction(hash)
 			if err != nil {
 				return 0, fmt.Errorf("look up transaction %x: %w", hash, err)
 			}
@@ -234,51 +239,4 @@ func (f *queryFixture) pickStart(rng *rand.Rand, span uint32) uint32 {
 		return f.FirstLedger
 	}
 	return f.FirstLedger + uint32(rng.IntN(int(room-span+1))) //nolint:gosec // room fits a chunk range
-}
-
-// txReader assembles the two-tier by-hash probe for one read view, the way the
-// serving adapter does: the hot indexes of every published chunk, then the
-// frozen cold window indexes on demand, with the candidate ledgers read back
-// through the view.
-//
-// The view owns both tiers. It hands over each index already gated to the
-// servable ledger range, and it opens a cold .idx only on that index's first
-// probe and closes it on Release. Both properties are load-bearing for these
-// numbers, so the bench states what it depends on:
-//
-//   - The gate sits between the index probe and the ledger read. A frozen cold
-//     index covers a thousand chunks, but each chunk's ledger file goes as soon
-//     as that chunk falls below the retention floor, so for most of its life the
-//     index names transactions whose ledgers are gone. Ungated, those reads
-//     fail; gated, they are the not-found they should be.
-//   - Cold indexes open lazily, and the probe asks for them only after every hot
-//     index missed. A hot hit therefore pays no file open — which is the whole
-//     shape of the hot/cold split this benchmark reports.
-func (f *queryFixture) txReader(view *query.ReadView) (*txhash.TxReader, error) {
-	probe, err := txhash.NewTxReader(
-		view.HotTxHashIndexes(), view.ColdTxIndexes,
-		&viewLedgerSource{view: view}, f.Passphrase)
-	if err != nil {
-		return nil, fmt.Errorf("assemble the by-hash probe: %w", err)
-	}
-	return probe, nil
-}
-
-// viewLedgerSource reads a candidate ledger through the read view, so the
-// verification step routes to the same tier a served request would.
-type viewLedgerSource struct {
-	view *query.ReadView
-}
-
-func (s *viewLedgerSource) GetLedgerRaw(seq uint32) ([]byte, error) {
-	// A sub-genesis sequence would panic the chunk arithmetic. An index naming
-	// one is corrupt data, and it must fail the candidate, not the process.
-	if seq < chunk.FirstLedgerSeq {
-		return nil, stores.ErrNotFound
-	}
-	reader, err := s.view.Ledgers(chunk.IDFromLedger(seq))
-	if err != nil {
-		return nil, err
-	}
-	return reader.GetLedgerRaw(seq)
 }

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
@@ -63,10 +63,10 @@ func newQueryRequest(
 // ledgers from a random point in the fixture's range, through
 // ReadView.ScanLedgers.
 //
-// The span is a flag rather than two hard-coded shapes because a point read is
-// simply a span of one: mixing both into a single leg would blend two very
-// different distributions under one percentile. The default is the endpoint's
-// page cap, which is what a client actually asks for.
+// The span is a flag because a point read is simply a span of one, and a leg
+// measures one shape at a time, so its percentiles describe a single
+// distribution. The default is the endpoint's page cap, which is what a client
+// actually asks for.
 func ledgersRequest(f *queryFixture, p queryPlan) queryRequest {
 	return func(rng *rand.Rand) (cellSample, error) {
 		lo := f.pickStart(rng, p.LedgersSpan)
@@ -103,13 +103,11 @@ func ledgersRequest(f *queryFixture, p queryPlan) queryRequest {
 // materialize each one's transactions in apply order, stopping at
 // --txpage-limit transactions the way a page does.
 //
-// It materializes full transaction views rather than the cheaper hash-and-result
-// walk, because that is what the endpoint serves — envelopes included, which
-// costs a TxSet re-hash per transaction. Each ledger's transactions are counted
-// inside the loop body: ScanLedgers lends its ledger bytes only until the
-// iterator steps, and every byte field of a transaction view aliases them, so
-// carrying views out of the loop would need a copy the endpoint does not pay
-// here.
+// It materializes the full transaction views the endpoint serves, envelopes
+// included, which costs a TxSet re-hash per transaction. Each ledger's
+// transactions are counted inside the loop body, because ScanLedgers lends its
+// ledger bytes only until the iterator steps and every byte field of a
+// transaction view aliases them.
 func txPageRequest(f *queryFixture, p queryPlan) queryRequest {
 	return func(rng *rand.Rand) (cellSample, error) {
 		lo := f.pickStart(rng, p.TxPageSpan)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/query_types.go
@@ -21,10 +21,10 @@ import (
 // touches a store reader that ReadView did not hand over, so the p99-campaign
 // refactor of the readers moves these numbers without moving this code.
 
-// Sub-stage labels for the tx-hash distribution. The blended total_c<W> row is
-// what the results converter reads; these two additionally split it, since a
+// Sub-stage labels for the tx-hash distribution. The blended total_r<rate> row
+// is what the results converter reads; these two additionally split it, since a
 // hit and a miss are different amounts of work and a blended p99 hides which
-// one moved (see recordCell).
+// one moved (see recordLeg).
 const (
 	txHashStageFound = "found"
 	txHashStageMiss  = "miss"
@@ -32,7 +32,7 @@ const (
 
 // newQueryRequest builds one query type's measured request, sampling whatever
 // corpus it needs first. The corpus build reads the dataset and is deliberately
-// outside every timer; the returned closure is what the sweep measures.
+// outside every timer; the returned closure is what a leg measures.
 func newQueryRequest(
 	ctx context.Context, logger *supportlog.Entry, f *queryFixture, p queryPlan, qtype string,
 ) (queryRequest, error) {
@@ -64,7 +64,7 @@ func newQueryRequest(
 // ReadView.ScanLedgers.
 //
 // The span is a flag rather than two hard-coded shapes because a point read is
-// simply a span of one: mixing both into a single cell would blend two very
+// simply a span of one: mixing both into a single leg would blend two very
 // different distributions under one percentile. The default is the endpoint's
 // page cap, which is what a client actually asks for.
 func ledgersRequest(f *queryFixture, p queryPlan) queryRequest {
@@ -158,7 +158,7 @@ func txPageRequest(f *queryFixture, p queryPlan) queryRequest {
 // read, and it opens a cold index on that index's first probe, so a hot hit
 // pays no file open.
 //
-// The reader is stateless, so one serves every iteration of the cell.
+// The reader is stateless, so one serves every request of a leg.
 func txHashRequest(ctx context.Context, f *queryFixture, corpus *txHashCorpus) queryRequest {
 	reader := adapters.NewTransactionReader(f.Passphrase, nil)
 	return func(rng *rand.Rand) (cellSample, error) {

--- a/cmd/stellar-rpc/internal/rpcv2/bench/scratch.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/scratch.go
@@ -13,15 +13,23 @@ import (
 
 const catalogBaseDirPerm os.FileMode = 0o755 // owner rwx, group/others rx
 
-// openScratchCatalog creates a fresh catalog in a temp dir under catalogBase
-// and returns a release func that closes it and removes that temp dir.
+// Temp-dir prefixes naming which bench owns a scratch catalog, so a leftover
+// dir says where it came from.
+const (
+	scratchPrefixIngest = "bench-ingest-catalog-"
+	scratchPrefixQuery  = "bench-query-catalog-"
+)
+
+// openScratchCatalog creates a fresh catalog in a temp dir named prefix* under
+// catalogBase and returns a release func that closes it and removes that temp
+// dir.
 func openScratchCatalog(
-	catalogBase string, layout geometry.Layout, logger *supportlog.Entry,
+	catalogBase, prefix string, layout geometry.Layout, logger *supportlog.Entry,
 ) (*catalog.Catalog, func(), error) {
 	if err := os.MkdirAll(catalogBase, catalogBaseDirPerm); err != nil {
 		return nil, nil, fmt.Errorf("create catalog base dir %s: %w", catalogBase, err)
 	}
-	dir, err := os.MkdirTemp(catalogBase, "bench-ingest-catalog-")
+	dir, err := os.MkdirTemp(catalogBase, prefix)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create scratch catalog dir: %w", err)
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/query/registry.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/registry.go
@@ -143,8 +143,9 @@ func OpenRegistry(
 
 // NewRegistry binds a bare Registry to the catalog and retention policy: an empty
 // handle map and latest ledger zero. The daemon uses OpenRegistry; this is the
-// seam for tests, which publish their own state (the bench publishes into a
-// closingSink, not a Registry).
+// seam for callers that publish their own state, such as tests and the bench's
+// cold query fixture, which serves frozen chunks and has no hot handle to
+// publish.
 func NewRegistry(cat *catalog.Catalog, retention geometry.Retention) *Registry {
 	r := &Registry{
 		catalog:     cat,

--- a/cmd/stellar-rpc/rpcv2/main.go
+++ b/cmd/stellar-rpc/rpcv2/main.go
@@ -43,6 +43,7 @@ func main() {
 
 	rootCmd.AddCommand(version.NewCommand())
 	rootCmd.AddCommand(bench.NewCommand())
+	rootCmd.AddCommand(bench.NewQueryCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "could not run: %v\n", err)


### PR DESCRIPTION
## Why

Full-history benchmark campaigns need a GitHub Actions entry point that launches and manages the complete campaign. This makes campaigns repeatable and operator-controlled without manual EC2 setup or result collection.

## What changed

- Add a manual workflow that validates campaign inputs and launches an EC2 benchmark runner.
- Generate the campaign configuration from workflow inputs.
- Relay S3 results across polling jobs until the campaign finishes or reaches its deadline.
- Preserve failed instances temporarily for SSM recovery.
- Add self-termination deadlines and a scheduled reaper for abandoned instances.
- Reject stale results from earlier workflow attempts.

## Testing

- Added relay tests for deadline handling and environment validation.
- Validated campaign input and failure paths during development.