### PR TITLE
Key cold-index routing (events + txhash) against adversarial block-overflow

### DIFF
--- a/cmd/stellar-rpc/internal/rpcv2/backfill/execute.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/execute.go
@@ -82,7 +82,8 @@ func (cfg ExecConfig) validate() error {
 	return nil
 }
 
-// processConfig projects the shared Catalog/Logger into the ProcessConfig.
+// processConfig projects the shared Catalog/Logger into the ProcessConfig. The
+// cold-index secret is sourced from the Catalog at point of use.
 func (cfg ExecConfig) processConfig() ProcessConfig {
 	p := cfg.Process
 	p.Catalog = cfg.Catalog

--- a/cmd/stellar-rpc/internal/rpcv2/backfill/perf_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/perf_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stellar/streamhash"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/txhash"
 )
 
@@ -80,12 +81,14 @@ func TestStreamingRebuild_ByteIdenticalToColdPath(t *testing.T) {
 	streamingIdx := cat.Layout().TxHashIndexFilePath(frozen)
 
 	// (2) The merged cold path, over the SAME .bin inputs, with the SAME
-	// MinLedger/MaxLedger anchor the streaming path derives (lo.FirstLedger,
-	// hi.LastLedger — build.go step 3).
+	// MinLedger/MaxLedger anchor (lo.FirstLedger, hi.LastLedger, window 0 —
+	// build.go step 3). Both paths adopt the same secret from the .bin
+	// headers, so the bytes must still match.
 	minLedger := chunk.ID(0).FirstLedger()
 	maxLedger := chunk.ID(2).LastLedger()
 	directIdx := filepath.Join(t.TempDir(), "direct.idx")
-	require.NoError(t, txhash.BuildColdIndex(context.Background(), inputs, directIdx, minLedger, maxLedger))
+	require.NoError(t, txhash.BuildColdIndex(
+		context.Background(), inputs, directIdx, minLedger, maxLedger))
 
 	streamingBytes, err := os.ReadFile(streamingIdx)
 	require.NoError(t, err)
@@ -102,9 +105,10 @@ func TestStreamingRebuild_ByteIdenticalToColdPath(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestStreamingBin_MatchesSpecFormat asserts the .bin a frozen chunk leaves on
-// disk matches gettransaction §6.1: a uint64-LE entry-count header followed by
-// 20-byte [16-byte key | 4-byte LE seq] entries. freezeChunkBin uses the real
-// txhash.WriteColdBin, so this is the producer's actual on-disk contract.
+// disk matches gettransaction §6.1: a uint64-LE entry-count header, then the
+// 16-byte index secret the keys were blinded with, then 20-byte [16-byte key |
+// 4-byte LE seq] entries. freezeChunkBin uses the real txhash.WriteColdBin, so
+// this is the producer's actual on-disk contract.
 func TestStreamingBin_MatchesSpecFormat(t *testing.T) {
 	cat, _ := smallTxHashIndexCatalog(t, 4)
 
@@ -115,9 +119,12 @@ func TestStreamingBin_MatchesSpecFormat(t *testing.T) {
 	raw, err := os.ReadFile(cat.Layout().TxHashBinPath(0))
 	require.NoError(t, err)
 
-	// §6.1: 8-byte header + N * 20-byte entries.
+	// §6.1: 24-byte header (8-byte uint64-LE count + 16-byte index secret) +
+	// N * 20-byte entries.
 	const (
-		hdrSize   = 8
+		countW    = 8                // uint64-LE entry count
+		secretW   = stores.SecretLen // index secret the keys were blinded with
+		hdrSize   = countW + secretW
 		keyW      = 16 // streamhash.MinKeySize
 		seqW      = 4
 		entryW    = keyW + seqW // 20 bytes exactly
@@ -127,16 +134,16 @@ func TestStreamingBin_MatchesSpecFormat(t *testing.T) {
 	require.Equal(t, streamhash.MinKeySize, keyW, "16-byte key == streamhash routing-key width")
 	require.Len(t, raw, hdrSize+wantCount*entryW, "header + 20-byte entries")
 
-	count := binary.LittleEndian.Uint64(raw[:hdrSize])
+	count := binary.LittleEndian.Uint64(raw[:countW])
 	require.Equal(t, uint64(wantCount), count, "uint64-LE entry-count header")
 
-	// Each entry: 16-byte truncated key, then a uint32-LE absolute seq. Entries
-	// are written sorted lex by key, so locate each by its known key prefix.
+	// Each entry: the 16-byte secret-keyed routing key (keyed at ingest — never
+	// the raw hash prefix), then a uint32-LE absolute seq. Entries are written
+	// sorted lex by keyed key, so locate each by its expected keyed key.
+	secret := chunkSecret(cat, 0)
 	wantSeqByKey := map[[keyW]byte]uint32{}
 	for _, e := range []txEntry{e0, e1} {
-		var k [keyW]byte
-		copy(k[:], e.hash[:keyW])
-		wantSeqByKey[k] = e.seq
+		wantSeqByKey[stores.BlindKey(secret, e.hash[:keyW])] = e.seq
 	}
 	for i := range wantCount {
 		off := hdrSize + i*entryW
@@ -181,8 +188,10 @@ func TestStreamingIdx_MatchesSpecFormat(t *testing.T) {
 	require.Equal(t, txhash.ColdFingerprintSize, idx.Stats().FingerprintSize, "1-byte fingerprint on disk")
 	require.Equal(t, uint64(2), idx.NumKeys(), "one key per indexed transaction")
 
-	gotMin, gotMax, err := txhash.ParseLedgerRange(idx.UserMetadata())
+	gotMin, gotMax, gotSecret, err := txhash.ParseColdMetadata(idx.UserMetadata())
 	require.NoError(t, err)
+	require.Equal(t, chunkSecret(cat, 0), gotSecret,
+		"metadata carries the derived per-index routing secret")
 	require.Equal(t, chunk.ID(0).FirstLedger(), gotMin, "MinLedger anchor = lo.FirstLedger")
 	require.Equal(t, chunk.ID(1).LastLedger(), gotMax, "MaxLedger = hi.LastLedger")
 

--- a/cmd/stellar-rpc/internal/rpcv2/backfill/process.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/process.go
@@ -17,8 +17,10 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/durable"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/ingest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/ledger"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/txhash"
 )
 
 // ErrBackendCoverageTimeout is returned when the bulk backend's tip never reaches the chunk in time.
@@ -56,12 +58,27 @@ func (cfg ProcessConfig) validate() error {
 
 // ingestConfigFor maps an artifact set to ingest.Config. It lives here, not on
 // catalog.ArtifactSet, so catalog needn't import ingest (the #824 split invariant).
-func ingestConfigFor(s catalog.ArtifactSet) ingest.Config {
-	return ingest.Config{
+// For a txhash or events request it resolves the chunk's per-index secret from the
+// catalog (the same one the index build derives), so ingest keys stay consistent.
+func ingestConfigFor(s catalog.ArtifactSet, chunkID chunk.ID, cfg ProcessConfig) ingest.Config {
+	c := ingest.Config{
 		Ledgers: s.Has(geometry.KindLedgers),
 		Txhash:  s.Has(geometry.KindTxHash),
 		Events:  s.Has(geometry.KindEvents),
 	}
+	if c.Txhash || c.Events {
+		catalogSecret := cfg.Catalog.Secret()
+		if c.Txhash {
+			indexID := uint32(cfg.Catalog.TxHashIndexLayout().TxHashIndexID(chunkID))
+			sec := txhash.ColdIndexSecret(catalogSecret[:], indexID)
+			c.TxhashSecret = sec[:]
+		}
+		if c.Events {
+			sec := event.ColdIndexSecret(catalogSecret[:], chunkID)
+			c.EventsSecret = sec[:]
+		}
+	}
+	return c
 }
 
 // processChunk materializes the requested cold artifacts for ONE chunk via the
@@ -115,8 +132,9 @@ func processChunk(ctx context.Context, chunkID chunk.ID, artifacts catalog.Artif
 		EventsDir:  layout.EventsBucketDir(chunkID),
 	}
 	raw := src.RawLedgers(ctx, ledgerbackend.BoundedRange(chunkID.FirstLedger(), chunkID.LastLedger()))
+	ic := ingestConfigFor(artifacts, chunkID, cfg)
 	if rerr := ingest.WriteColdChunk(
-		ctx, cfg.Logger, chunkID, raw, dirs, cfg.Sink, ingestConfigFor(artifacts),
+		ctx, cfg.Logger, chunkID, raw, dirs, cfg.Sink, ic,
 	); rerr != nil {
 		return fmt.Errorf("cold ingest chunk %s %s: %w", chunkID, artifacts, rerr)
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/backfill/txindex_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/txindex_test.go
@@ -26,6 +26,14 @@ func testBuildConfig(cat *catalog.Catalog) BuildConfig {
 	return BuildConfig{Catalog: cat, Logger: silentLogger()}
 }
 
+// chunkSecret is the routing secret chunkID's .bin entries are keyed with —
+// the same derivation (over the catalog's minted secret) ingest and the index
+// build use.
+func chunkSecret(cat *catalog.Catalog, chunkID chunk.ID) [stores.SecretLen]byte {
+	master := cat.Secret()
+	return txhash.ColdIndexSecret(master[:], uint32(cat.TxHashIndexLayout().TxHashIndexID(chunkID)))
+}
+
 // txEntry is a (full 32-byte tx hash, ledger seq) pair a test wants resolvable
 // through the cold index.
 type txEntry struct {
@@ -48,15 +56,14 @@ func hashAt(tag uint64) [32]byte {
 func freezeChunkBin(t *testing.T, cat *catalog.Catalog, chunkID chunk.ID, entries []txEntry) {
 	t.Helper()
 
+	secret := chunkSecret(cat, chunkID)
 	cold := make([]txhash.ColdEntry, len(entries))
 	for i, e := range entries {
 		require.GreaterOrEqual(t, e.seq, chunkID.FirstLedger(), "seq in chunk range")
 		require.LessOrEqual(t, e.seq, chunkID.LastLedger(), "seq in chunk range")
-		var key [txhash.ColdKeySize]byte
-		copy(key[:], e.hash[:txhash.ColdKeySize])
-		cold[i] = txhash.ColdEntry{Key: key, Seq: e.seq}
+		cold[i] = txhash.ColdEntry{Key: stores.BlindKey(secret, e.hash[:txhash.ColdKeySize]), Seq: e.seq}
 	}
-	// WriteColdBin writes entries verbatim; they must be sorted lex by key.
+	// WriteColdBin writes entries verbatim; they must be sorted lex by (keyed) key.
 	sort.Slice(cold, func(i, j int) bool {
 		return string(cold[i].Key[:]) < string(cold[j].Key[:])
 	})
@@ -64,7 +71,7 @@ func freezeChunkBin(t *testing.T, cat *catalog.Catalog, chunkID chunk.ID, entrie
 	path := cat.Layout().TxHashBinPath(chunkID)
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	require.NoError(t, cat.MarkChunkFreezing(chunkID, geometry.KindTxHash))
-	require.NoError(t, txhash.WriteColdBin(path, cold))
+	require.NoError(t, txhash.WriteColdBin(path, secret, cold))
 	require.NoError(t, durable.BarrierNewFile(path))
 	require.NoError(t, cat.FlipChunkFrozen(chunkID, geometry.KindTxHash))
 }

--- a/cmd/stellar-rpc/internal/rpcv2/catalog/catalog.go
+++ b/cmd/stellar-rpc/internal/rpcv2/catalog/catalog.go
@@ -31,6 +31,7 @@ type Catalog struct {
 	logger      *supportlog.Entry
 	layout      geometry.Layout
 	txhashIndex geometry.TxHashIndexLayout
+	secret      [32]byte // cold-index secret, minted once at Open then read-only
 }
 
 // Open opens the catalog's backing KV store at path (created if absent) and
@@ -44,7 +45,17 @@ func Open(
 	if err != nil {
 		return nil, err
 	}
-	return &Catalog{store: store, logger: logger, layout: layout, txhashIndex: txhashIndex}, nil
+	c := &Catalog{store: store, logger: logger, layout: layout, txhashIndex: txhashIndex}
+	// Mint-or-load the cold-index secret up front (get-or-create is not atomic;
+	// here it runs single-threaded) and cache it, so post-Open Secret() reads are
+	// lock-free and cannot fail.
+	secret, err := c.ensureSecret()
+	if err != nil {
+		_ = c.Close()
+		return nil, fmt.Errorf("catalog: ensure cold-index secret: %w", err)
+	}
+	c.secret = secret
+	return c, nil
 }
 
 // Close releases the backing store. Idempotent.

--- a/cmd/stellar-rpc/internal/rpcv2/catalog/kv_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/catalog/kv_test.go
@@ -214,6 +214,9 @@ func TestKV_PrefixScanEmptyPrefixWalksWholeStore(t *testing.T) {
 	var seen []string
 	for e, err := range c.prefixScan("") {
 		require.NoError(t, err)
+		if e.Key == catalogSecretStoreKey {
+			continue // minted by Open, not part of this test's data
+		}
 		seen = append(seen, e.Key+"="+e.Value)
 	}
 	assert.Equal(t, []string{"a=1", "b=2", "c=3"}, seen)

--- a/cmd/stellar-rpc/internal/rpcv2/catalog/secret.go
+++ b/cmd/stellar-rpc/internal/rpcv2/catalog/secret.go
@@ -1,0 +1,42 @@
+package catalog
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// catalogSecretStoreKey holds the deployment's cold-index secret.
+const catalogSecretStoreKey = "meta/catalog-secret"
+
+// Secret returns a copy of the deployment's cold-index secret, minted once at
+// Open and cached. Per-index secrets are derived from it, so an attacker who
+// influences indexed keys cannot predict which block a key lands in. Returning
+// a fixed-size array (not the internal slice) states the length and prevents a
+// caller aliasing or mutating the cached value. Stable for the life of the
+// catalog.
+func (c *Catalog) Secret() [32]byte { return c.secret }
+
+// ensureSecret loads the persisted cold-index secret, minting and persisting a
+// fresh random one on first call. Open runs it single-threaded and caches the
+// result; nothing else should call it (get-or-create is not atomic).
+func (c *Catalog) ensureSecret() ([32]byte, error) {
+	var s [32]byte
+	v, found, err := c.get(catalogSecretStoreKey)
+	if err != nil {
+		return s, err
+	}
+	if found {
+		if len(v) != len(s) {
+			return s, fmt.Errorf("persisted cold-index secret is %d bytes, want %d", len(v), len(s))
+		}
+		copy(s[:], v)
+		return s, nil
+	}
+	if _, err := rand.Read(s[:]); err != nil {
+		return s, err
+	}
+	if err := c.put(catalogSecretStoreKey, string(s[:])); err != nil {
+		return s, err
+	}
+	return s, nil
+}

--- a/cmd/stellar-rpc/internal/rpcv2/catalog/secret_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/catalog/secret_test.go
@@ -1,0 +1,44 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSecret_MintedOnceAndStable pins Secret()'s persistence contract: Open
+// mints a non-zero secret on first open, and reopening the same catalog returns
+// the identical bytes. A silent remint would make previously keyed txhash .bin
+// files incompatible with later index builds, so this is a load-bearing
+// invariant, not a nicety.
+func TestSecret_MintedOnceAndStable(t *testing.T) {
+	path := t.TempDir()
+
+	cat, err := openKVAt(t, path)
+	require.NoError(t, err)
+	first := cat.Secret()
+	require.NotEqual(t, [32]byte{}, first, "Open must mint a non-zero secret")
+	require.NoError(t, cat.Close())
+
+	reopened, err := openKVAt(t, path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close() })
+	require.Equal(t, first, reopened.Secret(), "reopening the same catalog returns the identical secret")
+}
+
+// TestSecret_RejectsCorruptedPersisted pins that a wrong-length persisted
+// secret fails Open loudly instead of silently reminting: a truncated write or
+// downgraded encoding must not swap in a fresh secret, which would orphan every
+// txhash .bin already keyed under the old one.
+func TestSecret_RejectsCorruptedPersisted(t *testing.T) {
+	path := t.TempDir()
+
+	cat, err := openKVAt(t, path)
+	require.NoError(t, err)
+	require.NoError(t, cat.put(catalogSecretStoreKey, "short"))
+	require.NoError(t, cat.Close())
+
+	_, err = openKVAt(t, path)
+	require.Error(t, err, "a corrupted persisted secret must fail Open, not remint")
+	require.ErrorContains(t, err, "persisted cold-index secret is 5 bytes")
+}

--- a/cmd/stellar-rpc/internal/rpcv2/ingest/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/ingest/config.go
@@ -1,6 +1,11 @@
 package ingest
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
+)
 
 // Config selects which data types the ingest drivers write. At least one of
 // Ledgers/Txhash/Events must be enabled.
@@ -11,12 +16,50 @@ type Config struct {
 	Ledgers bool
 	Txhash  bool
 	Events  bool
+
+	// TxhashSecret is the resolved per-index secret that blinds the txhash .bin
+	// keys — the caller derives it (txhash.ColdIndexSecret) so ingest keys match
+	// the index build. Required when Txhash is set — no unkeyed fallback.
+	TxhashSecret []byte
+
+	// EventsSecret is the resolved per-chunk secret that keys the events cold
+	// index's routing — the caller derives it (event.ColdIndexSecret) so the
+	// build is deterministic. Required when Events is set — no unkeyed fallback.
+	EventsSecret []byte
 }
 
-// validate rejects a Config with no enabled data types.
+// validate rejects a Config with no enabled data types, or a txhash/events
+// config missing its cold-index secret.
 func (c Config) validate() error {
 	if !c.Ledgers && !c.Txhash && !c.Events {
 		return errors.New("ingest: Config enables no data types (set at least one of Ledgers/Txhash/Events)")
 	}
+	if c.Txhash && len(c.TxhashSecret) != stores.SecretLen {
+		return fmt.Errorf("ingest: Txhash enabled but TxhashSecret is %d bytes, want %d (per-index secret required)",
+			len(c.TxhashSecret), stores.SecretLen)
+	}
+	if c.Events && len(c.EventsSecret) != stores.SecretLen {
+		return fmt.Errorf("ingest: Events enabled but EventsSecret is %d bytes, want %d (per-index secret required)",
+			len(c.EventsSecret), stores.SecretLen)
+	}
+	// An all-zero secret is the right length but disables blinding: an attacker
+	// can reproduce every blinded key and route them into one block. Reject it
+	// so a caller that forgot to derive a secret fails loudly, not silently.
+	if c.Txhash && isZeroSecret(c.TxhashSecret) {
+		return errors.New("ingest: TxhashSecret is all zero (blinding disabled — derive a per-index secret)")
+	}
+	if c.Events && isZeroSecret(c.EventsSecret) {
+		return errors.New("ingest: EventsSecret is all zero (blinding disabled — derive a per-index secret)")
+	}
 	return nil
+}
+
+// isZeroSecret reports whether b is all zero.
+func isZeroSecret(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/stellar-rpc/internal/rpcv2/ingest/events.go
+++ b/cmd/stellar-rpc/internal/rpcv2/ingest/events.go
@@ -10,6 +10,7 @@ import (
 	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
 )
 
@@ -26,7 +27,10 @@ type eventsCold struct {
 	mirror    event.Bitmaps
 	offsets   *event.LedgerOffsets
 	bucketDir string
-	metrics   coldMetrics
+	// secret is the chunk's deterministic routing secret (event.ColdIndexSecret),
+	// handed to WriteColdIndex at finalize.
+	secret  [stores.SecretLen]byte
+	metrics coldMetrics
 	// failed latches any write error. A failed write can leave the mirror
 	// and the pack ahead of offsets (offsets is the per-ledger commit point,
 	// appended last), so a subsequent finalize would commit an index whose
@@ -41,7 +45,9 @@ type eventsCold struct {
 // Layout's single derivation. The writer opts into the batch tuning
 // (coldEncoderConcurrency/coldBytesPerSync): WriteColdChunk, the sole
 // production caller, is always a batch freeze/backfill.
-func newEventsCold(bucketDir string, chunkID chunk.ID, sink MetricSink) (*eventsCold, error) {
+func newEventsCold(
+	bucketDir string, chunkID chunk.ID, sink MetricSink, secret [stores.SecretLen]byte,
+) (*eventsCold, error) {
 	if err := os.MkdirAll(bucketDir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", bucketDir, err)
 	}
@@ -58,6 +64,7 @@ func newEventsCold(bucketDir string, chunkID chunk.ID, sink MetricSink) (*events
 		mirror:    event.NewBitmaps(),
 		offsets:   event.NewLedgerOffsets(chunkID.FirstLedger()),
 		bucketDir: bucketDir,
+		secret:    secret,
 		metrics:   newColdMetrics(sink, dataTypeEvents),
 	}, nil
 }
@@ -96,7 +103,7 @@ func (e *eventsCold) finalize(ctx context.Context) error {
 		e.metrics.emit(time.Since(start), err)
 		return err
 	}
-	if err := event.WriteColdIndex(ctx, e.chunkID, e.mirror, e.bucketDir); err != nil {
+	if err := event.WriteColdIndex(ctx, e.chunkID, e.mirror, e.bucketDir, e.secret); err != nil {
 		// Finish already committed events.pack; the index-less pack is left
 		// in place — without the orchestrator's completion record it is
 		// inert scratch (see the package doc's artifact model), and the

--- a/cmd/stellar-rpc/internal/rpcv2/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/ingest/ingest_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/feewindow"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rpcv2test"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/ledger"
@@ -36,6 +37,23 @@ import (
 // testPassphrase is a network passphrase literal used only by the test fixtures
 // (transaction-hash derivation); the package itself never hardcodes one.
 const testPassphrase = "Public Global Stellar Network ; September 2015"
+
+// testTxhashKey is the fixed routing master key the txhash fixtures use;
+// index 0 matches the tests' fixed chunk 0.
+var testTxhashKey = bytes.Repeat([]byte{0xA7}, 32)
+
+// testTxhashSecret is the routing secret the ingested .bin keys are keyed with.
+func testTxhashSecret() [stores.SecretLen]byte { return txhash.ColdIndexSecret(testTxhashKey, 0) }
+
+// testTxhashSecretBytes is testTxhashSecret as a slice, for ingest.Config.TxhashSecret.
+func testTxhashSecretBytes() []byte { s := testTxhashSecret(); return s[:] }
+
+// testEventsSecret is the routing secret the events cold index builds use;
+// chunk 0 matches the tests' fixed chunk 0.
+func testEventsSecret() [stores.SecretLen]byte { return event.ColdIndexSecret(testTxhashKey, 0) }
+
+// testEventsSecretBytes is testEventsSecret as a slice, for ingest.Config.EventsSecret.
+func testEventsSecretBytes() []byte { s := testEventsSecret(); return s[:] }
 
 // ───────────────────────── test metric sink ─────────────────────────
 
@@ -500,7 +518,7 @@ func TestTxhashColdWriter_Bin(t *testing.T) {
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := newTxhashCold(txhashBinPath(coldDir), chunkID, nil)
+	ing, err := newTxhashCold(txhashBinPath(coldDir), chunkID, nil, testTxhashSecret())
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ing.close()) }()
 
@@ -522,7 +540,7 @@ func TestEventsColdWriter_Readback(t *testing.T) {
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
+	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil, testEventsSecret())
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ing.close()) }()
 
@@ -559,7 +577,7 @@ func TestEventsColdWriter_V0KeepsOffsetsContiguous(t *testing.T) {
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
+	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil, testEventsSecret())
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ing.close()) }()
 
@@ -620,7 +638,7 @@ func TestWriteColdChunk_EventlessChunk_FullyReadable(t *testing.T) {
 	// Every ledger in the chunk is a V0 (pre-Soroban) ledger → zero events.
 	require.NoError(t, WriteColdChunk(
 		context.Background(), logger, chunkID, rawChunk(fullStream(t, chunkID, marshalV0LCM), chunkID),
-		coldDirsAt(coldDir, chunkID), sink, Config{Events: true},
+		coldDirsAt(coldDir, chunkID), sink, Config{Events: true, EventsSecret: testEventsSecretBytes()},
 	))
 
 	bucketDir := filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID())
@@ -665,7 +683,11 @@ func TestColdChunk_Success(t *testing.T) {
 	sink := &testSink{}
 
 	cc, err := openColdChunk(
-		coldDirsAt(coldDir, chunkID), chunkID, sink, Config{Ledgers: true, Txhash: true, Events: true})
+		coldDirsAt(coldDir, chunkID), chunkID, sink,
+		Config{
+			Ledgers: true, Txhash: true, Events: true,
+			TxhashSecret: testTxhashSecretBytes(), EventsSecret: testEventsSecretBytes(),
+		})
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cc.close()) }()
 
@@ -753,7 +775,8 @@ func TestColdChunk_MidChunkFailure_NoArtifact(t *testing.T) {
 	coldDir := t.TempDir()
 	sink := &testSink{}
 
-	cc, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink, Config{Ledgers: true, Events: true})
+	cc, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink,
+		Config{Ledgers: true, Events: true, EventsSecret: testEventsSecretBytes()})
 	require.NoError(t, err)
 
 	require.NoError(t, cc.ingest(first, viewOf(t, first)))
@@ -933,31 +956,35 @@ func TestWriteColdChunk_ByteIdentity_SharedWalk(t *testing.T) {
 	}
 	require.NoError(t, WriteColdChunk(
 		context.Background(), testLogger(), chunkID, rawChunk(fullStream(t, chunkID, gen), chunkID),
-		coldDirsAt(coldDir, chunkID), nil, Config{Ledgers: true, Txhash: true, Events: true},
+		coldDirsAt(coldDir, chunkID), nil,
+		Config{
+			Ledgers: true, Txhash: true, Events: true,
+			TxhashSecret: testTxhashSecretBytes(), EventsSecret: testEventsSecretBytes(),
+		},
 	))
 
-	// Reference #1 — txhash: sorted, truncated entries for every resolvable
+	// Reference #1 — txhash: sorted, keyed entries for every resolvable
 	// hash (outer, plus a fee-bump's inner) over the sentinels.
 	var wantEntries []txhash.ColdEntry
 	for _, seq := range sentinels {
 		txParts, err := sdkingest.ExtractLedgerTxParts(xdr.LedgerCloseMetaView(raws[seq]))
 		require.NoError(t, err)
 		for i := range txParts {
-			var ke txhash.ColdEntry
-			copy(ke.Key[:], txParts[i].Hash[:txhash.ColdKeySize])
-			ke.Seq = seq
-			wantEntries = append(wantEntries, ke)
+			wantEntries = append(wantEntries, txhash.ColdEntry{
+				Key: stores.BlindKey(testTxhashSecret(), txParts[i].Hash[:txhash.ColdKeySize]),
+				Seq: seq,
+			})
 			if txParts[i].FeeBump {
-				var ike txhash.ColdEntry
-				copy(ike.Key[:], txParts[i].InnerHash[:txhash.ColdKeySize])
-				ike.Seq = seq
-				wantEntries = append(wantEntries, ike)
+				wantEntries = append(wantEntries, txhash.ColdEntry{
+					Key: stores.BlindKey(testTxhashSecret(), txParts[i].InnerHash[:txhash.ColdKeySize]),
+					Seq: seq,
+				})
 			}
 		}
 	}
 	slices.SortFunc(wantEntries, func(a, b txhash.ColdEntry) int { return bytes.Compare(a.Key[:], b.Key[:]) })
 	gotEntries := rpcv2test.ReadColdBin(t, txhashBinPath(filepath.Join(coldDir, dataTypeTxhash)))
-	require.Equal(t, wantEntries, gotEntries, "cold .bin must hold every resolvable hash, sorted and truncated")
+	require.Equal(t, wantEntries, gotEntries, "cold .bin must hold every resolvable hash, sorted and keyed")
 
 	// Reference #2 — events: PayloadsFromLedgerEvents with chunk-relative IDs
 	// assigned in ingest (ascending-seq) order, mapped to their term keys.
@@ -1044,7 +1071,7 @@ func TestWriteColdChunk_TxhashCold_Bin(t *testing.T) {
 
 	require.NoError(t, WriteColdChunk(
 		context.Background(), logger, chunkID, rawChunk(fullStream(t, chunkID, gen), chunkID),
-		coldDirsAt(coldDir, chunkID), nil, Config{Txhash: true},
+		coldDirsAt(coldDir, chunkID), nil, Config{Txhash: true, TxhashSecret: testTxhashSecretBytes()},
 	))
 
 	entries := rpcv2test.ReadColdBin(t, txhashBinPath(filepath.Join(coldDir, dataTypeTxhash)))
@@ -1072,7 +1099,7 @@ func TestWriteColdChunk_EventsCold_Readback(t *testing.T) {
 
 	require.NoError(t, WriteColdChunk(
 		context.Background(), logger, chunkID, rawChunk(fullStream(t, chunkID, gen), chunkID),
-		coldDirsAt(coldDir, chunkID), nil, Config{Events: true},
+		coldDirsAt(coldDir, chunkID), nil, Config{Events: true, EventsSecret: testEventsSecretBytes()},
 	))
 
 	bucketDir := filepath.Join(coldDir, "events", chunkID.BucketID())
@@ -1337,16 +1364,16 @@ func TestHotService_FailedPhaseCarriesPartialDuration(t *testing.T) {
 
 // TestTxhashColdWriter_BinContent ingests two tx-bearing ledgers, finalizes,
 // then reads the .bin back through the store codec and asserts the contract
-// the deferred streamhash builder relies on: each key == the fixture tx hash
-// truncated to txhash.ColdKeySize (pinned to streamhash.MinKeySize by the
-// codec), each seq == the ledger it was ingested in, and entries are in
-// non-decreasing key order.
+// the deferred streamhash builder relies on: each key == the secret-keyed
+// routing key of the fixture tx hash truncated to txhash.ColdKeySize (keyed
+// at ingest — never the raw hash prefix), each seq == the ledger it was
+// ingested in, and entries are in non-decreasing (keyed) key order.
 func TestTxhashColdWriter_BinContent(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := newTxhashCold(txhashBinPath(coldDir), chunkID, nil)
+	ing, err := newTxhashCold(txhashBinPath(coldDir), chunkID, nil, testTxhashSecret())
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ing.close()) }()
 
@@ -1354,9 +1381,7 @@ func TestTxhashColdWriter_BinContent(t *testing.T) {
 	wantSeqByKey := map[[txhash.ColdKeySize]byte]uint32{}
 	for _, seq := range []uint32{first, first + 1} {
 		raw, hash, _ := marshalLCMWithEvent(t, seq)
-		var key [txhash.ColdKeySize]byte
-		copy(key[:], hash[:txhash.ColdKeySize])
-		wantSeqByKey[key] = seq
+		wantSeqByKey[stores.BlindKey(testTxhashSecret(), hash[:txhash.ColdKeySize])] = seq
 		txParts, _ := extractFor(t, raw)
 		require.NoError(t, ing.write(seq, txParts))
 	}
@@ -1368,7 +1393,7 @@ func TestTxhashColdWriter_BinContent(t *testing.T) {
 	var prevKey [txhash.ColdKeySize]byte
 	for i, e := range entries {
 		wantSeq, known := wantSeqByKey[e.Key]
-		require.True(t, known, "entry %d key %x is not one of the ingested fixture hashes", i, e.Key)
+		require.True(t, known, "entry %d key %x is not a keyed fixture hash", i, e.Key)
 		require.Equal(t, wantSeq, e.Seq, "entry %d seq must equal the ledger it was ingested in", i)
 
 		if i > 0 {
@@ -1447,7 +1472,8 @@ func TestOpenColdChunk_RollbackOneBuilt(t *testing.T) {
 	// bucket-dir MkdirAll.
 	require.NoError(t, os.WriteFile(filepath.Join(coldDir, dataTypeTxhash), []byte("not a dir"), 0o644))
 
-	_, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink, Config{Ledgers: true, Txhash: true})
+	_, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink,
+		Config{Ledgers: true, Txhash: true, TxhashSecret: testTxhashSecretBytes()})
 	require.Error(t, err, "the txhash open must fail on the planted file")
 
 	// The ledger writer was opened then rolled back with no write/finalize, so
@@ -1471,7 +1497,10 @@ func TestOpenColdChunk_RollbackTwoBuilt(t *testing.T) {
 	require.NoError(t, os.MkdirAll(packPath, 0o755))
 
 	_, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink,
-		Config{Ledgers: true, Txhash: true, Events: true})
+		Config{
+			Ledgers: true, Txhash: true, Events: true,
+			TxhashSecret: testTxhashSecretBytes(), EventsSecret: testEventsSecretBytes(),
+		})
 	require.Error(t, err, "the events open must fail on the planted directory")
 
 	// Both the ledger and txhash writers were opened then rolled back with no
@@ -1515,7 +1544,7 @@ func TestEventsCold_FinishThenIndexFails_LeavesInertPack(t *testing.T) {
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
+	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil, testEventsSecret())
 	require.NoError(t, err)
 
 	// Ingest one event-bearing ledger so the mirror is non-empty, exercising a
@@ -1553,7 +1582,7 @@ func TestEventsCold_FinalizeAfterFailedIngest_Refuses(t *testing.T) {
 	chunkID := chunk.ID(0)
 	coldDir := t.TempDir()
 
-	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
+	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil, testEventsSecret())
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ing.close()) }()
 
@@ -1587,7 +1616,10 @@ func TestColdChunk_Finalize_FirstErrorStopsRemaining(t *testing.T) {
 	sink := &testSink{}
 
 	cc, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink,
-		Config{Ledgers: true, Txhash: true, Events: true})
+		Config{
+			Ledgers: true, Txhash: true, Events: true,
+			TxhashSecret: testTxhashSecretBytes(), EventsSecret: testEventsSecretBytes(),
+		})
 	require.NoError(t, err)
 
 	raw, _, _ := marshalLCMWithEvent(t, first)
@@ -1774,7 +1806,7 @@ func TestTxhashColdWriter_FeeBumpBothHashes(t *testing.T) {
 	seq := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := newTxhashCold(txhashBinPath(coldDir), chunkID, nil)
+	ing, err := newTxhashCold(txhashBinPath(coldDir), chunkID, nil, testTxhashSecret())
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ing.close()) }()
 
@@ -1792,6 +1824,8 @@ func TestTxhashColdWriter_FeeBumpBothHashes(t *testing.T) {
 		require.Equal(t, seq, entries[i].Seq)
 		keys = append(keys, entries[i].Key[:])
 	}
-	assert.Contains(t, keys, outerHash[:txhash.ColdKeySize])
-	assert.Contains(t, keys, innerHash[:txhash.ColdKeySize])
+	outerKey := stores.BlindKey(testTxhashSecret(), outerHash[:txhash.ColdKeySize])
+	innerKey := stores.BlindKey(testTxhashSecret(), innerHash[:txhash.ColdKeySize])
+	assert.Contains(t, keys, outerKey[:])
+	assert.Contains(t, keys, innerKey[:])
 }

--- a/cmd/stellar-rpc/internal/rpcv2/ingest/ingester.go
+++ b/cmd/stellar-rpc/internal/rpcv2/ingest/ingester.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
 
 // coldChunk is one chunk's set of cold writers — one concrete field per data
@@ -59,7 +60,12 @@ func openColdChunk(dirs ColdDirs, chunkID chunk.ID, sink MetricSink, cfg Config)
 		if dirs.TxhashBin == "" {
 			return fail(errors.New("ingest: txhash enabled but its ColdDirs path is empty"))
 		}
-		w, err := newTxhashCold(dirs.TxhashBin, chunkID, sink)
+		if len(cfg.TxhashSecret) != stores.SecretLen {
+			return fail(errors.New("ingest: txhash cold writer requires a per-index secret"))
+		}
+		var secret [stores.SecretLen]byte
+		copy(secret[:], cfg.TxhashSecret)
+		w, err := newTxhashCold(dirs.TxhashBin, chunkID, sink, secret)
 		if err != nil {
 			return fail(fmt.Errorf("open txhash cold writer: %w", err))
 		}
@@ -69,7 +75,12 @@ func openColdChunk(dirs ColdDirs, chunkID chunk.ID, sink MetricSink, cfg Config)
 		if dirs.EventsDir == "" {
 			return fail(errors.New("ingest: events enabled but its ColdDirs path is empty"))
 		}
-		w, err := newEventsCold(dirs.EventsDir, chunkID, sink)
+		if len(cfg.EventsSecret) != stores.SecretLen {
+			return fail(errors.New("ingest: events cold writer requires a per-index secret"))
+		}
+		var secret [stores.SecretLen]byte
+		copy(secret[:], cfg.EventsSecret)
+		w, err := newEventsCold(dirs.EventsDir, chunkID, sink, secret)
 		if err != nil {
 			return fail(fmt.Errorf("open events cold writer: %w", err))
 		}

--- a/cmd/stellar-rpc/internal/rpcv2/ingest/txhash.go
+++ b/cmd/stellar-rpc/internal/rpcv2/ingest/txhash.go
@@ -12,21 +12,25 @@ import (
 	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/txhash"
 )
 
 // ───────────────────────── Cold writer ─────────────────────────
 
-// txhashCold accumulates (txhash[:ColdKeySize], seq) tuples per ledger; at
-// finalize time it lex-sorts by the truncated key and writes a per-chunk
-// sorted .bin file under <out-root>/<bucketID:05d>/<chunkID:08d>.bin (the
-// documented raw-txhash layout). The .bin codec — including the matching
+// txhashCold accumulates (routing key, seq) tuples per ledger — each stored
+// key is stores.BlindKey(secret, txhash[:ColdKeySize]), keyed at ingest so
+// the deferred SortedBuilder index build consumes an already-keyed, sorted
+// .bin unchanged. At finalize time it lex-sorts by the (keyed) key and writes
+// a per-chunk sorted .bin file under <out-root>/<bucketID:05d>/<chunkID:08d>.bin
+// (the documented cold-txhash layout). The .bin codec — including the matching
 // reader the index-build step uses — lives in pkg/stores/txhash
 // (txhash.WriteColdBin and friends). A separate index-build step (not in
 // this package) turns these .bin files into the queryable cold MPHF index.
 type txhashCold struct {
 	binPath string
 	chunkID chunk.ID
+	secret  [stores.SecretLen]byte
 	entries []txhash.ColdEntry
 	metrics coldMetrics
 }
@@ -35,43 +39,49 @@ type txhashCold struct {
 // sorted .bin at binPath — the caller's geometry.Layout.TxHashBinPath(chunkID),
 // so the write path is Layout's single derivation — written at finalize
 // (overwriting any prior attempt's file — see the package doc's artifact model).
-func newTxhashCold(binPath string, chunkID chunk.ID, sink MetricSink) (*txhashCold, error) {
+// secret is the chunk's per-index secret — the same one the index build derives
+// (txhash.ColdIndexSecret) — that the stored keys are blinded with.
+func newTxhashCold(
+	binPath string, chunkID chunk.ID, sink MetricSink, secret [stores.SecretLen]byte,
+) (*txhashCold, error) {
 	if err := os.MkdirAll(filepath.Dir(binPath), 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(binPath), err)
 	}
 	// The initial cap (64Ki entries, ~1.3 MB) deliberately starts well below a
 	// typical pubnet chunk's tx count (~3M): empty/sparse chunks stay cheap,
 	// and a busy chunk just pays a few amortized growths.
-	return &txhashCold{
+	t := &txhashCold{
 		binPath: binPath,
 		chunkID: chunkID,
 		entries: make([]txhash.ColdEntry, 0, 1<<16),
 		metrics: newColdMetrics(sink, dataTypeTxhash),
-	}, nil
+	}
+	t.secret = secret
+	return t, nil
 }
 
 // write accumulates one ledger's tx hashes — one entry per hash, two for a
 // fee-bump (outer + inner). They come from coldChunk's shared
-// ExtractLedgerTxParts walk, in apply order. Each is truncated to ColdKeySize
-// and appended STRAIGHT into the
+// ExtractLedgerTxParts walk, in apply order. Each is keyed
+// (BlindKey(secret, hash[:ColdKeySize])) and appended STRAIGHT into the
 // accumulator — no intermediate per-ledger entry slice; over a ~3M-tx chunk
 // that intermediate would be hundreds of MB of transient garbage. The
 // extraction itself is metered once, ledger-scoped, as the ColdExtract signal;
-// this cheap truncate-append folds into the per-writer ColdIngest total (its
+// this cheap key-append folds into the per-writer ColdIngest total (its
 // per-chunk cost is the finalize sort + .bin write).
 func (t *txhashCold) write(seq uint32, txParts []sdkingest.LedgerTxParts) error {
 	start := time.Now()
 	before := len(t.entries)
 	for i := range txParts {
-		var ke txhash.ColdEntry
-		copy(ke.Key[:], txParts[i].Hash[:txhash.ColdKeySize])
-		ke.Seq = seq
-		t.entries = append(t.entries, ke)
+		t.entries = append(t.entries, txhash.ColdEntry{
+			Key: stores.BlindKey(t.secret, txParts[i].Hash[:txhash.ColdKeySize]),
+			Seq: seq,
+		})
 		if txParts[i].FeeBump {
-			var ike txhash.ColdEntry
-			copy(ike.Key[:], txParts[i].InnerHash[:txhash.ColdKeySize])
-			ike.Seq = seq
-			t.entries = append(t.entries, ike)
+			t.entries = append(t.entries, txhash.ColdEntry{
+				Key: stores.BlindKey(t.secret, txParts[i].InnerHash[:txhash.ColdKeySize]),
+				Seq: seq,
+			})
 		}
 	}
 	t.metrics.observe(time.Since(start), len(t.entries)-before, nil)
@@ -88,7 +98,7 @@ func (t *txhashCold) finalize(_ context.Context) error {
 	slices.SortFunc(t.entries, func(a, b txhash.ColdEntry) int {
 		return bytes.Compare(a.Key[:], b.Key[:])
 	})
-	err := txhash.WriteColdBin(t.binPath, t.entries)
+	err := txhash.WriteColdBin(t.binPath, t.secret, t.entries)
 	if err == nil {
 		t.metrics.sink.IngestStage(dataTypeTxhash, stageFinalize, time.Since(start), len(t.entries))
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/rpcv2test/rpcv2test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/rpcv2test/rpcv2test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/catalog"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/ledger"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/txhash"
@@ -213,16 +214,18 @@ func WriteColdTxIndexFile(
 	t *testing.T, cat *catalog.Catalog, cov geometry.TxHashIndexCoverage, entries map[xdr.Hash]uint32,
 ) {
 	t.Helper()
+	master := cat.Secret()
+	secret := txhash.ColdIndexSecret(master[:], uint32(cov.Index))
 	cold := make([]txhash.ColdEntry, 0, len(entries))
 	for h, seq := range entries {
 		var e txhash.ColdEntry
-		copy(e.Key[:], h[:txhash.ColdKeySize])
+		e.Key = stores.BlindKey(secret, h[:txhash.ColdKeySize])
 		e.Seq = seq
 		cold = append(cold, e)
 	}
 	slices.SortFunc(cold, func(a, b txhash.ColdEntry) int { return bytes.Compare(a.Key[:], b.Key[:]) })
 	bin := filepath.Join(t.TempDir(), txhash.ColdBinName(cov.Lo))
-	require.NoError(t, txhash.WriteColdBin(bin, cold))
+	require.NoError(t, txhash.WriteColdBin(bin, secret, cold))
 
 	idxPath := cat.Layout().TxHashIndexFilePath(cov)
 	require.NoError(t, os.MkdirAll(filepath.Dir(idxPath), 0o755))
@@ -330,13 +333,13 @@ func ReadColdBin(t *testing.T, path string) []txhash.ColdEntry {
 	require.NoError(t, err)
 	defer f.Close()
 
-	const headerSize = 8
+	const headerSize = 8 + stores.SecretLen // uint64-LE count + index secret
 	entrySize := txhash.ColdKeySize + 4
 
 	var header [headerSize]byte
 	_, err = io.ReadFull(f, header[:])
 	require.NoError(t, err)
-	count := binary.LittleEndian.Uint64(header[:])
+	count := binary.LittleEndian.Uint64(header[:8])
 
 	info, err := f.Stat()
 	require.NoError(t, err)

--- a/cmd/stellar-rpc/internal/rpcv2/stores/blind.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/blind.go
@@ -1,0 +1,50 @@
+package stores
+
+// Keyed block routing of cold streamhash indexes.
+//
+// streamhash's block routing is public and unkeyed, so an attacker could
+// grind keys into one block and abort the build (ErrBlockOverflow).
+// Feeding BlindKey(secret, key) at both build and query makes block
+// placement unpredictable without the per-index secret.
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"io"
+
+	"github.com/dchest/siphash"
+	"golang.org/x/crypto/hkdf"
+)
+
+// SecretLen is the byte length of a routing secret (a SipHash key).
+const SecretLen = 16
+
+// DeriveIndexSecret derives one index's secret from the deployment's catalog
+// secret: HKDF-SHA256(catalogSecret, info = domain ‖ indexID big-endian).
+// Deterministic, so the same secret is derivable at ingest, build, and query
+// time and rebuilds stay byte-identical.
+func DeriveIndexSecret(catalogSecret []byte, domain string, indexID uint32) [SecretLen]byte {
+	if len(catalogSecret) == 0 {
+		panic("stores: DeriveIndexSecret requires a non-empty catalog secret")
+	}
+	info := binary.BigEndian.AppendUint32([]byte(domain), indexID)
+	var s [SecretLen]byte
+	if _, err := io.ReadFull(hkdf.New(sha256.New, catalogSecret, nil, info), s[:]); err != nil {
+		panic(err) // unreachable: SecretLen is far below HKDF-SHA256's output limit
+	}
+	return s
+}
+
+// BlindKey returns SipHash-2-4-128(secret, key), secret split and output
+// packed little-endian (the SipHash reference byte layout).
+func BlindKey(secret [SecretLen]byte, key []byte) [SecretLen]byte {
+	r0, r1 := siphash.Hash128(
+		binary.LittleEndian.Uint64(secret[0:8]),
+		binary.LittleEndian.Uint64(secret[8:16]),
+		key,
+	)
+	var out [SecretLen]byte
+	binary.LittleEndian.PutUint64(out[0:8], r0)
+	binary.LittleEndian.PutUint64(out[8:16], r1)
+	return out
+}

--- a/cmd/stellar-rpc/internal/rpcv2/stores/blind_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/blind_test.go
@@ -1,0 +1,81 @@
+package stores
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// refSecret is the SipHash reference test key: bytes 00..0f.
+func refSecret() [SecretLen]byte {
+	var s [SecretLen]byte
+	for i := range s {
+		s[i] = byte(i)
+	}
+	return s
+}
+
+// TestBlindKey_KnownAnswer pins BlindKey to the SipHash-2-4 128-bit
+// reference vectors — any change to primitive, key split, or output
+// packing breaks every existing keyed index.
+func TestBlindKey_KnownAnswer(t *testing.T) {
+	msg := make([]byte, 16)
+	for i := range msg {
+		msg[i] = byte(i)
+	}
+	for _, tc := range []struct {
+		msgLen  int
+		wantHex string
+	}{
+		{8, "3b62a9ba6258f5610f83e264f31497b4"},
+		{16, "6ee2a4ca67b054bbfd3315bf85230577"},
+	} {
+		got := BlindKey(refSecret(), msg[:tc.msgLen])
+		assert.Equal(t, tc.wantHex, hex.EncodeToString(got[:]), "msg len %d", tc.msgLen)
+	}
+}
+
+func TestBlindKey_Deterministic(t *testing.T) {
+	secret := refSecret()
+	key := []byte("0123456789abcdef")
+
+	first := BlindKey(secret, key)
+	for range 5 {
+		assert.Equal(t, first, BlindKey(secret, key))
+	}
+
+	other := refSecret()
+	other[0] ^= 0xff
+	assert.NotEqual(t, first, BlindKey(other, key))
+	assert.NotEqual(t, first, BlindKey(secret, []byte("0123456789abcdeg")))
+}
+
+// TestDeriveIndexSecret_KnownAnswer pins DeriveIndexSecret to fixed
+// HKDF-SHA256(catalogSecret, nil, domain‖indexID(BE)) vectors — any change to the
+// KDF, info layout, or output length breaks every existing keyed index.
+func TestDeriveIndexSecret_KnownAnswer(t *testing.T) {
+	catalogSecret := bytes.Repeat([]byte{0x0b}, 32)
+	for _, tc := range []struct {
+		indexID uint32
+		wantHex string
+	}{
+		{0, "16a4530128a224e453bdc45e21190366"},
+		{1, "7e84f0acec98ee0c91262f4dbcbc84f1"},
+	} {
+		got := DeriveIndexSecret(catalogSecret, "txhash", tc.indexID)
+		assert.Equal(t, tc.wantHex, hex.EncodeToString(got[:]), "index %d", tc.indexID)
+	}
+}
+
+func TestDeriveIndexSecret_DeterministicAndDomainSeparated(t *testing.T) {
+	catalogSecret := bytes.Repeat([]byte{0x42}, 32)
+
+	first := DeriveIndexSecret(catalogSecret, "txhash", 3)
+	assert.Equal(t, first, DeriveIndexSecret(catalogSecret, "txhash", 3), "same inputs, same secret")
+
+	assert.NotEqual(t, first, DeriveIndexSecret(catalogSecret, "txhash", 4), "index ID separates")
+	assert.NotEqual(t, first, DeriveIndexSecret(catalogSecret, "events", 3), "domain separates")
+	assert.NotEqual(t, first, DeriveIndexSecret(bytes.Repeat([]byte{0x43}, 32), "txhash", 3), "master key separates")
+}

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_format.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_format.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/packfile"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/zstd"
 )
 
@@ -224,9 +225,47 @@ func DecodeLedgerOffsets(data []byte) (*LedgerOffsets, error) {
 // supplied key — they take the first 16 bytes as the routing
 // identity. TermKey is already a uniformly distributed 16-byte
 // xxh3-128 value (produced by ComputeTermKey via
-// streamhash.PreHashInPlace), so the wrapper passes TermKey[:]
-// through. No double-hashing.
+// streamhash.PreHashInPlace), but xxh3 is unkeyed, so an attacker
+// could grind terms into one streamhash block and abort the build
+// (see stores/blind.go). The wrapper therefore feeds
+// streamhash stores.BlindKey(secret, TermKey) at both build and
+// query, with the deterministic per-chunk secret (ColdIndexSecret)
+// stored in index.hash's user metadata. The 4-byte app fingerprint in index.pack and the
+// downstream post-filter stay on the ORIGINAL TermKey bytes.
 // ──────────────────────────────────────────────────────────────────
+
+// index.hash user-metadata wire format (streamhash WithMetadata):
+//
+//	offset  size  field
+//	0       1     version (0x01)
+//	1       16    routing secret (SipHash-2-4-128 key)
+const (
+	eventsMetaVersion byte = 0x01
+	eventsMetaLen          = 1 + stores.SecretLen
+)
+
+// errBadIndexMetadata is returned when index.hash carries user
+// metadata this binary cannot parse.
+var errBadIndexMetadata = errors.New("malformed index.hash metadata")
+
+func encodeEventsMeta(secret [stores.SecretLen]byte) []byte {
+	buf := make([]byte, eventsMetaLen)
+	buf[0] = eventsMetaVersion
+	copy(buf[1:], secret[:])
+	return buf
+}
+
+func decodeEventsMeta(data []byte) ([stores.SecretLen]byte, error) {
+	var secret [stores.SecretLen]byte
+	if len(data) != eventsMetaLen {
+		return secret, fmt.Errorf("%w: %d bytes, want %d", errBadIndexMetadata, len(data), eventsMetaLen)
+	}
+	if data[0] != eventsMetaVersion {
+		return secret, fmt.Errorf("%w: unknown version 0x%02x", errBadIndexMetadata, data[0])
+	}
+	copy(secret[:], data[1:])
+	return secret, nil
+}
 
 // ErrKeyNotFound is returned by Lookup when streamhash decides the
 // supplied key was not in the build set. Vanilla MPHF semantics
@@ -242,7 +281,8 @@ var ErrKeyNotFound = errors.New("events: key not in build set")
 // mphf wraps a streamhash MPHF index, suitable for repeated Lookup
 // against term keys.
 type mphf struct {
-	idx *streamhash.Index
+	idx    *streamhash.Index
+	secret [stores.SecretLen]byte
 }
 
 // buildMPHF constructs an MPHF over every TermKey in bitmaps,
@@ -266,8 +306,15 @@ type mphf struct {
 // ctx between keys so cancellation surfaces promptly on large
 // inputs.
 //
+// secret is the chunk's deterministic routing secret (ColdIndexSecret),
+// stored in metadata so readers route identically. Because it is fixed
+// per chunk, an ErrBlockOverflow is non-retryable: a rebuild routes the
+// same keys to the same blocks.
+//
 //nolint:nonamedreturns // named err carries through to the deferred builder.Close
-func buildMPHF(ctx context.Context, bitmaps Bitmaps, outputPath string) (m *mphf, err error) {
+func buildMPHF(
+	ctx context.Context, bitmaps Bitmaps, outputPath string, secret [stores.SecretLen]byte,
+) (m *mphf, err error) {
 	total := len(bitmaps)
 
 	tmpDir, terr := os.MkdirTemp("", "eventstore-unsorted-")
@@ -276,7 +323,8 @@ func buildMPHF(ctx context.Context, bitmaps Bitmaps, outputPath string) (m *mphf
 	}
 	defer os.RemoveAll(tmpDir)
 
-	builder, builderErr := streamhash.NewUnsortedBuilder(ctx, outputPath, uint64(total), tmpDir)
+	builder, builderErr := streamhash.NewUnsortedBuilder(ctx, outputPath, uint64(total), tmpDir,
+		streamhash.WithMetadata(encodeEventsMeta(secret)))
 	if builderErr != nil {
 		return nil, fmt.Errorf("events: create streamhash builder: %w", builderErr)
 	}
@@ -295,7 +343,8 @@ func buildMPHF(ctx context.Context, bitmaps Bitmaps, outputPath string) (m *mphf
 		if err = ctx.Err(); err != nil {
 			return nil, fmt.Errorf("events: build MPHF canceled after %d keys: %w", i, err)
 		}
-		if err = builder.AddKey(key[:], 0); err != nil {
+		rk := stores.BlindKey(secret, key[:])
+		if err = builder.AddKey(rk[:], 0); err != nil {
 			return nil, fmt.Errorf("events: add key %d: %w", i, err)
 		}
 		i++
@@ -330,7 +379,12 @@ func openMPHF(path string) (*mphf, error) {
 	if err != nil {
 		return nil, fmt.Errorf("events: parse %s: %w", path, err)
 	}
-	return &mphf{idx: idx}, nil
+	secret, merr := decodeEventsMeta(idx.UserMetadata())
+	if merr != nil {
+		_ = idx.Close()
+		return nil, fmt.Errorf("events: parse %s: %w", path, merr)
+	}
+	return &mphf{idx: idx, secret: secret}, nil
 }
 
 // Lookup returns the dense slot in [0, N) that key maps to.
@@ -343,7 +397,8 @@ func openMPHF(path string) (*mphf, error) {
 // index.pack — an MPHF can map an unseen key to a valid build-set
 // slot, and only the fingerprint catches that residual collision.
 func (m *mphf) Lookup(key TermKey) (uint32, error) {
-	slot, err := m.idx.QueryRank(key[:])
+	rk := stores.BlindKey(m.secret, key[:])
+	slot, err := m.idx.QueryRank(rk[:])
 	if err != nil {
 		if errors.Is(err, streamhash.ErrNotFound) {
 			return 0, ErrKeyNotFound

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_format_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_format_test.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/streamhash"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
 
 // ──────────────────────────────────────────────────────────────────
@@ -95,6 +100,13 @@ func TestLedgerOffsets_EncodeNil(t *testing.T) {
 // MPHF wrapper tests.
 // ──────────────────────────────────────────────────────────────────
 
+// testIndexSecret is the fixed routing secret every index build in this test
+// package uses (production derives one per chunk via ColdIndexSecret).
+var testIndexSecret = [stores.SecretLen]byte{
+	0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7,
+	0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf,
+}
+
 // keyFor returns the TermKey ComputeTermKey produces for the i'th
 // test value — useful for verifying Lookup against the same value
 // the test loaded into the Bitmaps.
@@ -125,7 +137,7 @@ func buildIndex(t *testing.T, n int) Bitmaps {
 
 func TestBuild_KnownKeysGetUniqueSlotsInRange(t *testing.T) {
 	const n = 128
-	m, err := buildMPHF(context.Background(), buildIndex(t, n), filepath.Join(t.TempDir(), "index.hash"))
+	m, err := buildMPHF(context.Background(), buildIndex(t, n), filepath.Join(t.TempDir(), "index.hash"), testIndexSecret)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -145,7 +157,7 @@ func TestBuild_KnownKeysGetUniqueSlotsInRange(t *testing.T) {
 
 func TestBuild_LookupIsDeterministic(t *testing.T) {
 	const n = 16
-	m, err := buildMPHF(context.Background(), buildIndex(t, n), filepath.Join(t.TempDir(), "index.hash"))
+	m, err := buildMPHF(context.Background(), buildIndex(t, n), filepath.Join(t.TempDir(), "index.hash"), testIndexSecret)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -168,17 +180,18 @@ func TestLookup_UnseenKeyBehavior(t *testing.T) {
 	// 4-byte fingerprint in index.pack to catch downstream. Pin both
 	// possibilities so cold-reader code (PR-3a) knows what to handle.
 	const n = 64
-	m, err := buildMPHF(context.Background(), buildIndex(t, n), filepath.Join(t.TempDir(), "index.hash"))
+	m, err := buildMPHF(context.Background(), buildIndex(t, n), filepath.Join(t.TempDir(), "index.hash"), testIndexSecret)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = m.Close() })
 
 	// Try a batch of unseen keys; record outcomes. Both outcomes are
-	// valid per the MPHF contract.
+	// valid per the MPHF contract. 2000 probes keep P(zero collisions)
+	// negligible.
 	var (
 		fastNoMatch  int
 		collidedSlot int
 	)
-	for i := range 200 {
+	for i := range 2000 {
 		unseen := ComputeTermKey(
 			fmt.Appendf(nil, "never-added-%d", i),
 			FieldTopic0,
@@ -205,7 +218,7 @@ func TestLookup_UnseenKeyBehavior(t *testing.T) {
 func TestBuild_EmptyIndexSucceeds(t *testing.T) {
 	// Zero terms builds a valid empty index rather than erroring.
 	empty := NewBitmaps()
-	m, err := buildMPHF(context.Background(), empty, filepath.Join(t.TempDir(), "index.hash"))
+	m, err := buildMPHF(context.Background(), empty, filepath.Join(t.TempDir(), "index.hash"), testIndexSecret)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = m.Close() })
 	assert.True(t, m.isEmpty())
@@ -217,7 +230,7 @@ func TestOpen_RoundTripsBuiltFile(t *testing.T) {
 	const n = 32
 	path := filepath.Join(t.TempDir(), "index.hash")
 
-	built, err := buildMPHF(context.Background(), buildIndex(t, n), path)
+	built, err := buildMPHF(context.Background(), buildIndex(t, n), path, testIndexSecret)
 	require.NoError(t, err)
 
 	// Record every (key, slot) the Build handle reports, then close
@@ -251,7 +264,7 @@ func TestBuild_AcceptsManyKeys(t *testing.T) {
 	// holding 10K terms, Build never materializes the keys as a
 	// slice.
 	const n = 10_000
-	m, err := buildMPHF(context.Background(), buildIndex(t, n), filepath.Join(t.TempDir(), "index.hash"))
+	m, err := buildMPHF(context.Background(), buildIndex(t, n), filepath.Join(t.TempDir(), "index.hash"), testIndexSecret)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -271,9 +284,116 @@ func TestOpen_NonExistentFileErrors(t *testing.T) {
 }
 
 func TestClose_IsIdempotent(t *testing.T) {
-	m, err := buildMPHF(context.Background(), buildIndex(t, 4), filepath.Join(t.TempDir(), "index.hash"))
+	m, err := buildMPHF(context.Background(), buildIndex(t, 4), filepath.Join(t.TempDir(), "index.hash"), testIndexSecret)
 	require.NoError(t, err)
 
 	require.NoError(t, m.Close())
 	assert.NoError(t, m.Close(), "second Close must be a no-op")
+}
+
+// Keyed-routing metadata tests.
+
+func TestEventsMeta_EncodeDecodeRoundTrip(t *testing.T) {
+	secret := testIndexSecret
+
+	blob := encodeEventsMeta(secret)
+	require.Len(t, blob, eventsMetaLen)
+	assert.Equal(t, eventsMetaVersion, blob[0])
+
+	decoded, err := decodeEventsMeta(blob)
+	require.NoError(t, err)
+	assert.Equal(t, secret, decoded)
+}
+
+func TestEventsMeta_DecodeRejectsBadInput(t *testing.T) {
+	good := encodeEventsMeta(testIndexSecret)
+
+	_, err := decodeEventsMeta(good[:len(good)-1])
+	assert.ErrorIs(t, err, errBadIndexMetadata, "short blob")
+
+	_, err = decodeEventsMeta(append(good, 0x00))
+	assert.ErrorIs(t, err, errBadIndexMetadata, "long blob")
+
+	bad := append([]byte(nil), good...)
+	bad[0] = 0x7f
+	_, err = decodeEventsMeta(bad)
+	assert.ErrorIs(t, err, errBadIndexMetadata, "unknown version")
+}
+
+func TestBuild_WritesKeyedRoutingMetadata(t *testing.T) {
+	// A fresh build must carry v1 metadata and route every term key
+	// through stores.BlindKey under the stored secret.
+	const n = 64
+	path := filepath.Join(t.TempDir(), "index.hash")
+	m, err := buildMPHF(context.Background(), buildIndex(t, n), path, testIndexSecret)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = m.Close() })
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	raw, err := streamhash.OpenBytes(data)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = raw.Close() })
+
+	meta := raw.UserMetadata()
+	require.Len(t, meta, eventsMetaLen, "index.hash must carry [version][secret] metadata")
+	assert.Equal(t, eventsMetaVersion, meta[0])
+	secret, err := decodeEventsMeta(meta)
+	require.NoError(t, err)
+	assert.Equal(t, testIndexSecret, secret, "stored secret must be the one the build was given")
+
+	for i := range n {
+		k := keyFor(i)
+		rk := stores.BlindKey(secret, k[:])
+		want, err := raw.QueryRank(rk[:])
+		require.NoError(t, err, "routed key %d must be in the build set", i)
+		got, err := m.Lookup(k)
+		require.NoError(t, err)
+		assert.Equal(t, uint32(want), got, "Lookup must equal QueryRank over the routed key")
+	}
+}
+
+func TestBuild_DeterministicForFixedSecret(t *testing.T) {
+	// Same inputs + same secret ⇒ byte-identical index.hash, so rebuilds
+	// are reproducible (streamhash's build is insertion-order-independent,
+	// covering the Bitmaps map-iteration randomness).
+	const n = 512
+	idx := buildIndex(t, n)
+
+	build := func() []byte {
+		path := filepath.Join(t.TempDir(), "index.hash")
+		m, err := buildMPHF(context.Background(), idx, path, testIndexSecret)
+		require.NoError(t, err)
+		require.NoError(t, m.Close())
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		return data
+	}
+
+	first := build()
+	second := build()
+	assert.Equal(t, first, second, "rebuild with the same secret must be byte-identical")
+}
+
+func TestOpenMPHF_RejectsMissingOrMalformedMetadata(t *testing.T) {
+	// Every index is keyed: openMPHF must refuse an index.hash whose
+	// metadata is absent or unparseable.
+	build := func(t *testing.T, opts ...streamhash.BuildOption) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "index.hash")
+		builder, err := streamhash.NewUnsortedBuilder(context.Background(), path, 4, t.TempDir(), opts...)
+		require.NoError(t, err)
+		for i := range 4 {
+			k := keyFor(i)
+			require.NoError(t, builder.AddKey(k[:], 0))
+		}
+		require.NoError(t, builder.Finish())
+		return path
+	}
+
+	_, err := openMPHF(build(t))
+	assert.ErrorIs(t, err, errBadIndexMetadata, "no metadata")
+
+	_, err = openMPHF(build(t, streamhash.WithMetadata([]byte{0x7f, 0x00})))
+	assert.ErrorIs(t, err, errBadIndexMetadata, "malformed metadata")
 }

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_index.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_index.go
@@ -22,7 +22,19 @@ import (
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/packfile"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
+
+// coldRoutingDomain is the DeriveIndexSecret domain for events cold indexes
+// (distinct from txhash's "txhash").
+const coldRoutingDomain = "events"
+
+// ColdIndexSecret derives chunkID's routing secret from the build-side master
+// key. The single derivation both ingest and the index build use, so rebuilds
+// stay byte-identical.
+func ColdIndexSecret(catalogSecret []byte, chunkID chunk.ID) [stores.SecretLen]byte {
+	return stores.DeriveIndexSecret(catalogSecret, coldRoutingDomain, uint32(chunkID))
+}
 
 // WriteColdIndex produces index.pack + index.hash for chunkID inside
 // bucketDir. Both files are fsync'd before the function returns.
@@ -82,7 +94,13 @@ import (
 // ctx cancels the MPHF build phase (the expensive part for large
 // chunks); the subsequent index.pack write is a tight in-memory
 // loop that doesn't poll ctx.
-func WriteColdIndex(ctx context.Context, chunkID chunk.ID, bitmaps Bitmaps, bucketDir string) (err error) {
+//
+// secret is the chunk's deterministic routing secret (ColdIndexSecret).
+// A streamhash.ErrBlockOverflow is non-retryable: rebuilding with the
+// same secret routes the same keys to the same blocks.
+func WriteColdIndex(
+	ctx context.Context, chunkID chunk.ID, bitmaps Bitmaps, bucketDir string, secret [stores.SecretLen]byte,
+) (err error) {
 	indexPackPath := filepath.Join(bucketDir, IndexPackName(chunkID))
 	indexHashPath := filepath.Join(bucketDir, IndexHashName(chunkID))
 
@@ -98,7 +116,7 @@ func WriteColdIndex(ctx context.Context, chunkID chunk.ID, bitmaps Bitmaps, buck
 		}
 	}()
 
-	m, err := buildMPHF(ctx, bitmaps, indexHashPath)
+	m, err := buildMPHF(ctx, bitmaps, indexHashPath, secret)
 	if err != nil {
 		return fmt.Errorf("events: build MPHF: %w", err)
 	}
@@ -110,6 +128,7 @@ func WriteColdIndex(ctx context.Context, chunkID chunk.ID, bitmaps Bitmaps, buck
 		if lerr != nil {
 			return fmt.Errorf("events: MPHF lookup during index.pack build: %w", lerr)
 		}
+		// App fingerprint stays on the ORIGINAL term key, not the routed key.
 		var fp [IndexRecordFingerprintLen]byte
 		copy(fp[:], term[:IndexRecordFingerprintLen])
 		// Mutate in place — bitmaps is uniquely owned by the caller, built

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_index_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_index_test.go
@@ -67,7 +67,7 @@ func loadIndexPack(t *testing.T, path string) map[int][]byte {
 // slip past every round-trip test.
 func TestIndexPack_TrailerPinsFormatAndRecordSize(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, indexFixture(t, 4), dir))
+	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, indexFixture(t, 4), dir, testIndexSecret))
 
 	r := packfile.Open(filepath.Join(dir, IndexPackName(indexTestChunkID)), packfile.ReaderOptions{})
 	t.Cleanup(func() { _ = r.Close() })
@@ -84,7 +84,7 @@ func TestWriteIndex_ProducesBothFiles(t *testing.T) {
 	dir := t.TempDir()
 	idx := indexFixture(t, 64)
 
-	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir))
+	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir, testIndexSecret))
 
 	// index.hash exists and is openable as an MPHF.
 	m, err := openMPHF(filepath.Join(dir, IndexHashName(indexTestChunkID)))
@@ -101,7 +101,7 @@ func TestWriteIndex_RoundTripsBitmapsPerTerm(t *testing.T) {
 	const n = 32
 	idx := indexFixture(t, n)
 
-	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir))
+	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir, testIndexSecret))
 
 	m, err := openMPHF(filepath.Join(dir, IndexHashName(indexTestChunkID)))
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestWriteIndex_UnseenTermFingerprintMismatches(t *testing.T) {
 	dir := t.TempDir()
 	idx := indexFixture(t, 32)
 
-	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir))
+	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir, testIndexSecret))
 
 	m, err := openMPHF(filepath.Join(dir, IndexHashName(indexTestChunkID)))
 	require.NoError(t, err)
@@ -153,9 +153,10 @@ func TestWriteIndex_UnseenTermFingerprintMismatches(t *testing.T) {
 	// fast-no-matches (ErrKeyNotFound — already covered by mphf_test)
 	// or returns a slot whose fingerprint does NOT match the unseen
 	// term's first four bytes. The latter is the case index.pack's
-	// fingerprint check screens.
+	// fingerprint check screens. 2000 probes keep P(zero collisions)
+	// negligible.
 	var collisions, mismatches int
-	for i := range 100 {
+	for i := range 2000 {
 		unseen := ComputeTermKey(
 			fmt.Appendf(nil, "never-seen-%d", i),
 			FieldTopic0,
@@ -191,7 +192,7 @@ func TestWriteIndex_RespectsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already done before WriteColdIndex sees it
 
-	err := WriteColdIndex(ctx, indexTestChunkID, indexFixture(t, 64), t.TempDir())
+	err := WriteColdIndex(ctx, indexTestChunkID, indexFixture(t, 64), t.TempDir(), testIndexSecret)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled,
 		"WriteColdIndex must surface ctx.Err() when canceled before start")
@@ -204,7 +205,7 @@ func TestWriteIndex_RespectsContextCancellation(t *testing.T) {
 // the ordinary path.
 func TestWriteIndex_ZeroTerms_WritesEmptyIndex(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, NewBitmaps(), dir))
+	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, NewBitmaps(), dir, testIndexSecret))
 
 	// index.hash exists (a real streamhash index built over zero terms).
 	hashInfo, err := os.Stat(filepath.Join(dir, IndexHashName(indexTestChunkID)))
@@ -237,7 +238,7 @@ func TestWriteIndex_FailedWriteCleansUpIndexHash(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.Mkdir(filepath.Join(dir, IndexPackName(indexTestChunkID)), 0o755))
 
-	err := WriteColdIndex(context.Background(), indexTestChunkID, indexFixture(t, 4), dir)
+	err := WriteColdIndex(context.Background(), indexTestChunkID, indexFixture(t, 4), dir, testIndexSecret)
 	require.Error(t, err, "WriteColdIndex must fail when index.pack path is a directory")
 
 	_, statErr := os.Stat(filepath.Join(dir, IndexHashName(indexTestChunkID)))
@@ -253,7 +254,7 @@ func TestWriteIndex_SlotsAreDense(t *testing.T) {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			dir := t.TempDir()
 			idx := indexFixture(t, n)
-			require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir))
+			require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir, testIndexSecret))
 
 			m, err := openMPHF(filepath.Join(dir, IndexHashName(indexTestChunkID)))
 			require.NoError(t, err)
@@ -283,7 +284,7 @@ func TestWriteIndex_LargeIndex(t *testing.T) {
 	const n = 5_000
 	idx := indexFixture(t, n)
 
-	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir))
+	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir, testIndexSecret))
 
 	m, err := openMPHF(filepath.Join(dir, IndexHashName(indexTestChunkID)))
 	require.NoError(t, err)
@@ -314,7 +315,7 @@ func TestWriteIndex_RecordEncoding(t *testing.T) {
 	idx := NewBitmaps()
 	idx.AddTo(ComputeTermKey([]byte("only"), FieldContractID), 42)
 
-	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir))
+	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir, testIndexSecret))
 
 	records := loadIndexPack(t, filepath.Join(dir, IndexPackName(indexTestChunkID)))
 	require.Len(t, records, 1)

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_reader_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_reader_test.go
@@ -77,7 +77,7 @@ func buildColdFixture(t *testing.T, chunkID chunk.ID, eventsPerLedger, ledgersPe
 	}
 
 	require.NoError(t, cw.Finish(offsets))
-	require.NoError(t, WriteColdIndex(context.Background(), chunkID, idx, dir))
+	require.NoError(t, WriteColdIndex(context.Background(), chunkID, idx, dir, testIndexSecret))
 	return dir, payloads
 }
 

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/match_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/match_test.go
@@ -1237,7 +1237,7 @@ func freezeFixtureToColdReader(t *testing.T, hot *HotStore, chunkID chunk.ID) *C
 	}
 
 	require.NoError(t, cw.Finish(coldOffsets))
-	require.NoError(t, WriteColdIndex(context.Background(), chunkID, idx, dir))
+	require.NoError(t, WriteColdIndex(context.Background(), chunkID, idx, dir, testIndexSecret))
 
 	cr, err := OpenColdReader(chunkID, dir, ColdReaderOptions{})
 	require.NoError(t, err)

--- a/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_bin.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_bin.go
@@ -1,6 +1,6 @@
 package txhash
 
-// cold_bin.go owns the on-disk format of the RAW cold txhash chunk: the
+// cold_bin.go owns the on-disk format of the cold txhash chunk: the
 // sorted per-chunk `<chunkID:08d>.bin` file the cold ingester publishes and
 // the deferred streamhash index builder consumes. Keeping the writer and
 // the filename helper next to the index builder's pre-scan in this package
@@ -10,13 +10,14 @@ package txhash
 //
 // File layout:
 //
-//	header  uint64 LE      entry count
-//	entry   ColdKeySize B  txhash[:ColdKeySize]
-//	        uint32 LE      absolute ledger seq
+//	header  uint64 LE           entry count
+//	        stores.SecretLen B  index secret the keys were blinded with
+//	entry   ColdKeySize B       blinded txhash[:ColdKeySize]
+//	        uint32 LE           absolute ledger seq
 //
-// Entries are lex-sorted by key. Duplicate truncated keys are written
+// Entries are lex-sorted by (blinded) key. Duplicate keys are written
 // verbatim, but the downstream streamhash build fails on them — with
-// 16-byte truncated hashes a collision is astronomically unlikely, and
+// 16-byte blinded keys a collision is astronomically unlikely, and
 // if one ever occurs the index build rejects it loudly rather than
 // serving an ambiguous key.
 
@@ -29,25 +30,31 @@ import (
 	"github.com/stellar/streamhash"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
 
 const (
-	// ColdKeySize is the truncated tx-hash key width stored in the cold
+	// ColdKeySize is the blinded routing-key width stored in the cold
 	// .bin file. It is pinned to streamhash.MinKeySize: the deferred
 	// streamhash index builder routes/hashes on the first MinKeySize bytes
-	// of each key, so the .bin producer must truncate to exactly that
+	// of each key, so the .bin producer's blinded keys are exactly that
 	// width for the round-trip to hold.
 	ColdKeySize = streamhash.MinKeySize
 	// coldBinSeqSize is the per-entry ledger seq width (uint32 LE).
 	coldBinSeqSize = 4
 	// coldBinEntrySize is the per-entry width in the cold .bin file:
-	// ColdKeySize bytes of truncated hash + the ledger seq.
+	// ColdKeySize bytes of blinded key + the ledger seq.
 	coldBinEntrySize = ColdKeySize + coldBinSeqSize
-	// coldBinHeaderSize is the leading uint64 LE entry count.
-	coldBinHeaderSize = 8
+	// coldBinCountSize is the leading uint64 LE entry count.
+	coldBinCountSize = 8
+	// coldBinHeaderSize is the count followed by the index secret the keys were
+	// blinded with (stores.SecretLen). The build reads the secret back and
+	// adopts it, so an index can never be built under a secret that disagrees
+	// with the one its .bin keys were keyed with (see BuildColdIndex).
+	coldBinHeaderSize = coldBinCountSize + stores.SecretLen
 )
 
-// ColdEntry is one (truncated txhash, ledger seq) tuple in a cold .bin file.
+// ColdEntry is one (blinded key, ledger seq) tuple in a cold .bin file.
 type ColdEntry struct {
 	Key [ColdKeySize]byte
 	Seq uint32
@@ -68,6 +75,10 @@ func ColdBinName(chunkID chunk.ID) string {
 // (and scanBinHeader's header-vs-size check rejects loudly if one is
 // ever opened).
 //
+// secret is the index secret entries' keys were blinded with; it is recorded in
+// the header so the deferred build adopts it instead of re-deriving one that
+// might disagree.
+//
 // entries must already be sorted (lex by Key, non-decreasing); this function
 // writes them verbatim.
 //
@@ -75,7 +86,7 @@ func ColdBinName(chunkID chunk.ID) string {
 // completion record must only be written once the data is durable, and on
 // many filesystems ENOSPC/EIO only surface at fd close — a silently
 // truncated .bin would produce a wrong index without any signal.
-func WriteColdBin(path string, entries []ColdEntry) error {
+func WriteColdBin(path string, secret [stores.SecretLen]byte, entries []ColdEntry) error {
 	f, cerr := os.Create(path)
 	if cerr != nil {
 		return fmt.Errorf("txhash: create %s: %w", path, cerr)
@@ -91,7 +102,8 @@ func WriteColdBin(path string, entries []ColdEntry) error {
 
 	bw := bufio.NewWriterSize(f, 1<<20)
 	var header [coldBinHeaderSize]byte
-	binary.LittleEndian.PutUint64(header[:], uint64(len(entries)))
+	binary.LittleEndian.PutUint64(header[:coldBinCountSize], uint64(len(entries)))
+	copy(header[coldBinCountSize:], secret[:])
 	if _, werr := bw.Write(header[:]); werr != nil {
 		return fmt.Errorf("txhash: write header: %w", werr)
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_bin_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_bin_test.go
@@ -2,6 +2,7 @@ package txhash
 
 import (
 	"bufio"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -13,7 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
+
+// testBinSecret is the index secret the .bin writer tests key their entries
+// with; the header records it and the reader/build validate it.
+var testBinSecret = [stores.SecretLen]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
 // readColdBin reads back a cold .bin file, validating its header count against
 // the file size via the shared coldBinCount. It is the test-side mirror of the
@@ -32,7 +38,7 @@ func readColdBin(path string) ([]ColdEntry, error) {
 	if _, err := io.ReadFull(br, header[:]); err != nil {
 		return nil, fmt.Errorf("txhash: read header of %s: %w", path, err)
 	}
-	count := binary.LittleEndian.Uint64(header[:])
+	count := binary.LittleEndian.Uint64(header[:coldBinCountSize])
 
 	info, err := f.Stat()
 	if err != nil {
@@ -64,7 +70,7 @@ func TestColdBin_RoundTrip(t *testing.T) {
 		{Key: [ColdKeySize]byte{0x02}, Seq: 11},
 		{Key: [ColdKeySize]byte{0x02}, Seq: 12}, // duplicate truncated key preserved
 	}
-	require.NoError(t, WriteColdBin(path, entries))
+	require.NoError(t, WriteColdBin(path, testBinSecret, entries))
 
 	got, err := readColdBin(path)
 	require.NoError(t, err)
@@ -80,12 +86,13 @@ func TestColdBin_HeaderAndLayout(t *testing.T) {
 		{Key: [ColdKeySize]byte{0xaa}, Seq: 7},
 		{Key: [ColdKeySize]byte{0xbb}, Seq: 8},
 	}
-	require.NoError(t, WriteColdBin(path, entries))
+	require.NoError(t, WriteColdBin(path, testBinSecret, entries))
 
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Len(t, data, coldBinHeaderSize+2*coldBinEntrySize)
-	assert.Equal(t, uint64(2), binary.LittleEndian.Uint64(data[:coldBinHeaderSize]))
+	assert.Equal(t, uint64(2), binary.LittleEndian.Uint64(data[:coldBinCountSize]))
+	assert.Equal(t, testBinSecret[:], data[coldBinCountSize:coldBinHeaderSize], "secret recorded after the count")
 	assert.Equal(t, byte(0xaa), data[coldBinHeaderSize])
 	assert.Equal(t, uint32(7),
 		binary.LittleEndian.Uint32(data[coldBinHeaderSize+ColdKeySize:coldBinHeaderSize+coldBinEntrySize]))
@@ -99,7 +106,7 @@ func TestColdBin_CreateFails(t *testing.T) {
 	path := filepath.Join(dir, "out.bin")
 	require.NoError(t, os.Mkdir(path, 0o755)) // create() will hit EISDIR
 
-	err := WriteColdBin(path, []ColdEntry{{Key: [ColdKeySize]byte{0x01}, Seq: 7}})
+	err := WriteColdBin(path, testBinSecret, []ColdEntry{{Key: [ColdKeySize]byte{0x01}, Seq: 7}})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "create")
 
@@ -121,7 +128,7 @@ func TestColdBin_OverwritesPriorAttempt(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, make([]byte, 4096), 0o600))
 
 	entries := []ColdEntry{{Key: [ColdKeySize]byte{0x03}, Seq: 21}}
-	require.NoError(t, WriteColdBin(path, entries))
+	require.NoError(t, WriteColdBin(path, testBinSecret, entries))
 
 	got, err := readColdBin(path)
 	require.NoError(t, err)
@@ -133,7 +140,7 @@ func TestColdBin_OverwritesPriorAttempt(t *testing.T) {
 func TestColdBin_ReadRejectsTruncated(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.bin")
-	require.NoError(t, WriteColdBin(path, []ColdEntry{
+	require.NoError(t, WriteColdBin(path, testBinSecret, []ColdEntry{
 		{Key: [ColdKeySize]byte{0x01}, Seq: 1},
 		{Key: [ColdKeySize]byte{0x02}, Seq: 2},
 	}))
@@ -143,4 +150,23 @@ func TestColdBin_ReadRejectsTruncated(t *testing.T) {
 
 	_, err = readColdBin(path)
 	require.Error(t, err)
+}
+
+// TestBuildColdIndex_RejectsMixedSecrets pins the H3 guard: BuildColdIndex
+// adopts the secret from the .bin headers and requires every input in a window
+// to carry the same one. Inputs blinded under different secrets (a catalog
+// remint or geometry drift between ingest passes) must fail the build loudly
+// rather than produce an index no query can hit.
+func TestBuildColdIndex_RejectsMixedSecrets(t *testing.T) {
+	dir := t.TempDir()
+	secretA := [stores.SecretLen]byte{0xa1}
+	secretB := [stores.SecretLen]byte{0xb2}
+	binA := filepath.Join(dir, "a.bin")
+	binB := filepath.Join(dir, "b.bin")
+	require.NoError(t, WriteColdBin(binA, secretA, []ColdEntry{{Key: [ColdKeySize]byte{0x01}, Seq: 1}}))
+	require.NoError(t, WriteColdBin(binB, secretB, []ColdEntry{{Key: [ColdKeySize]byte{0x02}, Seq: 2}}))
+
+	err := BuildColdIndex(context.Background(), []string{binA, binB}, filepath.Join(dir, "out.idx"), 0, 100)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "different index secret")
 }

--- a/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_format.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_format.go
@@ -6,6 +6,12 @@ package txhash
 // offset from the group's MinLedger, stored inline in the per-key payload.
 // One MPHF spans many chunks because a hash lookup has no ledger to narrow
 // on. The reader is in cold_reader.go, the build in cold_index.go.
+//
+// Routing is secret-keyed: the .bin producer stores
+// stores.BlindKey(secret, txhash[:ColdKeySize]) as each entry's key, the
+// build feeds those keys verbatim, and the reader keys its queries the same
+// way. secret = ColdIndexSecret(catalogSecret, indexID) — deterministic, and
+// stored in the index metadata so queries never need the master key.
 
 import (
 	"encoding/binary"
@@ -13,6 +19,8 @@ import (
 	"fmt"
 
 	"github.com/stellar/streamhash"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
 
 // DefaultChunksPerIndex is the default number of chunks per cold txhash index.
@@ -29,42 +37,55 @@ const ColdFingerprintSize = 1
 // coldPayloadMax is the largest offset that fits ColdPayloadSize bytes.
 const coldPayloadMax = uint64(1)<<(ColdPayloadSize*8) - 1
 
-// coldMetadataSize is the metadata blob width: two 4-byte LE values,
-// [MinLedger, MaxLedger].
-const coldMetadataSize = 8
+// coldMetadataSize is the metadata blob width:
+// [MinLedger:4 LE][MaxLedger:4 LE][routing secret:16].
+const coldMetadataSize = 8 + stores.SecretLen
+
+// coldRoutingDomain is the DeriveIndexSecret domain for txhash cold indexes.
+const coldRoutingDomain = "txhash"
 
 // ErrInvalidMetadata is returned when a cold index's metadata is not a valid
-// [MinLedger, MaxLedger] blob.
+// [MinLedger, MaxLedger, secret] blob.
 var ErrInvalidMetadata = errors.New("txhash: cold index user metadata malformed")
 
-// EncodeLedgerRange packs [minLedger, maxLedger] into the metadata blob.
-func EncodeLedgerRange(minLedger, maxLedger uint32) []byte {
+// ColdIndexSecret derives index indexID's routing secret from the
+// build-side master key. The single derivation both the .bin producer and
+// BuildColdIndex use, so ingest-time keys always match the built index.
+func ColdIndexSecret(catalogSecret []byte, indexID uint32) [stores.SecretLen]byte {
+	return stores.DeriveIndexSecret(catalogSecret, coldRoutingDomain, indexID)
+}
+
+// EncodeColdMetadata packs [minLedger, maxLedger, secret] into the metadata blob.
+func EncodeColdMetadata(minLedger, maxLedger uint32, secret [stores.SecretLen]byte) []byte {
 	buf := make([]byte, coldMetadataSize)
 	binary.LittleEndian.PutUint32(buf[:4], minLedger)
-	binary.LittleEndian.PutUint32(buf[4:], maxLedger)
+	binary.LittleEndian.PutUint32(buf[4:8], maxLedger)
+	copy(buf[8:], secret[:])
 	return buf
 }
 
-// ParseLedgerRange recovers [minLedger, maxLedger] from the metadata blob,
-// rejecting a wrong size or maxLedger < minLedger with ErrInvalidMetadata.
-func ParseLedgerRange(metadata []byte) (uint32, uint32, error) {
+// ParseColdMetadata recovers [minLedger, maxLedger, secret] from the metadata
+// blob, rejecting a wrong size or maxLedger < minLedger with ErrInvalidMetadata.
+func ParseColdMetadata(metadata []byte) (uint32, uint32, [stores.SecretLen]byte, error) {
+	var secret [stores.SecretLen]byte
 	if len(metadata) != coldMetadataSize {
-		return 0, 0, fmt.Errorf("%w: got %d bytes, want %d", ErrInvalidMetadata, len(metadata), coldMetadataSize)
+		return 0, 0, secret, fmt.Errorf("%w: got %d bytes, want %d", ErrInvalidMetadata, len(metadata), coldMetadataSize)
 	}
 	minLedger := binary.LittleEndian.Uint32(metadata[:4])
-	maxLedger := binary.LittleEndian.Uint32(metadata[4:])
+	maxLedger := binary.LittleEndian.Uint32(metadata[4:8])
 	if maxLedger < minLedger {
-		return 0, 0, fmt.Errorf("%w: maxLedger %d < minLedger %d", ErrInvalidMetadata, maxLedger, minLedger)
+		return 0, 0, secret, fmt.Errorf("%w: maxLedger %d < minLedger %d", ErrInvalidMetadata, maxLedger, minLedger)
 	}
-	return minLedger, maxLedger, nil
+	copy(secret[:], metadata[8:])
+	return minLedger, maxLedger, secret, nil
 }
 
 // ColdBuildOptions pins a cold index's payload size, fingerprint size, and
-// [minLedger, maxLedger] anchor.
-func ColdBuildOptions(minLedger, maxLedger uint32) []streamhash.BuildOption {
+// [minLedger, maxLedger, secret] metadata.
+func ColdBuildOptions(minLedger, maxLedger uint32, secret [stores.SecretLen]byte) []streamhash.BuildOption {
 	return []streamhash.BuildOption{
 		streamhash.WithPayload(ColdPayloadSize),
 		streamhash.WithFingerprint(ColdFingerprintSize),
-		streamhash.WithMetadata(EncodeLedgerRange(minLedger, maxLedger)),
+		streamhash.WithMetadata(EncodeColdMetadata(minLedger, maxLedger, secret)),
 	}
 }

--- a/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_format_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_format_test.go
@@ -13,25 +13,28 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
 
-func TestEncodeParseLedgerRange_RoundTrip(t *testing.T) {
+func TestEncodeParseColdMetadata_RoundTrip(t *testing.T) {
+	secret := testSecret()
 	cases := [][2]uint32{{0, 0}, {2, 2}, {100, 12345}, {50002, 60001}, {0, 0xFFFFFFFF}}
 	for _, c := range cases {
-		gotMin, gotMax, err := ParseLedgerRange(EncodeLedgerRange(c[0], c[1]))
+		gotMin, gotMax, gotSecret, err := ParseColdMetadata(EncodeColdMetadata(c[0], c[1], secret))
 		require.NoError(t, err)
 		assert.Equal(t, c[0], gotMin)
 		assert.Equal(t, c[1], gotMax)
+		assert.Equal(t, secret, gotSecret)
 	}
 }
 
-func TestParseLedgerRange_WrongSizeErrors(t *testing.T) {
-	for _, sz := range []int{0, 1, 4, 7, 9, 16} {
-		_, _, err := ParseLedgerRange(make([]byte, sz))
+func TestParseColdMetadata_WrongSizeErrors(t *testing.T) {
+	// 8 is the pre-secret layout; 24 is the only valid width.
+	for _, sz := range []int{0, 1, 4, 7, 8, 9, 16, 23, 25} {
+		_, _, _, err := ParseColdMetadata(make([]byte, sz))
 		assert.ErrorIs(t, err, ErrInvalidMetadata, "size %d should error", sz)
 	}
 }
 
-func TestParseLedgerRange_MaxBelowMinErrors(t *testing.T) {
-	_, _, err := ParseLedgerRange(EncodeLedgerRange(100, 99))
+func TestParseColdMetadata_MaxBelowMinErrors(t *testing.T) {
+	_, _, _, err := ParseColdMetadata(EncodeColdMetadata(100, 99, testSecret()))
 	assert.ErrorIs(t, err, ErrInvalidMetadata)
 }
 
@@ -76,7 +79,7 @@ func TestColdReader_UnseenKeyReturnsNotFound(t *testing.T) {
 
 func TestOpenColdReader_BadMetadataErrors(t *testing.T) {
 	// An index built without ColdBuildOptions' metadata must be rejected
-	// at open: ParseLedgerRange requires exactly 8 bytes.
+	// at open: ParseColdMetadata requires exactly coldMetadataSize bytes.
 	path := filepath.Join(t.TempDir(), "no-metadata.idx")
 	sb, err := streamhash.NewSortedBuilder(context.Background(), path, 1,
 		streamhash.WithPayload(ColdPayloadSize),
@@ -100,7 +103,7 @@ func TestOpenColdReader_WrongPayloadSizeErrors(t *testing.T) {
 	sb, err := streamhash.NewSortedBuilder(context.Background(), path, 1,
 		streamhash.WithPayload(ColdPayloadSize+1), // wrong width
 		streamhash.WithFingerprint(ColdFingerprintSize),
-		streamhash.WithMetadata(EncodeLedgerRange(2, 2)),
+		streamhash.WithMetadata(EncodeColdMetadata(2, 2, testSecret())),
 	)
 	require.NoError(t, err)
 	var k [ColdKeySize]byte

--- a/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_index.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_index.go
@@ -9,17 +9,21 @@ package txhash
 // The merge requires each file's entries pre-sorted ascending by the
 // big-endian uint64 of their first 8 key bytes — the block order streamhash
 // routes on (for the first 8 bytes this is identical to the lex key order
-// WriteColdBin guarantees).
+// WriteColdBin guarantees). The .bin keys are already the keyed routing keys
+// (see cold_format.go), so the build feeds them verbatim — no keying here.
 
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"runtime"
 
 	"github.com/stellar/streamhash"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
 
 // BuildColdIndex builds one cold txhash index from inputs (the per-chunk
@@ -32,6 +36,12 @@ import (
 // streamhash. By default the block build uses runtime.NumCPU()/2 workers
 // (~2.7x over single-threaded); caller opts override. Removes the partial
 // output on error, and honors ctx cancellation.
+//
+// The index secret written into the metadata is ADOPTED from the .bin headers
+// (the secret the .bin producer keyed the inputs with), not re-derived — so the
+// index can never disagree with its inputs' keying. All inputs must share one
+// secret (scanAndValidate enforces it). That secret is deterministic, so an
+// ErrBlockOverflow here recurs identically on rebuild — non-retryable by design.
 func BuildColdIndex(
 	ctx context.Context,
 	inputs []string,
@@ -47,7 +57,7 @@ func BuildColdIndex(
 			maxLedger-minLedger, ColdPayloadSize)
 	}
 
-	total, err := scanAndValidate(inputs)
+	total, secret, err := scanAndValidate(inputs)
 	if err != nil {
 		return err
 	}
@@ -58,7 +68,7 @@ func BuildColdIndex(
 	buildOpts := make([]streamhash.BuildOption, 0, len(opts)+4)
 	buildOpts = append(buildOpts, streamhash.WithWorkers(defaultBuildWorkers()))
 	buildOpts = append(buildOpts, opts...)
-	buildOpts = append(buildOpts, ColdBuildOptions(minLedger, maxLedger)...)
+	buildOpts = append(buildOpts, ColdBuildOptions(minLedger, maxLedger, secret)...)
 	builder, berr := streamhash.NewSortedBuilder(ctx, outputPath, total, buildOpts...)
 	if berr != nil {
 		return fmt.Errorf("txhash: create cold index builder at %s: %w", outputPath, berr)
@@ -110,38 +120,56 @@ func maxMergeLeaves() int {
 	return max(1, runtime.NumCPU()/2)
 }
 
-// scanAndValidate sums the per-file header counts, cross-checking each
-// against the file length: an understated count would otherwise silently
-// drop a file's trailing entries (the merge reads to EOF).
-func scanAndValidate(inputs []string) (uint64, error) {
+// scanAndValidate sums the per-file header counts, cross-checking each against
+// the file length (an understated count would otherwise silently drop a file's
+// trailing entries — the merge reads to EOF), and returns the index secret the
+// inputs were blinded with. Every input in a window must carry the SAME secret;
+// a mismatch means the .bin files were keyed under different secrets (a catalog
+// remint or geometry drift between ingest passes), so the build stops rather
+// than silently producing an index no query can hit.
+func scanAndValidate(inputs []string) (uint64, [stores.SecretLen]byte, error) {
 	var total uint64
-	for _, path := range inputs {
-		count, err := scanBinHeader(path)
+	var secret [stores.SecretLen]byte
+	if len(inputs) == 0 {
+		return 0, secret, errors.New("txhash: cold index build has no .bin inputs")
+	}
+	for i, path := range inputs {
+		count, s, err := scanBinHeader(path)
 		if err != nil {
-			return 0, err
+			return 0, secret, err
+		}
+		if i == 0 {
+			secret = s
+		} else if s != secret {
+			return 0, secret, fmt.Errorf(
+				"txhash: %s was blinded with a different index secret than %s — inputs must share one secret",
+				path, inputs[0])
 		}
 		total += count
 	}
-	return total, nil
+	return total, secret, nil
 }
 
-// scanBinHeader opens path, reads its declared entry count, and verifies its
-// byte size matches that count via coldBinCount (the shared, overflow-safe
-// header check).
-func scanBinHeader(path string) (uint64, error) {
+// scanBinHeader opens path, reads its declared entry count and index secret,
+// and verifies its byte size matches that count via coldBinCount (the shared,
+// overflow-safe header check).
+func scanBinHeader(path string) (uint64, [stores.SecretLen]byte, error) {
+	var secret [stores.SecretLen]byte
 	f, err := os.Open(path)
 	if err != nil {
-		return 0, fmt.Errorf("txhash: open %s: %w", path, err)
+		return 0, secret, fmt.Errorf("txhash: open %s: %w", path, err)
 	}
 	defer f.Close()
 
 	fi, err := f.Stat()
 	if err != nil {
-		return 0, fmt.Errorf("txhash: stat %s: %w", path, err)
+		return 0, secret, fmt.Errorf("txhash: stat %s: %w", path, err)
 	}
 	var hdr [coldBinHeaderSize]byte
 	if _, err := io.ReadFull(f, hdr[:]); err != nil {
-		return 0, fmt.Errorf("txhash: read header of %s: %w", path, err)
+		return 0, secret, fmt.Errorf("txhash: read header of %s: %w", path, err)
 	}
-	return coldBinCount(path, fi.Size(), binary.LittleEndian.Uint64(hdr[:]))
+	copy(secret[:], hdr[coldBinCountSize:])
+	count, err := coldBinCount(path, fi.Size(), binary.LittleEndian.Uint64(hdr[:coldBinCountSize]))
+	return count, secret, err
 }

--- a/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_index_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_index_test.go
@@ -25,6 +25,15 @@ import (
 // this package).
 // ──────────────────────────────────────────────────────────────────
 
+// testCatalogSecret/testIndexID are the fixed keying inputs every fixture build
+// and .bin writer share (deterministic, so fixtures are reproducible);
+// testSecret is the derived per-index routing secret.
+var testCatalogSecret = bytes.Repeat([]byte{0xA5}, 32)
+
+const testIndexID uint32 = 7
+
+func testSecret() [stores.SecretLen]byte { return ColdIndexSecret(testCatalogSecret, testIndexID) }
+
 // randHash returns a 32-byte hash drawn from r. Cold tests use true
 // random hashes (matching streamhash's own test patterns): structured
 // hashes can produce correlated 16-byte prefixes that defeat the
@@ -103,24 +112,29 @@ func makeFixtureEntries(n int) []fixtureEntry {
 	return entries
 }
 
-// writeBinFile writes entries to a per-chunk .bin file in the input
-// format BuildColdIndex consumes, sorted ascending by the 16-byte key
-// prefix (the per-file ordering the build's merge requires).
-func writeBinFile(t *testing.T, path string, entries []fixtureEntry) {
+// writeBinFile writes entries to a per-chunk .bin file in the input format
+// BuildColdIndex consumes: each stored key is the secret-keyed routing key of
+// the entry's hash prefix (mirroring ingest-time keying), sorted ascending
+// (the per-file ordering the build's merge requires).
+func writeBinFile(t *testing.T, path string, entries []fixtureEntry, secret [stores.SecretLen]byte) {
 	t.Helper()
-	sorted := append([]fixtureEntry(nil), entries...)
-	sort.Slice(sorted, func(i, j int) bool {
-		return bytes.Compare(sorted[i].hash[:ColdKeySize], sorted[j].hash[:ColdKeySize]) < 0
+	keyed := make([]ColdEntry, len(entries))
+	for i, e := range entries {
+		keyed[i] = ColdEntry{Key: stores.BlindKey(secret, e.hash[:ColdKeySize]), Seq: e.seq}
+	}
+	sort.Slice(keyed, func(i, j int) bool {
+		return bytes.Compare(keyed[i].Key[:], keyed[j].Key[:]) < 0
 	})
 
 	var buf bytes.Buffer
 	var hdr [coldBinHeaderSize]byte
-	binary.LittleEndian.PutUint64(hdr[:], uint64(len(sorted)))
+	binary.LittleEndian.PutUint64(hdr[:coldBinCountSize], uint64(len(keyed)))
+	copy(hdr[coldBinCountSize:], secret[:])
 	buf.Write(hdr[:])
 	var seqBuf [coldBinSeqSize]byte
-	for _, e := range sorted {
-		buf.Write(e.hash[:ColdKeySize])
-		binary.LittleEndian.PutUint32(seqBuf[:], e.seq)
+	for _, e := range keyed {
+		buf.Write(e.Key[:])
+		binary.LittleEndian.PutUint32(seqBuf[:], e.Seq)
 		buf.Write(seqBuf[:])
 	}
 	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o600))
@@ -132,6 +146,12 @@ func writeBinFile(t *testing.T, path string, entries []fixtureEntry) {
 // mirroring how #765's per-chunk ingester would lay them out.
 func writeFixtureBins(t *testing.T, dir string, entries []fixtureEntry) []string {
 	t.Helper()
+	return writeFixtureBinsKeyed(t, dir, entries, testSecret())
+}
+
+// writeFixtureBinsKeyed is writeFixtureBins under an explicit routing secret.
+func writeFixtureBinsKeyed(t *testing.T, dir string, entries []fixtureEntry, secret [stores.SecretLen]byte) []string {
+	t.Helper()
 	byChunk := make(map[chunk.ID][]fixtureEntry)
 	for _, e := range entries {
 		c := chunk.IDFromLedger(e.seq)
@@ -140,7 +160,7 @@ func writeFixtureBins(t *testing.T, dir string, entries []fixtureEntry) []string
 	inputs := make([]string, 0, len(byChunk))
 	for c, es := range byChunk {
 		p := filepath.Join(dir, c.String()+".bin")
-		writeBinFile(t, p, es)
+		writeBinFile(t, p, es, secret)
 		inputs = append(inputs, p)
 	}
 	return inputs
@@ -158,7 +178,8 @@ func buildColdFixture(t *testing.T, n int) (string, []fixtureEntry) {
 	require.Greater(t, len(inputs), 1, "fixture should span multiple .bin files to exercise the merge")
 
 	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
-	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath, fixtureMinLedger(), fixtureMaxLedger()))
+	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath,
+		fixtureMinLedger(), fixtureMaxLedger()))
 	return idxPath, entries
 }
 
@@ -210,7 +231,8 @@ func TestBuildColdIndex_LargeFilesSpanMultipleBuffers(t *testing.T) {
 		"fixture must produce a file larger than the read buffer to exercise refills")
 
 	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
-	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath, fixtureMinLedger(), fixtureMaxLedger()))
+	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath,
+		fixtureMinLedger(), fixtureMaxLedger()))
 
 	r, err := OpenColdReader(idxPath)
 	require.NoError(t, err)
@@ -225,25 +247,32 @@ func TestBuildColdIndex_LargeFilesSpanMultipleBuffers(t *testing.T) {
 // assertEmptyColdIndex checks that idxPath is a valid empty cold index: it
 // opens cleanly, carries its coverage's [wantMin, wantMax] metadata, and every
 // lookup misses.
-func assertEmptyColdIndex(t *testing.T, idxPath string, wantMin, wantMax uint32) {
+func assertEmptyColdIndex(t *testing.T, idxPath string, wantMin, wantMax uint32, wantSecret [stores.SecretLen]byte) {
 	t.Helper()
 	assert.FileExists(t, idxPath)
 	r, err := OpenColdReader(idxPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = r.Close() })
-	// The empty index must still carry correct coverage bounds.
+	// The empty index must still carry correct coverage bounds and the adopted
+	// index secret: a query blinds with the metadata secret, so dropping it on
+	// the empty path would break lookups once the range fills.
 	assert.Equal(t, wantMin, r.MinLedger(), "empty index minLedger")
 	assert.Equal(t, wantMax, r.MaxLedger(), "empty index maxLedger")
+	assert.Equal(t, wantSecret, r.secret, "empty index metadata secret")
 	_, err = r.Get(randHash(testRNG(99)))
 	require.ErrorIs(t, err, stores.ErrNotFound)
 }
 
 func TestBuildColdIndex_NoInputs(t *testing.T) {
-	// No .bin files at all: streamhash now builds a valid empty index rather
-	// than refusing.
+	// With adopt-the-secret, the build reads the index secret from the .bin
+	// headers, so it needs at least one input. Zero inputs is refused — it never
+	// happens in production (a window always has its chunks' .bin files, empty or
+	// not; an all-empty window is TestBuildColdIndex_AllEmptyInputs).
 	idxPath := filepath.Join(t.TempDir(), indexFileName(0))
-	require.NoError(t, BuildColdIndex(context.Background(), nil, idxPath, 2, 2))
-	assertEmptyColdIndex(t, idxPath, 2, 2)
+	err := BuildColdIndex(context.Background(), nil, idxPath, 2, 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no .bin inputs")
+	assert.NoFileExists(t, idxPath)
 }
 
 func TestBuildColdIndex_MaxBelowMinErrors(t *testing.T) {
@@ -265,12 +294,13 @@ func TestBuildColdIndex_AllEmptyInputs(t *testing.T) {
 	inputs := make([]string, 0, len(chunks))
 	for _, c := range chunks {
 		p := filepath.Join(dir, c.String()+".bin")
-		writeBinFile(t, p, nil)
+		writeBinFile(t, p, nil, testSecret())
 		inputs = append(inputs, p)
 	}
 	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
-	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath, fixtureMinLedger(), fixtureMaxLedger()))
-	assertEmptyColdIndex(t, idxPath, fixtureMinLedger(), fixtureMaxLedger())
+	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath,
+		fixtureMinLedger(), fixtureMaxLedger()))
+	assertEmptyColdIndex(t, idxPath, fixtureMinLedger(), fixtureMaxLedger(), testSecret())
 }
 
 func TestBuildColdIndex_MissingInputErrors(t *testing.T) {
@@ -296,9 +326,10 @@ func TestBuildColdIndex_SeqOutsideCoverageErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			p := filepath.Join(dir, "00000004.bin")
-			writeBinFile(t, p, []fixtureEntry{{hash: randHash(testRNG(1)), seq: tc.seq}})
+			writeBinFile(t, p, []fixtureEntry{{hash: randHash(testRNG(1)), seq: tc.seq}}, testSecret())
 			idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
-			err := BuildColdIndex(context.Background(), []string{p}, idxPath, fixtureMinLedger(), fixtureMaxLedger())
+			err := BuildColdIndex(context.Background(), []string{p}, idxPath,
+				fixtureMinLedger(), fixtureMaxLedger())
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "outside index coverage")
 			assert.NoFileExists(t, idxPath)
@@ -314,10 +345,11 @@ func TestBuildColdIndex_CoverageSpanExceedsBudgetErrors(t *testing.T) {
 	overflowSeq := minLedger + uint32(coldPayloadMax) + 1
 	entries := []fixtureEntry{{hash: randHash(testRNG(2)), seq: overflowSeq}}
 	p := filepath.Join(dir, "99999999.bin")
-	writeBinFile(t, p, entries)
+	writeBinFile(t, p, entries, testSecret())
 
 	idxPath := filepath.Join(dir, indexFileName(0))
-	err := BuildColdIndex(context.Background(), []string{p}, idxPath, minLedger, overflowSeq)
+	err := BuildColdIndex(
+		context.Background(), []string{p}, idxPath, minLedger, overflowSeq)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "payload budget")
 	assert.NoFileExists(t, idxPath)
@@ -332,7 +364,8 @@ func TestBuildColdIndex_CallerOptsCannotOverrideFormat(t *testing.T) {
 	inputs := writeFixtureBins(t, dir, entries)
 	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 	err := BuildColdIndex(context.Background(), inputs, idxPath,
-		fixtureMinLedger(), fixtureMaxLedger(), streamhash.WithMetadata(EncodeLedgerRange(7, 7)))
+		fixtureMinLedger(), fixtureMaxLedger(),
+		streamhash.WithMetadata(EncodeColdMetadata(7, 7, testSecret())))
 	require.NoError(t, err)
 
 	r, err := OpenColdReader(idxPath)
@@ -363,7 +396,8 @@ func TestBuildColdIndex_TruncatedFileErrors(t *testing.T) {
 	require.NoError(t, os.WriteFile(p, buf.Bytes(), 0o600))
 
 	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
-	err := BuildColdIndex(context.Background(), []string{p}, idxPath, fixtureMinLedger(), fixtureMaxLedger())
+	err := BuildColdIndex(context.Background(), []string{p}, idxPath,
+		fixtureMinLedger(), fixtureMaxLedger())
 	require.Error(t, err)
 	assert.NoFileExists(t, idxPath)
 }
@@ -382,7 +416,8 @@ func TestBuildColdIndex_HeaderUndercountErrors(t *testing.T) {
 	require.NoError(t, os.WriteFile(p, buf.Bytes(), 0o600))
 
 	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
-	err := BuildColdIndex(context.Background(), []string{p}, idxPath, fixtureMinLedger(), fixtureMaxLedger())
+	err := BuildColdIndex(context.Background(), []string{p}, idxPath,
+		fixtureMinLedger(), fixtureMaxLedger())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "header claims")
 	assert.NoFileExists(t, idxPath)
@@ -404,7 +439,8 @@ func TestBuildColdIndex_HeaderOverflowRejected(t *testing.T) {
 	require.NoError(t, os.WriteFile(p, buf.Bytes(), 0o600))
 
 	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
-	err := BuildColdIndex(context.Background(), []string{p}, idxPath, fixtureMinLedger(), fixtureMaxLedger())
+	err := BuildColdIndex(context.Background(), []string{p}, idxPath,
+		fixtureMinLedger(), fixtureMaxLedger())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "header claims")
 	assert.NoFileExists(t, idxPath)
@@ -419,7 +455,8 @@ func TestBuildColdIndex_InputOrderIndependent(t *testing.T) {
 	require.Greater(t, len(inputs), 1)
 
 	forwardPath := filepath.Join(dir, "forward.idx")
-	require.NoError(t, BuildColdIndex(context.Background(), inputs, forwardPath, fixtureMinLedger(), fixtureMaxLedger()))
+	require.NoError(t, BuildColdIndex(context.Background(), inputs, forwardPath,
+		fixtureMinLedger(), fixtureMaxLedger()))
 
 	reversed := append([]string(nil), inputs...)
 	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
@@ -434,4 +471,44 @@ func TestBuildColdIndex_InputOrderIndependent(t *testing.T) {
 	reversedBytes, err := os.ReadFile(reversedPath)
 	require.NoError(t, err)
 	assert.Equal(t, forwardBytes, reversedBytes, "index must not depend on input file order")
+}
+
+// TestBuildColdIndex_CatalogSecretChangesRoutingNotResults: two master keys route
+// the same entries differently (different .idx bytes — the anti-grinding
+// property), while each keyed build→query round trip still resolves every
+// entry and rejects an unseen hash.
+func TestBuildColdIndex_CatalogSecretChangesRoutingNotResults(t *testing.T) {
+	dir := t.TempDir()
+	entries := makeFixtureEntries(200)
+
+	build := func(name string, catalogSecret []byte) string {
+		binDir := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		inputs := writeFixtureBinsKeyed(t, binDir, entries, ColdIndexSecret(catalogSecret, testIndexID))
+		idxPath := filepath.Join(dir, name+".idx")
+		require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath,
+			fixtureMinLedger(), fixtureMaxLedger()))
+		return idxPath
+	}
+	pathA := build("a", testCatalogSecret)
+	pathB := build("b", bytes.Repeat([]byte{0x5A}, 32))
+
+	bytesA, err := os.ReadFile(pathA)
+	require.NoError(t, err)
+	bytesB, err := os.ReadFile(pathB)
+	require.NoError(t, err)
+	assert.NotEqual(t, bytesA, bytesB, "a different master key must produce different routing")
+
+	for _, idxPath := range []string{pathA, pathB} {
+		r, err := OpenColdReader(idxPath)
+		require.NoError(t, err)
+		for _, e := range entries {
+			got, gerr := r.Get(e.hash)
+			require.NoError(t, gerr)
+			require.Equal(t, e.seq, got)
+		}
+		_, miss := r.Get(randHash(testRNG(0xabad1dea)))
+		require.ErrorIs(t, miss, stores.ErrNotFound)
+		require.NoError(t, r.Close())
+	}
 }

--- a/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_reader.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/txhash/cold_reader.go
@@ -22,6 +22,7 @@ import (
 // unmaps.
 type ColdReader struct {
 	idx       *streamhash.PayloadIndex
+	secret    [stores.SecretLen]byte
 	minLedger uint32
 	maxLedger uint32
 	closed    atomic.Bool
@@ -41,23 +42,25 @@ func OpenColdReader(path string) (*ColdReader, error) {
 		_ = idx.Close()
 		return nil, fmt.Errorf("txhash: cold index %s payload size %d, want %d", path, got, ColdPayloadSize)
 	}
-	minLedger, maxLedger, err := ParseLedgerRange(idx.UserMetadata())
+	minLedger, maxLedger, secret, err := ParseColdMetadata(idx.UserMetadata())
 	if err != nil {
 		_ = idx.Close()
 		return nil, fmt.Errorf("txhash: open cold index %s: %w", path, err)
 	}
-	return &ColdReader{idx: idx, minLedger: minLedger, maxLedger: maxLedger}, nil
+	return &ColdReader{idx: idx, secret: secret, minLedger: minLedger, maxLedger: maxLedger}, nil
 }
 
 // Get returns the ledgerSeq the hash was committed in, stores.ErrNotFound
 // if it wasn't in the build set (residual fingerprint false positives are
-// caught downstream), or stores.ErrStoreClosed after Close. streamhash keys on the first
-// 16 bytes, so the full 32-byte hash and hash[:16] are equivalent.
+// caught downstream), or stores.ErrStoreClosed after Close. The index keys on
+// the secret-keyed routing key of hash[:ColdKeySize] (see cold_format.go), so
+// the full 32-byte hash and hash[:16] are equivalent.
 func (r *ColdReader) Get(hash [32]byte) (uint32, error) {
 	if r.closed.Load() {
 		return 0, stores.ErrStoreClosed
 	}
-	_, payload, err := r.idx.QueryPayload(hash[:])
+	rk := stores.BlindKey(r.secret, hash[:ColdKeySize])
+	_, payload, err := r.idx.QueryPayload(rk[:])
 	if err != nil {
 		if errors.Is(err, streamhash.ErrNotFound) {
 			return 0, stores.ErrNotFound

--- a/cmd/stellar-rpc/internal/rpcv2/stores/txhash/read_assembly_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/txhash/read_assembly_test.go
@@ -157,7 +157,8 @@ func buildColdReader(t *testing.T, baseChunk chunk.ID, entries []fixtureEntry) *
 	}
 	inputs := writeFixtureBins(t, dir, entries)
 	idxPath := filepath.Join(dir, indexFileName(baseChunk))
-	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath, minSeq, maxSeq))
+	require.NoError(t, BuildColdIndex(
+		context.Background(), inputs, idxPath, minSeq, maxSeq))
 	rd, err := OpenColdReader(idxPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rd.Close() })

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,10 @@ require (
 	github.com/stretchr/testify v1.11.1
 )
 
-require go.uber.org/goleak v1.3.0
+require (
+	github.com/dchest/siphash v1.2.3
+	go.uber.org/goleak v1.3.0
+)
 
 require (
 	cel.dev/expr v0.25.0 // indirect
@@ -143,7 +146,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/crypto v0.52.0
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/mod v0.35.0
 	golang.org/x/net v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/siphash v1.2.3 h1:QXwFc8cFOR2dSa/gE6o/HokBMWtLUaNDVd+22aKHeEA=
+github.com/dchest/siphash v1.2.3/go.mod h1:0NvQU092bT0ipiFN++/rXm69QG9tVxLAlQHIXMPAkHc=
 github.com/djherbis/fscache v0.10.1 h1:hDv+RGyvD+UDKyRYuLoVNbuRTnf2SrA2K3VyR1br9lk=
 github.com/djherbis/fscache v0.10.1/go.mod h1:yyPYtkNnnPXsW+81lAcQS6yab3G2CRfnPLotBvtbf0c=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -443,8 +445,6 @@ github.com/spf13/viper v1.17.0 h1:I5txKw7MJasPL/BrfkbA0Jyo/oELqVmux4pR/UxOMfI=
 github.com/spf13/viper v1.17.0/go.mod h1:BmMMMLQXSbcHK6KAOiFLz0l5JHrU89OdIRHvsk0+yVI=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
-github.com/stellar/go-stellar-sdk v0.7.3-0.20260819053947-7cf218897cec h1:Qlvfsrx3pbdhDpkKvBQ8WWz3EK+6MU94ld5X6TsIw7w=
-github.com/stellar/go-stellar-sdk v0.7.3-0.20260819053947-7cf218897cec/go.mod h1:YTYl7/zFt7oIX5Y4WRgL+3d2upWQDLywlHunZ4fOxvc=
 github.com/stellar/go-stellar-sdk v0.7.4-0.20260825061852-f479ee9335f3 h1:UZH3dIn0PHPqF4ZkuZ6DkhVKtP7UmC0BXuFyInEtbwI=
 github.com/stellar/go-stellar-sdk v0.7.4-0.20260825061852-f479ee9335f3/go.mod h1:YTYl7/zFt7oIX5Y4WRgL+3d2upWQDLywlHunZ4fOxvc=
 github.com/stellar/go-xdr v0.0.0-20260806060815-dc590f17552a h1:40YIhQusSioBKDW5Tr+YdjoXphcVeu7eXUS2ibMQBTs=


### PR DESCRIPTION
## Summary

Both cold stores build streamhash MPHFs, and streamhash routes each key to a block via a public, **unkeyed** function of the key bytes. An attacker who influences indexed keys — event topics / contract IDs they emit, or transaction hashes — can grind keys into one block, exceed its per-block cap, and abort the chunk's cold-index build (`ErrBlockOverflow`). Routing is deterministic, so retries fail identically: a permanent backfill stall.

Fix: **blind** every key with `SipHash-2-4-128` under a per-index secret before it reaches streamhash, at build and query. Without the secret an attacker can't predict which block a key lands in.

## Secret handling

- The deployment's cold-index secret (`catalogSecret`) is **minted once and persisted in the catalog** (`Catalog.Secret`, get-or-create at open) — no operator config, no TOML key.
- Consumers **source it at point of use** from the catalog they already hold — it is not threaded through configs.
- Each index's secret is derived: `indexSecret = HKDF(catalogSecret, domain, indexID)`, domain-separated per store (`"txhash"` / `"events"`).
- The transform is `BlindKey(indexSecret, key)` (shared helper in the `stores` package, KAT-tested).

## Per store

- **txhash** — keys are blinded at **ingest** (when the `.bin` is written), so the existing streaming `SortedBuilder` build is untouched and same-node rebuilds stay **byte-identical**. The `.bin` header records the secret its keys were blinded with, and the index build **adopts** that secret (erroring if inputs disagree), so an index can never be built under a secret that mismatches its keys. The derived secret is stored in the index metadata.
- **events** — term keys are blinded at build with the chunk's deterministic per-index secret (`domain = "events"`), stored in the index metadata. Deterministic, so rebuilds are byte-identical.

## Notes

- The secret is **per-node** (each deployment mints its own), so index files are not byte-identical across nodes. This is intentional — it preserves the streaming `SortedBuilder` build; cross-node reproducibility is not needed for serving (see the thread discussion) and is a possible future opt-in via a normalization pass.
- **Overflow is non-retryable** at the residual (~1e-12) rate: the secret is deterministic, so a rebuild can't clear a natural overflow; recovery is operator-level.
- Keying adds **no per-key heap allocation** on the ingest hot path (verified via escape analysis); secrets are derived once per writer/build.
- Fingerprints, per store: **events** keeps its 4-byte `index.pack` fingerprint (and post-filter) on the **original** term bytes. **txhash** has only streamhash's 1-byte fingerprint, which — since txhash feeds streamhash the blinded key — covers the **blinded** bytes (equivalent detection power, blinding being deterministic per key); the downstream cold-hit check resolves against the **original** tx hash in the ledger, so a wrong index can only miss, never return a wrong answer.
- No backward compatibility (unreleased): a single fixed metadata format, no versioning.

## Test

Unit tests pass for `catalog`, `stores`, `stores/txhash`, `stores/event`, `ingest`, `backfill`, `query`, `lifecycle`, and the daemon suite. Build / vet / gofmt / golangci-lint all clean.
