### PR TITLE
perf-eval: fix per-eval for full-history

### DIFF
--- a/cmd/stellar-rpc/internal/jsonrpc/admin.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/admin.go
@@ -13,9 +13,17 @@ import (
 	"github.com/stellar/go-stellar-sdk/support/log"
 )
 
-// DefaultHTTPReadTimeout is the http.Server ReadTimeout both daemons use for
-// their serving and admin listeners.
-const DefaultHTTPReadTimeout = 5 * time.Second
+// DefaultHTTPReadTimeout and DefaultHTTPIdleTimeout are the http.Server
+// timeouts both daemons set on their serving and admin listeners.
+//
+// The idle timeout has to be set explicitly: when it is zero, net/http falls
+// back to ReadTimeout for idle keep-alive connections, so every pooled client
+// connection that sat idle for more than 5s got closed under it, and the
+// client's next request on that connection failed with EOF or a reset.
+const (
+	DefaultHTTPReadTimeout = 5 * time.Second
+	DefaultHTTPIdleTimeout = 2 * time.Minute
+)
 
 // NewAdminMux is the operator-facing mux both daemons serve on their admin
 // endpoint: the pprof handlers plus Prometheus /metrics over the given

--- a/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
@@ -40,6 +40,7 @@ import (
 
 const (
 	defaultShutdownGracePeriod = 10 * time.Second
+	defaultIdleTimeout         = 2 * time.Minute
 
 	// Since our default retention window will be 7 days (7*17,280 ledgers),
 	// choose a random 5-digit prime to have irregular logging intervals at each
@@ -402,6 +403,7 @@ func (d *Daemon) setupHTTPServers(cfg *config.Config) {
 	d.server = &http.Server{
 		Handler:     createHTTPHandler(d.logger, d.jsonRPCHandler),
 		ReadTimeout: jsonrpc.DefaultHTTPReadTimeout,
+		IdleTimeout: defaultIdleTimeout,
 	}
 
 	if cfg.AdminEndpoint != "" {

--- a/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
@@ -40,7 +40,6 @@ import (
 
 const (
 	defaultShutdownGracePeriod = 10 * time.Second
-	defaultIdleTimeout         = 2 * time.Minute
 
 	// Since our default retention window will be 7 days (7*17,280 ledgers),
 	// choose a random 5-digit prime to have irregular logging intervals at each
@@ -403,7 +402,7 @@ func (d *Daemon) setupHTTPServers(cfg *config.Config) {
 	d.server = &http.Server{
 		Handler:     createHTTPHandler(d.logger, d.jsonRPCHandler),
 		ReadTimeout: jsonrpc.DefaultHTTPReadTimeout,
-		IdleTimeout: defaultIdleTimeout,
+		IdleTimeout: jsonrpc.DefaultHTTPIdleTimeout,
 	}
 
 	if cfg.AdminEndpoint != "" {
@@ -425,7 +424,11 @@ func (d *Daemon) setupAdminServer(cfg *config.Config) {
 	if err != nil {
 		d.logger.WithError(err).WithField("endpoint", cfg.AdminEndpoint).Fatal("cannot listen on admin endpoint")
 	}
-	d.adminServer = &http.Server{Handler: adminMux} //nolint:gosec
+	d.adminServer = &http.Server{
+		Handler:     adminMux,
+		ReadTimeout: jsonrpc.DefaultHTTPReadTimeout,
+		IdleTimeout: jsonrpc.DefaultHTTPIdleTimeout,
+	}
 }
 
 // mustInitializeStorage initializes the storage using what was on the DB

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/backfill-test/runner/instantiate.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/backfill-test/runner/instantiate.go
@@ -258,7 +258,7 @@ func runBackfill(
 			fmt.Fprintln(os.Stderr, scanner.Text())
 		}
 		pr.Close()
-		_ = cmd.Wait() // reap; a kill from cancel surfaces here and is expected
+		logger.Infof("daemon exited: %v", cmd.Wait())
 	}()
 	daemon := &daemonHandle{cancel: cancel, done: done}
 	if !keepAlive {

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/backfill-test/runner/instantiate.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/backfill-test/runner/instantiate.go
@@ -4,11 +4,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -112,7 +114,7 @@ func instantiate(ctx context.Context) error {
 
 	if daemon != nil {
 		// hand the serving box off to the chained blaster leg
-		servePhase(ctx, daemon)
+		servePhase(ctx, daemon, cfg.Bucket, cfg.ResultKey)
 	}
 	return nil
 }
@@ -181,12 +183,15 @@ func renderConfig(repoRoot, workDir, coreCfg, retention, endpoint string) (strin
 
 // daemonHandle controls a daemon left running past its backfill phase.
 type daemonHandle struct {
-	cancel context.CancelFunc
-	done   chan struct{} // closed once the daemon is reaped
+	cancel   context.CancelFunc
+	done     chan struct{} // closed once the daemon is reaped
+	err      error         // cmd.Wait's result; valid once done is closed
+	stopping atomic.Bool   // set by Stop, so the reaper can tell a requested kill from a crash
 }
 
 // Stop kills the daemon and waits (bounded) for it to be reaped.
 func (d *daemonHandle) Stop() {
+	d.stopping.Store(true)
 	d.cancel()
 	select {
 	case <-d.done:
@@ -249,23 +254,35 @@ func runBackfill(
 		return 0, 0, 0, nil, fmt.Errorf("daemon exited or hit the %s deadline before backfill completed", deadline)
 	}
 
-	// keep draining the pipe (the daemon blocks on it once full) and teeing
-	// its catchup/ingestion output to the box log until it dies
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for scanner.Scan() {
-			fmt.Fprintln(os.Stderr, scanner.Text())
-		}
-		pr.Close()
-		logger.Infof("daemon exited: %v", cmd.Wait())
-	}()
-	daemon := &daemonHandle{cancel: cancel, done: done}
+	daemon := &daemonHandle{cancel: cancel, done: make(chan struct{})}
+	go daemon.reap(scanner, pr, cmd)
 	if !keepAlive {
 		daemon.Stop() // stop the daemon before it starts live ingestion
 		return elapsed, lo, hi, nil, nil
 	}
 	return elapsed, lo, hi, daemon, nil
+}
+
+// reap keeps draining the pipe (the daemon blocks on it once full), teeing its
+// catchup/ingestion output to the box log until it dies, then records how.
+func (d *daemonHandle) reap(scanner *bufio.Scanner, pr *os.File, cmd *exec.Cmd) {
+	defer close(d.done)
+	for scanner.Scan() {
+		fmt.Fprintln(os.Stderr, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		// a line over the scanner's cap must not stop the drain: closing the
+		// read end would SIGPIPE-kill a healthy daemon on its next write
+		logger.Warnf("reading daemon output: %v; draining the rest unbuffered", err)
+		_, _ = io.Copy(os.Stderr, pr)
+	}
+	pr.Close()
+	d.err = cmd.Wait()
+	if d.stopping.Load() {
+		logger.Infof("daemon stopped on request: %v", d.err)
+	} else {
+		logger.Warnf("daemon exited on its own: %v", d.err)
+	}
 }
 
 func renderMarkdown(sha, retention string, lo, hi, ingested int, elapsed time.Duration) string {

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/backfill-test/runner/serve.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/backfill-test/runner/serve.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
 	"os/exec"
 	"path"
 	"strings"
@@ -14,28 +15,39 @@ import (
 const (
 	rpcPort               = "8000"
 	serveSnapshotInterval = 2 * time.Minute
+	// snapshotTimeout bounds one box-log upload. Under the tick, so uploads
+	// never overlap and a stalled S3 path cannot keep the serve loop from
+	// noticing a daemon exit or the ceiling.
+	snapshotTimeout = time.Minute
+	// ceilingBackstopSlackMinutes keeps the OS poweroff behind the in-process
+	// ceiling, so the teardown defers (the final snapshot included) run first.
+	ceilingBackstopSlackMinutes = 2
 )
 
 type serveEnv struct {
-	Ceiling   time.Duration `env:"SERVE_CEILING" envDefault:"6h"`
-	Bucket    string        `env:"BUCKET"        envDefault:"stellar-rpc-ci-load-test"`
-	ResultKey string        `env:"RESULT_KEY"`
+	Ceiling time.Duration `env:"SERVE_CEILING" envDefault:"6h"`
 }
 
-// servePhase keeps the daemon available to the blaster leg.
-func servePhase(ctx context.Context, daemon *daemonHandle) {
+// servePhase keeps the daemon available to the blaster leg, snapshotting the
+// box log next to the result object until the box is terminated.
+func servePhase(ctx context.Context, daemon *daemonHandle, bucket, resultKey string) {
 	cfg, err := env.ParseAs[serveEnv]()
 	if err != nil {
 		logger.Warnf("parsing serve env: %v", err)
 		cfg.Ceiling = 6 * time.Hour
 	}
 
-	defer rescheduleShutdown(ctx, 1, "serve phase over")
-	defer snapshotBoxLog(context.WithoutCancel(ctx), cfg.Bucket, cfg.ResultKey)
+	// teardown outlives ctx: the final snapshot and the poweroff must run
+	// however the loop below exits
+	teardown := context.WithoutCancel(ctx)
+	defer rescheduleShutdown(teardown, 1, "serve phase over")
+	defer snapshotBoxLog(teardown, bucket, resultKey)
 	defer daemon.Stop()
 
-	rescheduleShutdown(ctx, int(cfg.Ceiling.Minutes()), "serve ceiling")
-	snapshotBoxLog(ctx, cfg.Bucket, cfg.ResultKey)
+	// the OS poweroff is only the safety net; the in-process ceiling fires first
+	backstop := int(math.Ceil(cfg.Ceiling.Minutes())) + ceilingBackstopSlackMinutes
+	rescheduleShutdown(ctx, backstop, "serve ceiling backstop")
+	snapshotBoxLog(ctx, bucket, resultKey)
 
 	logger.Infof("serving :%s until external termination (ceiling %s)", rpcPort, cfg.Ceiling)
 	ceiling := time.After(cfg.Ceiling)
@@ -49,11 +61,11 @@ func servePhase(ctx context.Context, daemon *daemonHandle) {
 			logger.Warnf("serve ceiling passed without external termination")
 			return
 		case <-daemon.done:
-			logger.Warnf("serving daemon exited")
-			dumpDmesgTail(ctx)
+			logger.Warnf("serving daemon exited: %v", daemon.err)
+			dumpDmesgTail(teardown)
 			return
 		case <-ticker.C:
-			snapshotBoxLog(ctx, cfg.Bucket, cfg.ResultKey)
+			snapshotBoxLog(ctx, bucket, resultKey)
 		}
 	}
 }
@@ -76,6 +88,8 @@ func snapshotBoxLog(ctx context.Context, bucket, key string) {
 	if bucket == "" || key == "" {
 		return
 	}
+	ctx, cancel := context.WithTimeout(ctx, snapshotTimeout)
+	defer cancel()
 	dst := fmt.Sprintf("s3://%s/%s/user-data-serving.log", bucket, path.Dir(key))
 	cmd := exec.CommandContext(ctx, "aws", "s3", "cp", "/var/log/user-data.log", dst)
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/backfill-test/runner/serve.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/backfill-test/runner/serve.go
@@ -5,46 +5,70 @@ import (
 	"fmt"
 	"os/exec"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/caarlos0/env/v11"
 )
 
-const rpcPort = "8000" // rpcPort is where the daemon serves, crosses VPC
+const (
+	rpcPort               = "8000"
+	serveSnapshotInterval = 2 * time.Minute
+)
 
-// serveEnv is the serve phase's env-derived config.
 type serveEnv struct {
 	Ceiling   time.Duration `env:"SERVE_CEILING" envDefault:"6h"`
-	Bucket    string        `env:"BUCKET"`
+	Bucket    string        `env:"BUCKET"        envDefault:"stellar-rpc-ci-load-test"`
 	ResultKey string        `env:"RESULT_KEY"`
 }
 
-// servePhase parks the box serving for the blaster leg, which gets this box's
-// IP through the coordinator. Termination is through other job's adopt cleanup.
+// servePhase keeps the daemon available to the blaster leg.
 func servePhase(ctx context.Context, daemon *daemonHandle) {
-	// on the backstop path the leg script's EXIT trap gets a minute to upload
-	// the box log before poweroff
-	defer rescheduleShutdown(ctx, 1, "serve phase over")
-	defer daemon.Stop()
-
 	cfg, err := env.ParseAs[serveEnv]()
 	if err != nil {
 		logger.Warnf("parsing serve env: %v", err)
 		cfg.Ceiling = 6 * time.Hour
 	}
 
-	// the boot-time self-terminate (budget+15m) can predate the blast's end
-	rescheduleShutdown(ctx, int(cfg.Ceiling.Minutes()), "serve ceiling")
+	defer rescheduleShutdown(ctx, 1, "serve phase over")
+	defer snapshotBoxLog(context.WithoutCancel(ctx), cfg.Bucket, cfg.ResultKey)
+	defer daemon.Stop()
 
-	// the happy-path hard kill skips the EXIT-trap upload, persist the log up to now
+	rescheduleShutdown(ctx, int(cfg.Ceiling.Minutes()), "serve ceiling")
 	snapshotBoxLog(ctx, cfg.Bucket, cfg.ResultKey)
 
 	logger.Infof("serving :%s until external termination (ceiling %s)", rpcPort, cfg.Ceiling)
-	select {
-	case <-ctx.Done():
-	case <-time.After(cfg.Ceiling):
-		logger.Warnf("serve ceiling passed without external termination") // backstops orphaned runs
+	ceiling := time.After(cfg.Ceiling)
+	ticker := time.NewTicker(serveSnapshotInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ceiling:
+			logger.Warnf("serve ceiling passed without external termination")
+			return
+		case <-daemon.done:
+			logger.Warnf("serving daemon exited")
+			dumpDmesgTail(ctx)
+			return
+		case <-ticker.C:
+			snapshotBoxLog(ctx, cfg.Bucket, cfg.ResultKey)
+		}
 	}
+}
+
+func dumpDmesgTail(ctx context.Context) {
+	out, err := exec.CommandContext(ctx, "dmesg").CombinedOutput()
+	if err != nil {
+		logger.Warnf("dumping dmesg tail: %v (%s)", err, out)
+		return
+	}
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	if len(lines) > 100 {
+		lines = lines[len(lines)-100:]
+	}
+	logger.Warnf("dmesg tail:\n%s", strings.Join(lines, "\n"))
 }
 
 // snapshotBoxLog copies the box log so far next to the result object.

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/go-bench/runner/instantiate.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/go-bench/runner/instantiate.go
@@ -11,7 +11,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -28,6 +28,16 @@ const legTitle = "Go endpoint benchmarks"
 var benchDenylist = []string{
 	"BenchmarkGetLedgerEntries", // is an integration test
 	"BenchmarkTransactionFetch", // is broken in current baseline release
+}
+
+var nativeLibRoots = []string{
+	"github.com/linxGnu/grocksdb",
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/zstd",
+}
+
+var v2Prefixes = []string{
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2",
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/rpcv2",
 }
 
 // instantiate is the instance half after the bootstrap, which runs the benches
@@ -74,17 +84,15 @@ func instantiate(ctx context.Context) error {
 		return bail("checking out baseline %s: %v", baselineRef, err)
 	}
 
-	for _, dir := range []string{baselineDir, repoRoot} {
-		logger.Infof("building rpc libs in %s", dir)
-		if err := harness.RunStreaming(ctx, dir, nil, 40, "make", "build-libs"); err != nil {
-			return bail("make build-libs failed in %s: %v", dir, err)
-		}
+	baselinePkgs, candidatePkgs, err := prepareSuites(ctx, baselineDir, repoRoot)
+	if err != nil {
+		return bail("%v", err)
 	}
 
 	logger.Infof("running audited benchmarks (count=%d) on baseline %s", count, baselineRef)
-	baselineFails := runSuite(ctx, baselineDir, baselineOut, count)
+	baselineFails := runSuite(ctx, baselineDir, baselineOut, count, baselinePkgs)
 	logger.Infof("running audited benchmarks (count=%d) on candidate %s", count, env["TARGET_SHA"])
-	candidateFails := runSuite(ctx, repoRoot, candidateOut, count)
+	candidateFails := runSuite(ctx, repoRoot, candidateOut, count, candidatePkgs)
 
 	logger.Infof("comparing with benchstat")
 	if err := runBenchstat(ctx, baselineOut, candidateOut, benchstatOut); err != nil {
@@ -128,6 +136,21 @@ func instantiate(ctx context.Context) error {
 	return nil
 }
 
+func prepareSuites(ctx context.Context, baselineDir, candidateDir string) ([]string, []string, error) {
+	pkgs := make([][]string, 2)
+	for i, dir := range []string{baselineDir, candidateDir} {
+		logger.Infof("building rpc libs in %s", dir)
+		if err := harness.RunStreaming(ctx, dir, nil, 40, "make", "build-libs"); err != nil {
+			return nil, nil, fmt.Errorf("make build-libs failed in %s: %w", dir, err)
+		}
+		var err error
+		if pkgs[i], err = benchPackages(ctx, dir); err != nil {
+			return nil, nil, err
+		}
+	}
+	return pkgs[0], pkgs[1], nil
+}
+
 // publishOK writes the bench metadata and publishes the ok result object.
 func publishOK(
 	ctx context.Context, client *s3.Client, r benchReport, env map[string]string, benchResults string,
@@ -166,20 +189,22 @@ func checkoutBaseline(ctx context.Context, dir, repo, ref string) (string, error
 	return strings.TrimSpace(string(out)), nil
 }
 
-// runSuite runs every benchmark in the module in dir except benchDenylist.
+// runSuite runs every benchmark of pkgs in dir except benchDenylist.
 // Only stderr (tool/compile errors, low-volume) streams to the log.
 // Returns the packages go test reported as failed (empty on success).
-func runSuite(ctx context.Context, dir, outFile string, count int) []string {
+func runSuite(ctx context.Context, dir, outFile string, count int, pkgs []string) []string {
 	f, err := os.OpenFile(outFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		logger.Warnf("opening %s: %v", outFile, err)
 		return []string{"<suite>"}
 	}
 	defer f.Close()
-	cmd := exec.CommandContext(ctx, "go", "test", "-run", "^$", "-bench", ".",
-		"-skip", "^("+strings.Join(benchDenylist, "|")+")$",
+	args := append([]string{
+		"test", "-run", "^$", "-bench", ".",
+		"-skip", "^(" + strings.Join(benchDenylist, "|") + ")$",
 		"-benchmem", "-count", strconv.Itoa(count), "-timeout", "30m",
-		"./...")
+	}, pkgs...)
+	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = dir
 	cmd.Stdout, cmd.Stderr = f, os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -191,6 +216,75 @@ func runSuite(ctx context.Context, dir, outFile string, count int) []string {
 		return failed
 	}
 	return nil
+}
+
+// benchPackages excludes rpcv2 and packages that need native libraries absent
+// from the benchmark box.
+func benchPackages(ctx context.Context, dir string) ([]string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "go", "list", "-test", "-json", "./...")
+	cmd.Dir = dir
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("go list -test in %s: %w (%s)", dir, err, strings.TrimSpace(stderr.String()))
+	}
+
+	all, excluded := map[string]bool{}, map[string]bool{}
+	decoder := json.NewDecoder(&stdout)
+	for {
+		var listed struct {
+			ImportPath string   `json:"importPath"`
+			ForTest    string   `json:"forTest"`
+			Deps       []string `json:"deps"`
+		}
+		if err := decoder.Decode(&listed); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("decoding go list output: %w", err)
+		}
+
+		pkg := listed.ImportPath
+		testPkg, isTestBinary := strings.CutSuffix(pkg, ".test")
+		switch {
+		case listed.ForTest != "":
+			pkg = listed.ForTest
+		case isTestBinary:
+			pkg = testPkg
+		default:
+			all[pkg] = true
+		}
+		if excludeFromBench(pkg, listed.Deps) {
+			excluded[pkg] = true
+		}
+	}
+
+	var kept, skipped []string
+	for pkg := range all {
+		if excluded[pkg] {
+			skipped = append(skipped, pkg)
+		} else {
+			kept = append(kept, pkg)
+		}
+	}
+	slices.Sort(kept)
+	slices.Sort(skipped)
+	logger.Infof("bench suite in %s: %d packages, %d excluded (v2 tree or native libs): %s",
+		dir, len(kept), len(skipped), strings.Join(skipped, ", "))
+	return kept, nil
+}
+
+func excludeFromBench(pkg string, deps []string) bool {
+	for _, prefix := range v2Prefixes {
+		if pkg == prefix || strings.HasPrefix(pkg, prefix+"/") {
+			return true
+		}
+	}
+	for _, root := range nativeLibRoots {
+		if pkg == root || slices.Contains(deps, root) {
+			return true
+		}
+	}
+	return false
 }
 
 // parseFailedPkgs scans a bench output file for go test's FAIL lines.
@@ -256,7 +350,7 @@ func uploadRawLogs(
 		}
 		uploaded = append(uploaded, name)
 	}
-	sort.Strings(uploaded)
+	slices.Sort(uploaded)
 	return uploaded
 }
 
@@ -278,7 +372,7 @@ type benchReport struct {
 func renderMarkdown(r benchReport) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "**Baseline** `%s` (`%s`) vs **candidate** `%s` — `-benchmem -count=%d`, "+
-		"both refs sequentially on one box.\n",
+		"both refs sequentially on one box; rpcv2 excluded.\n",
 		r.BaselineRef, r.BaselineSHA[:min(12, len(r.BaselineSHA))], r.TargetSHA[:min(12, len(r.TargetSHA))], r.Count)
 	for _, pkg := range r.CandidateFails {
 		fmt.Fprintf(&b, "\n❌ Candidate bench run failed in `%s`; see the box log.\n", pkg)

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/go-bench/runner/instantiate.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/go-bench/runner/instantiate.go
@@ -218,11 +218,13 @@ func runSuite(ctx context.Context, dir, outFile string, count int, pkgs []string
 	return nil
 }
 
-// benchPackages excludes rpcv2 and packages that need native libraries absent
-// from the benchmark box.
+// benchPackages lists the module's packages minus rpcv2 and anything needing
+// native libraries absent from the benchmark box. A package that fails to load
+// stays in (-e), so go test reports it as a per-package failure the way
+// `go test ./...` did, instead of the listing failing the whole leg.
 func benchPackages(ctx context.Context, dir string) ([]string, error) {
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "go", "list", "-test", "-json", "./...")
+	cmd := exec.CommandContext(ctx, "go", "list", "-e", "-test", "-json", "./...")
 	cmd.Dir = dir
 	cmd.Stdout, cmd.Stderr = &stdout, &stderr
 	if err := cmd.Run(); err != nil {
@@ -232,15 +234,18 @@ func benchPackages(ctx context.Context, dir string) ([]string, error) {
 	all, excluded := map[string]bool{}, map[string]bool{}
 	decoder := json.NewDecoder(&stdout)
 	for {
-		var listed struct {
-			ImportPath string   `json:"importPath"`
-			ForTest    string   `json:"forTest"`
-			Deps       []string `json:"deps"`
-		}
+		var listed goListPackage
 		if err := decoder.Decode(&listed); err == io.EOF {
 			break
 		} else if err != nil {
 			return nil, fmt.Errorf("decoding go list output: %w", err)
+		}
+		if listed.Incomplete {
+			reason := "a dependency failed to load"
+			if listed.Error != nil {
+				reason = listed.Error.Err
+			}
+			logger.Warnf("%s in %s did not load cleanly; go test will report it: %s", listed.ImportPath, dir, reason)
 		}
 
 		pkg := listed.ImportPath
@@ -271,6 +276,24 @@ func benchPackages(ctx context.Context, dir string) ([]string, error) {
 	logger.Infof("bench suite in %s: %d packages, %d excluded (v2 tree or native libs): %s",
 		dir, len(kept), len(skipped), strings.Join(skipped, ", "))
 	return kept, nil
+}
+
+// goListPackage is the subset of `go list -json` output benchPackages reads.
+// The tags spell go list's keys exactly, so decoding never depends on
+// encoding/json's case-insensitive fallback.
+//
+//nolint:tagliatelle // go list emits PascalCase keys
+type goListPackage struct {
+	ImportPath string          `json:"ImportPath"`
+	ForTest    string          `json:"ForTest"`
+	Deps       []string        `json:"Deps"`
+	Incomplete bool            `json:"Incomplete"`
+	Error      *goListPkgError `json:"Error"`
+}
+
+//nolint:tagliatelle // go list emits PascalCase keys
+type goListPkgError struct {
+	Err string `json:"Err"`
 }
 
 func excludeFromBench(pkg string, deps []string) bool {

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/go-bench/runner/instantiate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/infrastructure/perf-eval/go-bench/runner/instantiate_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExcludeFromBench(t *testing.T) {
+	const (
+		zstd     = "github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/zstd"
+		grocksdb = "github.com/linxGnu/grocksdb"
+	)
+	for _, tc := range []struct {
+		name string
+		pkg  string
+		deps []string
+		want bool
+	}{
+		{name: "rpcv2", pkg: zstd, want: true},
+		{name: "rpcv2 child", pkg: zstd + "/internal", want: true},
+		{name: "native dependency", pkg: "example.com/pkg", deps: []string{grocksdb}, want: true},
+		{name: "rpcv1", pkg: "github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv1"},
+		{name: "similar prefix", pkg: "github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2extra"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, excludeFromBench(tc.pkg, tc.deps))
+		})
+	}
+}

--- a/cmd/stellar-rpc/internal/rpcv2/serve.go
+++ b/cmd/stellar-rpc/internal/rpcv2/serve.go
@@ -35,7 +35,11 @@ func newServeReads(
 		p.ledgerReader = adapters.NewLedgerReader()
 		p.transactionReader = adapters.NewTransactionReader(p.networkPassphrase, p.metrics)
 		handler := newJSONRPCHandler(cfg, p)
-		server := &http.Server{Handler: handler, ReadTimeout: jsonrpc.DefaultHTTPReadTimeout}
+		server := &http.Server{
+			Handler:     handler,
+			ReadTimeout: jsonrpc.DefaultHTTPReadTimeout,
+			IdleTimeout: jsonrpc.DefaultHTTPIdleTimeout,
+		}
 
 		// Both exits close the server: on death this reaps established
 		// keep-alive conns Serve abandoned; after the graceful path's
@@ -79,7 +83,11 @@ func startAdminServer(
 	if err != nil {
 		return nil, fmt.Errorf("admin server listen on %q: %w", endpoint, err)
 	}
-	server := &http.Server{Handler: mux, ReadTimeout: jsonrpc.DefaultHTTPReadTimeout}
+	server := &http.Server{
+		Handler:     mux,
+		ReadTimeout: jsonrpc.DefaultHTTPReadTimeout,
+		IdleTimeout: jsonrpc.DefaultHTTPIdleTimeout,
+	}
 	go func() {
 		// Log-only on purpose, matching v1: a dead admin server (pprof,
 		// /metrics) must not take down a node that is still serving reads.


### PR DESCRIPTION
## Summary

- Exclude rpcv2 and native-library packages from go-bench on stock boxes.
- Upload backfill logs while serving and report early daemon exits.
- Set the rpcv1 HTTP idle timeout to 2 minutes to prevent keep-alive reuse failures.

## Validation
- [x] CI
- [x] Copilot Review  

Full coordinator runs: 
- [x]  [32521300483](https://github.com/stellar/stellar-rpc/actions/runs/32521300483)
- [x] [32538909114](https://github.com/stellar/stellar-rpc/actions/runs/32538909114)
- [x] [32763039473](https://github.com/stellar/stellar-rpc/actions/runs/32763039473)

## Note for Reviewer
* I added a comment for each changeset to mark the changes related to `feature/full-history` merge and the ones that were discovered during testing. 

Closes #944 