### PR TITLE
rpcv2: the getEvents term budget knob, and the EventScope rename

### DIFF
--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -128,7 +128,7 @@ type MethodsConfig struct {
 	GetTransaction  MethodConfig          `toml:"getTransaction"`
 	GetTransactions PaginatedMethodConfig `toml:"getTransactions"`
 	GetLedgers      PaginatedMethodConfig `toml:"getLedgers"`
-	GetEvents       PaginatedMethodConfig `toml:"getEvents"`
+	GetEvents       EventsMethodConfig    `toml:"getEvents"`
 	GetFeeStats     MethodConfig          `toml:"getFeeStats"`
 
 	// The three methods that read current ledger state through captive core
@@ -158,6 +158,24 @@ type PaginatedMethodConfig struct {
 
 	MaxItemsPerResponse     *uint `toml:"max_items_per_response"`
 	DefaultItemsPerResponse *uint `toml:"default_items_per_response"`
+}
+
+// EventsMethodConfig adds getEvents' own knobs such as term_budget
+// which are not for other methods. The decoder flattens the embedded
+// fields, keeping the method's TOML table flat.
+//
+// Known trade-off of embedding: the decoder also accepts the shared
+// keys through a table named after the embedded type, in any casing,
+// and strict mode cannot reject it. Accepted over duplicating the
+// fields: the config is trusted input, and nobody writes a Go type
+// name into TOML by hand.
+type EventsMethodConfig struct {
+	PaginatedMethodConfig
+
+	// TermBudget caps the distinct index terms one request may look
+	// up; over budget fails with the v2 invalid_params error. Must be
+	// >= 1: a zero budget would reject every filtered request.
+	TermBudget *uint `toml:"term_budget"`
 }
 
 // HealthMethodConfig extends MethodConfig for getHealth with the staleness
@@ -420,8 +438,13 @@ const (
 	//   - getLedgers is 20/5, not v1's 200/50 — the item here is a full
 	//     LedgerCloseMeta (megabytes each on a busy pubnet ledger), so v1's
 	//     200-item page could exceed a hundred MB of XDR in one response.
-	DefaultGetEventsMaxItemsPerResponse           uint = 1000
-	DefaultGetEventsDefaultItemsPerResponse       uint = 100
+	DefaultGetEventsMaxItemsPerResponse     uint = 1000
+	DefaultGetEventsDefaultItemsPerResponse uint = 100
+
+	// DefaultGetEventsTermBudget is the getEvents v2 proposal's default
+	// (github.com/orgs/stellar/discussions/1872).
+	DefaultGetEventsTermBudget uint = 15
+
 	DefaultGetTransactionsMaxItemsPerResponse     uint = 200
 	DefaultGetTransactionsDefaultItemsPerResponse uint = 50
 	DefaultGetLedgersMaxItemsPerResponse          uint = 20
@@ -619,6 +642,7 @@ func (cfg Config) WithDefaults() Config {
 	dur(&m.GetEvents.MaxExecutionDuration, DefaultScanMethodMaxExecutionDuration)
 	fillUint(&m.GetEvents.MaxItemsPerResponse, DefaultGetEventsMaxItemsPerResponse)
 	fillUint(&m.GetEvents.DefaultItemsPerResponse, DefaultGetEventsDefaultItemsPerResponse)
+	fillUint(&m.GetEvents.TermBudget, DefaultGetEventsTermBudget)
 
 	queue(&m.GetFeeStats.QueueLimit, DefaultGetFeeStatsQueueLimit)
 	dur(&m.GetFeeStats.MaxExecutionDuration, DefaultMethodMaxExecutionDuration)

--- a/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
@@ -225,6 +225,7 @@ func TestParseConfig_ServiceDefaults(t *testing.T) {
 
 	assert.Equal(t, DefaultGetEventsMaxItemsPerResponse, *m.GetEvents.MaxItemsPerResponse)
 	assert.Equal(t, DefaultGetEventsDefaultItemsPerResponse, *m.GetEvents.DefaultItemsPerResponse)
+	assert.Equal(t, DefaultGetEventsTermBudget, *m.GetEvents.TermBudget)
 	assert.Equal(t, DefaultGetTransactionsMaxItemsPerResponse, *m.GetTransactions.MaxItemsPerResponse)
 	assert.Equal(t, DefaultGetLedgersMaxItemsPerResponse, *m.GetLedgers.MaxItemsPerResponse)
 
@@ -540,4 +541,17 @@ func TestValidateRoots(t *testing.T) {
 		p.Events = "/data/ledgers/events"
 		require.NoError(t, p.ValidateRoots())
 	})
+}
+
+// TestEventsMethodConfig_TypeNameAlias documents a known, accepted
+// quirk of embedding PaginatedMethodConfig (see the struct doc): the
+// decoder also accepts the shared keys through a table named after
+// the embedded type, and strict mode cannot reject it. If this test
+// ever fails, the alias got closed: delete it and the doc note.
+func TestEventsMethodConfig_TypeNameAlias(t *testing.T) {
+	cfg, err := DecodeConfig([]byte(
+		"[service.methods.getEvents.PaginatedMethodConfig]\nqueue_limit = 3\n"))
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Service.Methods.GetEvents.QueueLimit)
+	assert.Equal(t, uint(3), *cfg.Service.Methods.GetEvents.QueueLimit)
 }

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags.go
@@ -231,6 +231,8 @@ func leafKind(t reflect.Type) kind {
 //     become a settable file key with no flag — the one way the file schema
 //     and the flag set could drift apart (see DataStoreConfig for the same
 //     concern with embedded SDK structs);
+//   - an untagged anonymous struct field recurses with the SAME
+//     prefix, matching the decoder's flattening of embedded structs;
 //   - a tagged struct field recurses with its tag as a path segment;
 //   - a tagged leaf of an unsupported type PANICS at BindFlags time — adding a
 //     config field of a new type must extend leafKind, not silently lose its flag.
@@ -242,6 +244,10 @@ func walkLeaves(v reflect.Value, prefix string, visit func(path string, f reflec
 			continue
 		}
 		tag := field.Tag.Get("toml")
+		if tag == "" && field.Anonymous && field.Type.Kind() == reflect.Struct {
+			walkLeaves(v.Field(i), prefix, visit)
+			continue
+		}
 		if tag == "" {
 			panic(fmt.Sprintf("config flags: exported field %s.%s has no toml tag — go-toml would "+
 				"accept it as a file key by field name, but it would get no flag; "+

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
@@ -275,6 +275,18 @@ captive_core_config = "/cc"
 		assert.Equal(t, DefaultGetFeeStatsQueueLimit, *m.GetFeeStats.QueueLimit, "tier 3: compiled default")
 	})
 
+	t.Run("term_budget is flag-settable and file-settable", func(t *testing.T) {
+		cfg := load(t, `
+[storage]
+default_data_dir = "/d"
+[service.methods.getEvents]
+term_budget = 20
+[ingestion]
+captive_core_config = "/cc"
+`, "--service.methods.getEvents.term_budget=30")
+		assert.Equal(t, uint(30), *cfg.Service.Methods.GetEvents.TermBudget, "CLI beats file")
+	})
+
 	t.Run("example D: durations cascade the same way", func(t *testing.T) {
 		cfg := load(t, `
 [storage]

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -283,6 +283,9 @@ func validateService(svc config.ServiceConfig) error {
 	if err := validatePaginatedMethods(m); err != nil {
 		return err
 	}
+	if err := validateEventsMethod(m.GetEvents); err != nil {
+		return err
+	}
 	if err := validatePreflight(svc.Preflight); err != nil {
 		return err
 	}
@@ -309,7 +312,7 @@ func validatePaginatedMethods(m config.MethodsConfig) error {
 	}{
 		{"getTransactions", m.GetTransactions},
 		{"getLedgers", m.GetLedgers},
-		{"getEvents", m.GetEvents},
+		{"getEvents", m.GetEvents.PaginatedMethodConfig},
 	}
 	for _, pp := range paginated {
 		if *pp.p.MaxItemsPerResponse < 1 {
@@ -322,6 +325,14 @@ func validatePaginatedMethods(m config.MethodsConfig) error {
 			return fmt.Errorf("[service.methods.%s].default_items_per_response (%d) cannot exceed max_items_per_response (%d)",
 				pp.name, *pp.p.DefaultItemsPerResponse, *pp.p.MaxItemsPerResponse)
 		}
+	}
+	return nil
+}
+
+// validateEventsMethod form-validates getEvents' v2 knobs.
+func validateEventsMethod(e config.EventsMethodConfig) error {
+	if *e.TermBudget < 1 {
+		return errors.New("[service.methods.getEvents].term_budget must be >= 1")
 	}
 	return nil
 }

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
@@ -184,6 +184,11 @@ func TestValidateConfig_RejectsMalformedService(t *testing.T) {
 			"default_items_per_response",
 		},
 		{
+			"zero term_budget",
+			func(c *config.Config) { c.Service.Methods.GetEvents.TermBudget = uintPtr(0) },
+			"[service.methods.getEvents].term_budget",
+		},
+		{
 			"fee window above the cap",
 			func(c *config.Config) { c.Service.FeeStats.ClassicFeeWindowLedgers = uint32Ptr(1001) },
 			"classic_fee_window_ledgers",

--- a/cmd/stellar-rpc/internal/rpcv2/events/concurrent_bitmaps.go
+++ b/cmd/stellar-rpc/internal/rpcv2/events/concurrent_bitmaps.go
@@ -107,7 +107,7 @@ func NewConcurrentBitmapsFromBitmaps(b Bitmaps) *ConcurrentBitmaps {
 // ≥2-input qualifier on FastAnd/FastOr: with a single input the
 // roaring library has historically taken a Clone-the-input
 // shortcut, so callers MUST avoid passing a singleton slice to
-// those aggregators (the event store's Query guards its single-input
+// those aggregators (the event store's Matches guards its single-input
 // cases before calling FastAnd/FastOr).
 //
 // Callers may hold the pointer arbitrarily long. A subsequent Get

--- a/cmd/stellar-rpc/internal/rpcv2/events/concurrent_ledgeroffsets.go
+++ b/cmd/stellar-rpc/internal/rpcv2/events/concurrent_ledgeroffsets.go
@@ -89,7 +89,7 @@ func (m *ConcurrentLedgerOffsets) EndLedger() uint32 {
 
 // View returns a *LedgerOffsets sharing the live backing array,
 // capped to the count visible at call time. Used by HotStore on
-// the query hot path: each Query allocates one View (~24 bytes:
+// the query hot path: each Matches call allocates one View (~24 bytes:
 // slice header + startLedger) instead of a 40KB deep copy of the
 // full backing array.
 //

--- a/cmd/stellar-rpc/internal/rpcv2/query/event_cursor.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/event_cursor.go
@@ -88,12 +88,12 @@ type EventPosition struct {
 	Ledger, Tx, Op, Event, LedgerOrdinal uint32
 }
 
-// EventCursorQuery is the canonical (engine) form of the original query the
+// EventScope is the canonical (engine) form of the original query the
 // cursor pins: ledger bounds, direction, and the engine's filters. A nil
 // MaxLedger is the proposal's open upper bound: an ascending query that
 // follows the chain tip across pages. Descending queries always carry one,
 // pinned at query start.
-type EventCursorQuery struct {
+type EventScope struct {
 	MinLedger uint32
 	MaxLedger *uint32
 	Dir       Direction
@@ -107,7 +107,7 @@ type EventCursorQuery struct {
 // resume starts just past the watermark. A present one is the mid-ledger
 // re-entry point.
 type EventCursor struct {
-	Scope         EventCursorQuery
+	Scope         EventScope
 	Position      *EventPosition
 	ScannedLedger uint32
 }

--- a/cmd/stellar-rpc/internal/rpcv2/query/event_cursor_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/event_cursor_test.go
@@ -50,14 +50,14 @@ func TestCursorRoundTrip(t *testing.T) {
 		{
 			name: "ascending unbounded (nil max), watermark-only, match-all",
 			env: EventCursor{
-				Scope:         EventCursorQuery{MinLedger: 100, Dir: Ascending},
+				Scope:         EventScope{MinLedger: 100, Dir: Ascending},
 				ScannedLedger: 175,
 			},
 		},
 		{
 			name: "ascending unbounded with position",
 			env: EventCursor{
-				Scope:         EventCursorQuery{MinLedger: 100, Dir: Ascending},
+				Scope:         EventScope{MinLedger: 100, Dir: Ascending},
 				Position:      &EventPosition{Ledger: 150, Tx: 3, Op: 1, Event: 2, LedgerOrdinal: 41},
 				ScannedLedger: 150,
 			},
@@ -65,7 +65,7 @@ func TestCursorRoundTrip(t *testing.T) {
 		{
 			name: "ascending bounded with position, zero filters (match-all)",
 			env: EventCursor{
-				Scope:         EventCursorQuery{MinLedger: 100, MaxLedger: maxPtr(200), Dir: Ascending},
+				Scope:         EventScope{MinLedger: 100, MaxLedger: maxPtr(200), Dir: Ascending},
 				Position:      &EventPosition{Ledger: 150, Tx: 3, Op: 1, Event: 2, LedgerOrdinal: 41},
 				ScannedLedger: 150,
 			},
@@ -74,14 +74,14 @@ func TestCursorRoundTrip(t *testing.T) {
 			// A present all-zero position must stay distinct from nil.
 			name: "all-zero position",
 			env: EventCursor{
-				Scope:    EventCursorQuery{MinLedger: 1, MaxLedger: maxPtr(2), Dir: Ascending},
+				Scope:    EventScope{MinLedger: 1, MaxLedger: maxPtr(2), Dir: Ascending},
 				Position: &EventPosition{},
 			},
 		},
 		{
 			name: "max uint32 field values",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: math.MaxUint32, MaxLedger: maxPtr(math.MaxUint32), Dir: Ascending,
 				},
 				Position: &EventPosition{
@@ -100,7 +100,7 @@ func TestCursorRoundTripFilters(t *testing.T) {
 		{
 			name: "descending with position, contract-only filter",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: 50, MaxLedger: maxPtr(900), Dir: Descending,
 					Filters: []event.Filter{{ContractID: testContract(0xC1)}},
 				},
@@ -111,7 +111,7 @@ func TestCursorRoundTripFilters(t *testing.T) {
 		{
 			name: "descending watermark-only, topics with gaps (t0 and t2 set)",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: 1, MaxLedger: maxPtr(10), Dir: Descending,
 					Filters: []event.Filter{{
 						Topics: [protocol.MaxTopicCount][]byte{testTopic(0xA0), nil, testTopic(0xA2), nil},
@@ -123,7 +123,7 @@ func TestCursorRoundTripFilters(t *testing.T) {
 		{
 			name: "full filter",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: 20002, MaxLedger: maxPtr(30001), Dir: Ascending,
 					Filters: []event.Filter{{
 						ContractID: testContract(0xC2),
@@ -141,7 +141,7 @@ func TestCursorRoundTripFilters(t *testing.T) {
 		{
 			name: "type-only filter and exact-count filter",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: 3, MaxLedger: maxPtr(9), Dir: Descending,
 					Filters: []event.Filter{
 						{EventType: eventTypePtr(xdr.ContractEventTypeSystem)},
@@ -155,7 +155,7 @@ func TestCursorRoundTripFilters(t *testing.T) {
 		{
 			name: "multiple filters including an empty match-all filter",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: 5, MaxLedger: maxPtr(6), Dir: Descending,
 					Filters: []event.Filter{
 						{ContractID: testContract(0xC3)},
@@ -202,7 +202,7 @@ func TestCursorGoldenV1(t *testing.T) {
 		{
 			name: "minimal: ascending unbounded, watermark-only, match-all",
 			env: EventCursor{
-				Scope:         EventCursorQuery{MinLedger: 100, Dir: Ascending},
+				Scope:         EventScope{MinLedger: 100, Dir: Ascending},
 				ScannedLedger: 175,
 			},
 			body: cat(
@@ -215,7 +215,7 @@ func TestCursorGoldenV1(t *testing.T) {
 		{
 			name: "full: descending, max, position, contract+topic1 filter",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: 1, MaxLedger: maxPtr(2), Dir: Descending,
 					Filters: []event.Filter{{
 						ContractID: testContract(0xC5),
@@ -241,7 +241,7 @@ func TestCursorGoldenV1(t *testing.T) {
 		{
 			name: "the #904 fields: system type, exactly-2 count, contract",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: 9, MaxLedger: maxPtr(10), Dir: Ascending,
 					Filters: []event.Filter{{
 						ContractID: testContract(0xC6),
@@ -401,7 +401,7 @@ func TestCursorMalformedInputs(t *testing.T) {
 
 func TestCursorEncodeDeterministic(t *testing.T) {
 	env := EventCursor{
-		Scope: EventCursorQuery{
+		Scope: EventScope{
 			MinLedger: 1, MaxLedger: maxPtr(1000), Dir: Descending,
 			Filters: []event.Filter{{
 				ContractID: testContract(0xC4),
@@ -428,20 +428,20 @@ func TestCursorEncodeRejects(t *testing.T) {
 	}{
 		{
 			name: "invalid direction",
-			env:  EventCursor{Scope: EventCursorQuery{MinLedger: 1, Dir: Direction(99)}},
+			env:  EventCursor{Scope: EventScope{MinLedger: 1, Dir: Direction(99)}},
 		},
 		{
 			name: "descending without max",
-			env:  EventCursor{Scope: EventCursorQuery{MinLedger: 1, Dir: Descending}},
+			env:  EventCursor{Scope: EventScope{MinLedger: 1, Dir: Descending}},
 		},
 		{
 			name: "min greater than max",
-			env:  EventCursor{Scope: EventCursorQuery{MinLedger: 3, MaxLedger: maxPtr(2), Dir: Ascending}},
+			env:  EventCursor{Scope: EventScope{MinLedger: 3, MaxLedger: maxPtr(2), Dir: Ascending}},
 		},
 		{
 			name: "bad contract length",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: 1, Dir: Ascending,
 					Filters: []event.Filter{{ContractID: bytes.Repeat([]byte{1}, 31)}},
 				},
@@ -450,7 +450,7 @@ func TestCursorEncodeRejects(t *testing.T) {
 		{
 			name: "too many filters",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: 1, Dir: Ascending,
 					Filters: make([]event.Filter, maxCursorFilters+1),
 				},
@@ -461,7 +461,7 @@ func TestCursorEncodeRejects(t *testing.T) {
 			// oversized topic.
 			name: "oversized output",
 			env: EventCursor{
-				Scope: EventCursorQuery{
+				Scope: EventScope{
 					MinLedger: 1, Dir: Ascending,
 					Filters: []event.Filter{{
 						Topics: [protocol.MaxTopicCount][]byte{bytes.Repeat([]byte{7}, maxCursorBytes)},
@@ -493,7 +493,7 @@ func TestCursorSizeWorstCase(t *testing.T) {
 		filters[i].TopicCount = event.TopicCountFilter{Count: protocol.MaxTopicCount, Exact: true}
 	}
 	env := EventCursor{
-		Scope: EventCursorQuery{
+		Scope: EventScope{
 			MinLedger: 1, MaxLedger: maxPtr(math.MaxUint32), Dir: Ascending, Filters: filters,
 		},
 		Position: &EventPosition{
@@ -523,7 +523,7 @@ func TestCursorCodecCoversFilter(t *testing.T) {
 // wire cannot represent them: a set topic bit must carry a nonzero length.
 func TestCursorEmptyValuesEncodeAsAbsent(t *testing.T) {
 	withEmpty := EventCursor{
-		Scope: EventCursorQuery{
+		Scope: EventScope{
 			MinLedger: 1, MaxLedger: maxPtr(2), Dir: Ascending,
 			Filters: []event.Filter{{
 				ContractID: []byte{},
@@ -532,7 +532,7 @@ func TestCursorEmptyValuesEncodeAsAbsent(t *testing.T) {
 		},
 	}
 	withNil := EventCursor{
-		Scope: EventCursorQuery{
+		Scope: EventScope{
 			MinLedger: 1, MaxLedger: maxPtr(2), Dir: Ascending,
 			Filters: []event.Filter{{}},
 		},
@@ -549,7 +549,7 @@ func TestCursorEmptyValuesEncodeAsAbsent(t *testing.T) {
 // exact input bytes — one envelope, one encoding, no exceptions.
 func FuzzDecodeEventCursor(f *testing.F) {
 	valid := EventCursor{
-		Scope: EventCursorQuery{
+		Scope: EventScope{
 			MinLedger: 1, MaxLedger: maxPtr(2), Dir: Ascending,
 			Filters: []event.Filter{{ContractID: testContract(0xC0)}},
 		},
@@ -560,7 +560,7 @@ func FuzzDecodeEventCursor(f *testing.F) {
 	if err != nil {
 		f.Fatal(err)
 	}
-	unbounded := EventCursor{Scope: EventCursorQuery{MinLedger: 9, Dir: Ascending}}
+	unbounded := EventCursor{Scope: EventScope{MinLedger: 9, Dir: Ascending}}
 	seed2, err := unbounded.Encode()
 	if err != nil {
 		f.Fatal(err)

--- a/cmd/stellar-rpc/internal/rpcv2/query/event_page.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/event_page.go
@@ -138,7 +138,7 @@ func validateCursor(cursor *EventCursor, limit int) error {
 }
 
 // validateScope rejects scope shapes the server never mints.
-func validateScope(scope *EventCursorQuery) error {
+func validateScope(scope *EventScope) error {
 	switch scope.Dir {
 	case Ascending:
 	case Descending:
@@ -510,7 +510,7 @@ func watermark(cursor *EventCursor, walk walkResult, clo, chi uint32, desc bool)
 // terminalStatus classifies a walk that finished its clamped window:
 // either the scope's own bound was reached (complete), or the walk
 // stopped at the edge of the node's serving range [oldest, latest].
-func terminalStatus(scope *EventCursorQuery, desc bool, oldest, latest uint32) ScanStatus {
+func terminalStatus(scope *EventScope, desc bool, oldest, latest uint32) ScanStatus {
 	if desc {
 		if scope.MinLedger >= oldest {
 			return ScanComplete

--- a/cmd/stellar-rpc/internal/rpcv2/query/event_page_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/event_page_test.go
@@ -208,7 +208,7 @@ func TestQueryEvents_SinglePageComplete(t *testing.T) {
 	maxL := f + 3
 	d := &pageDriver{
 		t: t, r: r, limit: 10,
-		cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f, MaxLedger: &maxL}},
+		cursor: EventCursor{Scope: EventScope{MinLedger: f, MaxLedger: &maxL}},
 	}
 	page := d.next()
 	assert.Equal(t, []string{"a0", "a1", "b0", "a2", "b1", "a3"}, labels(t, page.Events))
@@ -232,7 +232,7 @@ func TestQueryEvents_PagingSeamMatrix(t *testing.T) {
 			t.Run(fmt.Sprintf("dir=%d/limit=%d", dir, limit), func(t *testing.T) {
 				d := &pageDriver{
 					t: t, r: r, limit: limit,
-					cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f, MaxLedger: &maxL, Dir: dir}},
+					cursor: EventCursor{Scope: EventScope{MinLedger: f, MaxLedger: &maxL, Dir: dir}},
 				}
 				got, status := d.drain()
 				want := asc
@@ -255,7 +255,7 @@ func TestQueryEvents_FilteredMidLedgerResume(t *testing.T) {
 	maxL := f + 3
 	d := &pageDriver{
 		t: t, r: r, limit: 2,
-		cursor: EventCursor{Scope: EventCursorQuery{
+		cursor: EventCursor{Scope: EventScope{
 			MinLedger: f, MaxLedger: &maxL,
 			Filters: []event.Filter{{ContractID: cidA[:]}},
 		}},
@@ -281,7 +281,7 @@ func TestQueryEvents_DescendingFilteredMidLedgerResume(t *testing.T) {
 	maxL := f + 3
 	d := &pageDriver{
 		t: t, r: r, limit: 3,
-		cursor: EventCursor{Scope: EventCursorQuery{
+		cursor: EventCursor{Scope: EventScope{
 			MinLedger: f, MaxLedger: &maxL, Dir: Descending,
 			Filters: []event.Filter{{ContractID: cidA[:]}},
 		}},
@@ -320,7 +320,7 @@ func TestQueryEvents_ChunkSeamFullChunk(t *testing.T) {
 			t.Run(fmt.Sprintf("walk/dir=%d/limit=%d", tc.dir, limit), func(t *testing.T) {
 				d := &pageDriver{
 					t: t, r: r, limit: limit,
-					cursor: EventCursor{Scope: EventCursorQuery{MinLedger: lo, MaxLedger: &maxL, Dir: tc.dir}},
+					cursor: EventCursor{Scope: EventScope{MinLedger: lo, MaxLedger: &maxL, Dir: tc.dir}},
 				}
 				got, status := d.drain()
 				assert.Equal(t, tc.want, got)
@@ -334,7 +334,7 @@ func TestQueryEvents_ChunkSeamFullChunk(t *testing.T) {
 	t.Run("resume at the seam", func(t *testing.T) {
 		d := &pageDriver{
 			t: t, r: r, limit: 4,
-			cursor: EventCursor{Scope: EventCursorQuery{MinLedger: lo, MaxLedger: &maxL}},
+			cursor: EventCursor{Scope: EventScope{MinLedger: lo, MaxLedger: &maxL}},
 		}
 		page := d.next()
 		assert.Equal(t, []string{"x0", "x1", "y0", "x2"}, labels(t, page.Events),
@@ -359,7 +359,7 @@ func TestQueryEvents_ChunkSeamFullChunk(t *testing.T) {
 			{symEvent(cidA, "x4")},
 		}})
 		d := &pageDriver{t: t, r: shallow, limit: 10, cursor: EventCursor{
-			Scope: EventCursorQuery{MinLedger: lo, MaxLedger: &maxL, Dir: Descending},
+			Scope: EventScope{MinLedger: lo, MaxLedger: &maxL, Dir: Descending},
 		}}
 		page := d.next()
 		assert.Equal(t, []string{"x4", "y1", "x3"}, labels(t, page.Events))
@@ -389,7 +389,7 @@ func TestQueryEvents_UncoveredWindowFailsLoud(t *testing.T) {
 	require.NoError(t, err)
 	defer a.Release()
 	_, err = a.QueryEvents(context.Background(),
-		EventCursor{Scope: EventCursorQuery{MinLedger: f}}, 10)
+		EventCursor{Scope: EventScope{MinLedger: f}}, 10)
 	require.ErrorContains(t, err, "offsets cover")
 
 	// Head side: ingest enforces chunk-aligned starts, so this state
@@ -409,7 +409,7 @@ func TestQueryEvents_UncoveredWindowFailsLoud(t *testing.T) {
 // delivers exactly the newly committed events.
 func TestQueryEvents_FollowsTheTip(t *testing.T) {
 	r, db, f := singleChunkFixture(t)
-	d := &pageDriver{t: t, r: r, limit: 10, cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f}}}
+	d := &pageDriver{t: t, r: r, limit: 10, cursor: EventCursor{Scope: EventScope{MinLedger: f}}}
 
 	page := d.next()
 	assert.Len(t, page.Events, 6)
@@ -433,7 +433,7 @@ func TestQueryEvents_WatermarkOnlyResume(t *testing.T) {
 	r, db, f := singleChunkFixture(t)
 	d := &pageDriver{
 		t: t, r: r, limit: 10,
-		cursor: EventCursor{Scope: EventCursorQuery{
+		cursor: EventCursor{Scope: EventScope{
 			MinLedger: f,
 			Filters:   []event.Filter{{ContractID: cidC[:]}},
 		}},
@@ -458,7 +458,7 @@ func TestQueryEvents_BoundBeyondLatestWaits(t *testing.T) {
 	maxL := f + 10 // beyond latest (f+3)
 	d := &pageDriver{
 		t: t, r: r, limit: 10,
-		cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f, MaxLedger: &maxL}},
+		cursor: EventCursor{Scope: EventScope{MinLedger: f, MaxLedger: &maxL}},
 	}
 	page := d.next()
 	assert.Len(t, page.Events, 6)
@@ -470,7 +470,7 @@ func TestQueryEvents_MinLedgerBeyondLatestIsEmptyWait(t *testing.T) {
 	r, _, f := singleChunkFixture(t)
 	d := &pageDriver{
 		t: t, r: r, limit: 10,
-		cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f + 100}},
+		cursor: EventCursor{Scope: EventScope{MinLedger: f + 100}},
 	}
 	page := d.next()
 	assert.Empty(t, page.Events)
@@ -483,7 +483,7 @@ func TestQueryEvents_OldestReachedDescending(t *testing.T) {
 	maxL := f + 3
 	d := &pageDriver{
 		t: t, r: r, limit: 10,
-		cursor: EventCursor{Scope: EventCursorQuery{MinLedger: 2, MaxLedger: &maxL, Dir: Descending}},
+		cursor: EventCursor{Scope: EventScope{MinLedger: 2, MaxLedger: &maxL, Dir: Descending}},
 	}
 	page := d.next()
 	assert.Len(t, page.Events, 6)
@@ -512,14 +512,14 @@ func TestQueryEvents_BelowFloorByDirection(t *testing.T) {
 
 	// Fresh ascending query starting below the floor.
 	_, err = a.QueryEvents(context.Background(),
-		EventCursor{Scope: EventCursorQuery{MinLedger: 2}}, 10)
+		EventCursor{Scope: EventScope{MinLedger: 2}}, 10)
 	var re *RangeError
 	require.ErrorAs(t, err, &re)
 
 	// Fresh descending scope entirely below the floor: legal and empty.
 	lowMax := f - 1
 	page, err := a.QueryEvents(context.Background(), EventCursor{
-		Scope: EventCursorQuery{MinLedger: 2, MaxLedger: &lowMax, Dir: Descending},
+		Scope: EventScope{MinLedger: 2, MaxLedger: &lowMax, Dir: Descending},
 	}, 10)
 	require.NoError(t, err)
 	assert.Empty(t, page.Events)
@@ -529,7 +529,7 @@ func TestQueryEvents_BelowFloorByDirection(t *testing.T) {
 	// same empty OldestReached page, not an error.
 	maxL := f + 3
 	cur := EventCursor{
-		Scope:         EventCursorQuery{MinLedger: 2, MaxLedger: &maxL, Dir: Descending},
+		Scope:         EventScope{MinLedger: 2, MaxLedger: &maxL, Dir: Descending},
 		ScannedLedger: f,
 	}
 	page, err = a.QueryEvents(context.Background(), cur, 10)
@@ -549,7 +549,7 @@ func TestQueryEvents_ConsumedRangeCompletes(t *testing.T) {
 	defer a.Release()
 	maxL := f + 3
 	page, err := a.QueryEvents(context.Background(), EventCursor{
-		Scope:         EventCursorQuery{MinLedger: f, MaxLedger: &maxL},
+		Scope:         EventScope{MinLedger: f, MaxLedger: &maxL},
 		ScannedLedger: f + 3,
 	}, 10)
 	require.NoError(t, err)
@@ -565,7 +565,7 @@ func TestQueryEvents_ConsumedRangeCompletes(t *testing.T) {
 // identically while newly committed ones are visited exactly once.
 func TestQueryEvents_EndStabilityAcrossIngest(t *testing.T) {
 	r, db, f := singleChunkFixture(t)
-	d := &pageDriver{t: t, r: r, limit: 2, cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f}}}
+	d := &pageDriver{t: t, r: r, limit: 2, cursor: EventCursor{Scope: EventScope{MinLedger: f}}}
 
 	page := d.next()
 	assert.Equal(t, []string{"a0", "a1"}, labels(t, page.Events))
@@ -605,7 +605,7 @@ func TestQueryEvents_DescendingResumeAboveLatestWaits(t *testing.T) {
 	maxL := f + 5
 	d := &pageDriver{
 		t: t, r: r, limit: 1,
-		cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f, MaxLedger: &maxL, Dir: Descending}},
+		cursor: EventCursor{Scope: EventScope{MinLedger: f, MaxLedger: &maxL, Dir: Descending}},
 	}
 	page := d.next()
 	require.Equal(t, []string{"a4"}, labels(t, page.Events))
@@ -636,7 +636,7 @@ func TestQueryEvents_ScanBudget(t *testing.T) {
 	maxL := f + 3
 
 	// Match-nothing filter: two windows cover the scope, no events.
-	d := &pageDriver{t: t, r: r, limit: 10, cursor: EventCursor{Scope: EventCursorQuery{
+	d := &pageDriver{t: t, r: r, limit: 10, cursor: EventCursor{Scope: EventScope{
 		MinLedger: f, MaxLedger: &maxL,
 		Filters: []event.Filter{{ContractID: cidC[:]}},
 	}}}
@@ -650,7 +650,7 @@ func TestQueryEvents_ScanBudget(t *testing.T) {
 	assert.Equal(t, f+3, page.Next.ScannedLedger)
 
 	// Match-all descending: the windows walk down without gaps.
-	d = &pageDriver{t: t, r: r, limit: 10, cursor: EventCursor{Scope: EventCursorQuery{
+	d = &pageDriver{t: t, r: r, limit: 10, cursor: EventCursor{Scope: EventScope{
 		MinLedger: f, MaxLedger: &maxL, Dir: Descending,
 	}}}
 	all, status := d.drain()
@@ -672,7 +672,7 @@ func TestQueryEvents_OpensOnlyScannedChunks(t *testing.T) {
 	}})
 	maxL := f6 + 1
 	d := &pageDriver{t: t, r: r, limit: 1, cursor: EventCursor{
-		Scope: EventCursorQuery{MinLedger: f5, MaxLedger: &maxL, Dir: Descending},
+		Scope: EventScope{MinLedger: f5, MaxLedger: &maxL, Dir: Descending},
 	}}
 
 	got := make([]string, 0, 3)
@@ -697,7 +697,7 @@ func TestQueryEvents_DescendingWatermarkAboveLatestWaits(t *testing.T) {
 	defer a.Release()
 	maxL := f + 8
 	page, err := a.QueryEvents(context.Background(), EventCursor{
-		Scope:         EventCursorQuery{MinLedger: f, MaxLedger: &maxL, Dir: Descending},
+		Scope:         EventScope{MinLedger: f, MaxLedger: &maxL, Dir: Descending},
 		ScannedLedger: f + 6,
 	}, 10)
 	require.NoError(t, err)
@@ -716,7 +716,7 @@ func TestQueryEvents_DescendingFreshScopeAboveLatestWaits(t *testing.T) {
 	r, db, f := singleChunkFixture(t) // latest = f+3
 	maxL := f + 5
 	d := &pageDriver{t: t, r: r, limit: 10, cursor: EventCursor{
-		Scope: EventCursorQuery{MinLedger: f, MaxLedger: &maxL, Dir: Descending},
+		Scope: EventScope{MinLedger: f, MaxLedger: &maxL, Dir: Descending},
 	}}
 	page := d.next()
 	assert.Empty(t, page.Events)
@@ -743,7 +743,7 @@ func TestQueryEvents_WatermarkStaysInsideWindow(t *testing.T) {
 	// fully covered, so the fresh cursor's zero watermark is kept.
 	d := &pageDriver{
 		t: t, r: r, limit: 1,
-		cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f, MaxLedger: &maxL, Dir: Descending}},
+		cursor: EventCursor{Scope: EventScope{MinLedger: f, MaxLedger: &maxL, Dir: Descending}},
 	}
 	page := d.next()
 	assert.Equal(t, []string{"a3"}, labels(t, page.Events))
@@ -752,7 +752,7 @@ func TestQueryEvents_WatermarkStaysInsideWindow(t *testing.T) {
 	// Descending, page fills after draining all of ledger f+3: covered.
 	d = &pageDriver{
 		t: t, r: r, limit: 2,
-		cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f, MaxLedger: &maxL, Dir: Descending}},
+		cursor: EventCursor{Scope: EventScope{MinLedger: f, MaxLedger: &maxL, Dir: Descending}},
 	}
 	page = d.next()
 	assert.Equal(t, []string{"a3", "b1"}, labels(t, page.Events))
@@ -764,7 +764,7 @@ func TestQueryEvents_WatermarkStaysInsideWindow(t *testing.T) {
 	// MinLedger.
 	d = &pageDriver{
 		t: t, r: r, limit: 1,
-		cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f, MaxLedger: &maxL}},
+		cursor: EventCursor{Scope: EventScope{MinLedger: f, MaxLedger: &maxL}},
 	}
 	page = d.next()
 	assert.Equal(t, []string{"a0"}, labels(t, page.Events))
@@ -779,7 +779,7 @@ func TestQueryEvents_WatermarkStaysInsideWindow(t *testing.T) {
 // chunk-relative slot arithmetic is pinned too.
 func TestQueryEvents_ResumeMismatchFailsLoud(t *testing.T) {
 	r, _, f := singleChunkFixture(t)
-	d := &pageDriver{t: t, r: r, limit: 5, cursor: EventCursor{Scope: EventCursorQuery{MinLedger: f}}}
+	d := &pageDriver{t: t, r: r, limit: 5, cursor: EventCursor{Scope: EventScope{MinLedger: f}}}
 	page := d.next()
 	require.Equal(t, []string{"a0", "a1", "b0", "a2", "b1"}, labels(t, page.Events))
 	require.Equal(t, uint32(0), page.Next.Position.LedgerOrdinal, "b1 opens ledger f+3")
@@ -801,7 +801,7 @@ func TestQueryEvents_ResumeMismatchFailsLoud(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			bad := corrupt(*page.Next.Position)
 			d2 := &pageDriver{t: t, r: r, limit: 5, cursor: EventCursor{
-				Scope:         EventCursorQuery{MinLedger: f},
+				Scope:         EventScope{MinLedger: f},
 				Position:      &bad,
 				ScannedLedger: page.Next.ScannedLedger,
 			}}
@@ -824,34 +824,34 @@ func TestQueryEvents_CursorValidation(t *testing.T) {
 		limit   int
 		wantErr error // the handler maps on these sentinels
 	}{
-		"zero limit":        {EventCursor{Scope: EventCursorQuery{MinLedger: f}}, 0, ErrInvalidLimit},
-		"negative limit":    {EventCursor{Scope: EventCursorQuery{MinLedger: f}}, -3, ErrInvalidLimit},
-		"descending no max": {EventCursor{Scope: EventCursorQuery{MinLedger: f, Dir: Descending}}, 1, ErrCursorMalformed},
-		"invalid direction": {EventCursor{Scope: EventCursorQuery{MinLedger: f, Dir: Direction(9)}}, 1, ErrCursorMalformed},
+		"zero limit":        {EventCursor{Scope: EventScope{MinLedger: f}}, 0, ErrInvalidLimit},
+		"negative limit":    {EventCursor{Scope: EventScope{MinLedger: f}}, -3, ErrInvalidLimit},
+		"descending no max": {EventCursor{Scope: EventScope{MinLedger: f, Dir: Descending}}, 1, ErrCursorMalformed},
+		"invalid direction": {EventCursor{Scope: EventScope{MinLedger: f, Dir: Direction(9)}}, 1, ErrCursorMalformed},
 		"min above max": {
-			EventCursor{Scope: EventCursorQuery{MinLedger: minAboveMax, MaxLedger: &maxL}},
+			EventCursor{Scope: EventScope{MinLedger: minAboveMax, MaxLedger: &maxL}},
 			1, ErrInvertedRange,
 		},
 		"min below genesis": {
-			EventCursor{Scope: EventCursorQuery{MinLedger: chunk.FirstLedgerSeq - 1}},
+			EventCursor{Scope: EventScope{MinLedger: chunk.FirstLedgerSeq - 1}},
 			1, ErrCursorMalformed,
 		},
 		// The server mints scope and bookmarks together, so a bookmark
 		// outside the scope's own bounds is forged or corrupt.
 		"position below min": {EventCursor{
-			Scope:    EventCursorQuery{MinLedger: f},
+			Scope:    EventScope{MinLedger: f},
 			Position: &EventPosition{Ledger: f - 1},
 		}, 1, ErrCursorMalformed},
 		"position above max": {EventCursor{
-			Scope:    EventCursorQuery{MinLedger: f, MaxLedger: &maxL},
+			Scope:    EventScope{MinLedger: f, MaxLedger: &maxL},
 			Position: &EventPosition{Ledger: maxL + 1},
 		}, 1, ErrCursorMalformed},
 		"watermark above max": {EventCursor{
-			Scope:         EventCursorQuery{MinLedger: f, MaxLedger: &maxL},
+			Scope:         EventScope{MinLedger: f, MaxLedger: &maxL},
 			ScannedLedger: maxL + 1,
 		}, 1, ErrCursorMalformed},
 		"watermark below min": {EventCursor{
-			Scope:         EventCursorQuery{MinLedger: f},
+			Scope:         EventScope{MinLedger: f},
 			ScannedLedger: f - 1,
 		}, 1, ErrCursorMalformed},
 		// The pair must also be mintable together: a present position
@@ -859,32 +859,32 @@ func TestQueryEvents_CursorValidation(t *testing.T) {
 		// at the zero-watermark anchor), since assemblePage drops a
 		// passed one. Any other pair is forged.
 		"position behind watermark ascending": {EventCursor{
-			Scope:         EventCursorQuery{MinLedger: f},
+			Scope:         EventScope{MinLedger: f},
 			Position:      &EventPosition{Ledger: f},
 			ScannedLedger: f + 1,
 		}, 1, ErrCursorMalformed},
 		"position ahead of watermark": {EventCursor{
-			Scope:         EventCursorQuery{MinLedger: f},
+			Scope:         EventScope{MinLedger: f},
 			Position:      &EventPosition{Ledger: f + 2},
 			ScannedLedger: f,
 		}, 1, ErrCursorMalformed},
 		"position with zero watermark off the scope start": {EventCursor{
-			Scope:    EventCursorQuery{MinLedger: f},
+			Scope:    EventScope{MinLedger: f},
 			Position: &EventPosition{Ledger: f + 1},
 		}, 1, ErrCursorMalformed},
 		"position behind watermark descending": {EventCursor{
-			Scope:         EventCursorQuery{MinLedger: f, MaxLedger: &maxHigh, Dir: Descending},
+			Scope:         EventScope{MinLedger: f, MaxLedger: &maxHigh, Dir: Descending},
 			Position:      &EventPosition{Ledger: f},
 			ScannedLedger: f + 2,
 		}, 1, ErrCursorMalformed},
 		"position with zero watermark off the scope top descending": {EventCursor{
-			Scope:    EventCursorQuery{MinLedger: f, MaxLedger: &maxHigh, Dir: Descending},
+			Scope:    EventScope{MinLedger: f, MaxLedger: &maxHigh, Dir: Descending},
 			Position: &EventPosition{Ledger: f + 1},
 		}, 1, ErrCursorMalformed},
 		// A scope above the codec's filter cap would do the page's work
 		// and then fail to encode the advanced cursor: refused up front.
 		"more filters than the codec cap": {EventCursor{
-			Scope: EventCursorQuery{
+			Scope: EventScope{
 				MinLedger: f,
 				Filters:   make([]event.Filter, maxCursorFilters+1),
 			},
@@ -892,13 +892,13 @@ func TestQueryEvents_CursorValidation(t *testing.T) {
 		// Malformed filters fail up front, even on a range this view
 		// would not scan (beyond latest).
 		"malformed filter on an unscanned range": {EventCursor{
-			Scope: EventCursorQuery{
+			Scope: EventScope{
 				MinLedger: f + 100,
 				Filters:   []event.Filter{{ContractID: []byte{0x0a, 0x0b}}},
 			},
 		}, 1, ErrCursorMalformed},
 		"watermark overflow sentinel": {EventCursor{
-			Scope:         EventCursorQuery{MinLedger: f},
+			Scope:         EventScope{MinLedger: f},
 			ScannedLedger: math.MaxUint32,
 		}, 1, ErrCursorMalformed},
 	} {

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_reader.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_reader.go
@@ -36,8 +36,8 @@ package event
 //     logging, metrics, or error context after closing the reader.
 //
 // Caching, pooling, or per-query lifecycle policy is the consumer's
-// problem (e.g., the serving read side, PR-3c). ColdReader is a
-// primitive: New (well, Open) and Close.
+// problem (the query ReadView owns cold readers today). ColdReader
+// is a primitive: New (well, Open) and Close.
 
 import (
 	"bytes"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_store.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_store.go
@@ -151,10 +151,10 @@ func (h *HotStore) EventCount() (uint32, error) {
 //
 // Implementation: returns a *LedgerOffsets sharing the live
 // backing array, capped at the count visible at call time
-// (~24-byte allocation per Query). A concurrent IngestLedgerToBatch
+// (~24-byte allocation per Matches call). A concurrent IngestLedgerToBatch
 // may extend the backing past the cap, but the returned view's
 // slice stays bounded to what was visible when Offsets returned.
-// Callers (Query) take the view once at entry and pass it through
+// Callers (Matches) take the view once at entry and pass it through
 // their helpers.
 //
 // Read-only: the returned view's underlying slice shares memory
@@ -455,7 +455,7 @@ func (h *HotStore) index() *events.ConcurrentBitmaps { return h.mirror }
 // single-writer contract); the only non-completion is a crash, after which warmup
 // rebuilds.
 //
-// Ordering invariant: mirror BEFORE offsets. A concurrent Query that snapshots
+// Ordering invariant: mirror BEFORE offsets. A concurrent Matches call that snapshots
 // offsets then reads the mirror must see either the prior state or a consistent
 // later one. Reversing it would let a reader see an offsets count including IDs
 // the mirror hasn't published — FetchEvents would then miss them, silently.

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_store_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_store_test.go
@@ -529,7 +529,7 @@ func TestHotStore_ReopenRecoversState(t *testing.T) {
 func TestHotStore_SatisfiesReader(t *testing.T) {
 	// Compile-time guard already enforces this via the package-level
 	// var declaration; this test demonstrates callers can hold a
-	// *HotStore as a Reader for the freeze path and query coordinator.
+	// *HotStore as a Reader for the freeze path and the events pager.
 	h := openHotStoreForTest(t, 0)
 	var r Reader = h.store
 	assert.Equal(t, chunk.ID(0), r.ChunkID())

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/query.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/query.go
@@ -85,26 +85,36 @@ func (f TopicCountFilter) termKeys() []events.TermKey {
 	return events.TopicCountTermKeysAtLeast(f.Count)
 }
 
-// termGroups returns the indexed terms this filter constrains, grouped
-// by field: the bitmaps within a group are OR-ed and the groups are
-// AND-ed. Only the topic-count group ever holds more than one term.
-func (f *Filter) termGroups() [][]events.TermKey {
-	var groups [][]events.TermKey
+// valueTermKeys returns one term per constrained value field
+// (contract ID, event type, topics): the single enumeration
+// termGroups and CountDistinctTerms share, so the two cannot drift
+// over which values a filter names. The topic-count buckets are not
+// value terms; termGroups adds them separately and the budget does
+// not count them.
+func (f *Filter) valueTermKeys() []events.TermKey {
+	var keys []events.TermKey
 	if len(f.ContractID) > 0 {
-		groups = append(groups, []events.TermKey{
-			events.ComputeTermKey(f.ContractID, events.FieldContractID),
-		})
+		keys = append(keys, events.ComputeTermKey(f.ContractID, events.FieldContractID))
 	}
 	if f.EventType != nil {
-		groups = append(groups, []events.TermKey{events.EventTypeTermKey(*f.EventType)})
+		keys = append(keys, events.EventTypeTermKey(*f.EventType))
 	}
 	for tIdx, t := range f.Topics {
 		if len(t) == 0 {
 			continue
 		}
-		groups = append(groups, []events.TermKey{
-			events.ComputeTermKey(t, topicFieldByPosition[tIdx]),
-		})
+		keys = append(keys, events.ComputeTermKey(t, topicFieldByPosition[tIdx]))
+	}
+	return keys
+}
+
+// termGroups returns the indexed terms this filter constrains, grouped
+// by field: the bitmaps within a group are OR-ed and the groups are
+// AND-ed. Only the topic-count group ever holds more than one term.
+func (f *Filter) termGroups() [][]events.TermKey {
+	var groups [][]events.TermKey
+	for _, key := range f.valueTermKeys() {
+		groups = append(groups, []events.TermKey{key})
 	}
 	// A constrained topic position already implies an "at least" count at
 	// or below it, since a topic term is only indexed for events carrying
@@ -544,6 +554,25 @@ func ValidateFilters(filters []Filter) error {
 		}
 	}
 	return nil
+}
+
+// CountDistinctTerms returns how many distinct value terms the
+// filters name, deduped by field and value together: one contract ID
+// in five filters counts once, the same bytes in two topic positions
+// count twice. Topic-count buckets are excluded: they are an
+// implementation detail of the engine's grouping, not a value the
+// client named. Exported for the v2 handler's term-budget check. It
+// lives here, beside termGroups, so the budget and the engine's
+// lookups agree on what a value term is: TermKey over the store's
+// canonical bytes.
+func CountDistinctTerms(filters []Filter) int {
+	unique := make(map[events.TermKey]struct{})
+	for i := range filters {
+		for _, key := range filters[i].valueTermKeys() {
+			unique[key] = struct{}{}
+		}
+	}
+	return len(unique)
 }
 
 // unionSlots ORs the bitmaps at slots, and returns nil when every one

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/query_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/query_test.go
@@ -178,7 +178,7 @@ func eventIDRangeFor(t *testing.T, fx *queryFixture, startLedger, endLedger uint
 
 // wholeChunk returns the IDRange covering everything r has
 // ingested at this moment — the test-side equivalent of the
-// snapshot the multi-chunk coordinator pins at request entry.
+// snapshot the events pager pins at request entry.
 // Each test that wants "scan the whole chunk" pins its OWN snapshot
 // via this helper rather than relying on a hidden engine default,
 // keeping the snapshot-isolation contract visible at every call site.
@@ -703,8 +703,8 @@ func TestQuery_EmptyLeadingLedgerRangeStaysEmpty(t *testing.T) {
 	}))
 
 	// IDRangeForLedgers translates the empty-prefix request to
-	// IDRange{0, 0}. This is what the future adapter / coordinator
-	// will hand to Query for a getEvents call restricted to ledger `first`.
+	// IDRange{0, 0}: what the pager hands to Matches for a getEvents
+	// call restricted to ledger `first`.
 	ofs, err := h.store.Offsets()
 	require.NoError(t, err)
 	emptyRange, err := IDRangeForLedgers(ofs, first, first)
@@ -1749,4 +1749,34 @@ func TestPostFilter_OrdinalAlignmentWithLeadingDrop(t *testing.T) {
 	assert.Equal(t, uint32(9), got[0].Ordinal,
 		"the survivor must carry its own ordinal, not the dropped candidate's")
 	assert.Equal(t, "keep", dataSym(t, got[0].Payload))
+}
+
+// TestCountDistinctTerms pins the term-budget denomination: distinct
+// (field, value) pairs, deduped across filters the same way the
+// engine dedups its lookup batch.
+func TestCountDistinctTerms(t *testing.T) {
+	cid := bytes.Repeat([]byte{0x0a}, 32)
+	alpha, beta := []byte("alpha"), []byte("beta")
+
+	assert.Equal(t, 0, CountDistinctTerms(nil), "no filters look up nothing")
+	assert.Equal(t, 0, CountDistinctTerms([]Filter{{}}), "a match-all filter looks up nothing")
+	assert.Equal(t, 3, CountDistinctTerms([]Filter{
+		{ContractID: cid, Topics: [protocol.MaxTopicCount][]byte{alpha, nil, beta}},
+	}))
+	assert.Equal(t, 3, CountDistinctTerms([]Filter{
+		{ContractID: cid, Topics: [protocol.MaxTopicCount][]byte{alpha}},
+		{ContractID: cid, Topics: [protocol.MaxTopicCount][]byte{beta}},
+	}), "the shared contract term counts once")
+	assert.Equal(t, 2, CountDistinctTerms([]Filter{
+		{Topics: [protocol.MaxTopicCount][]byte{alpha, alpha}},
+	}), "the same value at two positions is two terms")
+
+	system := xdr.ContractEventTypeSystem
+	assert.Equal(t, 2, CountDistinctTerms([]Filter{
+		{EventType: &system, Topics: [protocol.MaxTopicCount][]byte{alpha}},
+		{EventType: &system},
+	}), "the shared type term counts once")
+	assert.Equal(t, 1, CountDistinctTerms([]Filter{
+		{ContractID: cid, TopicCount: TopicCountFilter{Count: 1}},
+	}), "topic-count buckets are not value terms and are not counted")
 }

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/reader.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/reader.go
@@ -40,9 +40,9 @@ var ErrFetchRangeOutOfBounds = errors.New("events: FetchRange out of bounds")
 // Reader is the unified read surface for one Chunk's events,
 // implemented by both HotStore (RocksDB + in-memory caches) and
 // ColdReader (mmap'd events.pack + index.pack + index.hash).
-// Consumers like the query coordinator (PR-3c) work against this
-// interface so they don't need to branch on hot-vs-cold beyond
-// reader construction.
+// Consumers like the events pager work against this interface so
+// they don't need to branch on hot-vs-cold beyond reader
+// construction.
 //
 // All implementations return events in chunk-relative eventID
 // order. EventIDs are dense in `[0, EventCount())`.
@@ -119,11 +119,11 @@ type Reader interface {
 	// eventIDs and returns them positionally aligned with the input
 	// slice (result[i] corresponds to eventIDs[i]).
 	//
-	// eventIDs MUST be sorted ascending with no duplicates. The
-	// coordinator iterating a bitmap intersection
-	// (roaring.Bitmap.Iterator yields ascending) satisfies this for
-	// free. Both implementations validate the precondition up front
-	// and return a wrapped ErrUnsortedEventIDs on violation.
+	// eventIDs MUST be sorted ascending with no duplicates. Matches
+	// iterating a bitmap intersection (roaring.Bitmap.Iterator yields
+	// ascending) satisfies this for free. Both implementations
+	// validate the precondition up front and return a wrapped
+	// ErrUnsortedEventIDs on violation.
 	//
 	// ctx cancels in-flight I/O; the cold path checks ctx between
 	// scattered-read batches, the hot path checks between Gets.

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -163,6 +163,9 @@ max_execution_duration = "10s"
 # The getEvents v2 API caps pages at 1,000 (spec constant), unlike v1's 10000.
 max_items_per_response = 1000
 default_items_per_response = 100
+# Cap on distinct index terms one request may look up. Over budget fails
+# with invalid_params; the client splits the query and merges results.
+term_budget = 15
 
 [service.methods.getFeeStats]
 queue_limit = 100


### PR DESCRIPTION
## What

The naming follow-up #934 deferred, plus the first half of the getEvents v2 term budget (#774).

1. **Rename**: `EventCursorQuery` becomes `EventScope`, the name the `Scope` field already implies. Stale `PR-3c` and "query coordinator" comments now name the events pager and `Matches`.
2. **Term budget inputs**: `term_budget` on `[service.methods.getEvents]`, default 15 per the proposal, and `event.CountDistinctTerms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
