### PR TITLE
Use GetLedgerRaw in getLatestLedger endpoint

### DIFF
--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -91,27 +91,35 @@ func (l ledgerReaderTx) BatchGetLedgers(
 
 	batch := make([]LedgerMetadataChunk, len(results))
 	for i, meta := range results {
-		batch[i] = LedgerMetadataChunk{Lcm: meta}
-
-		var v xdr.Int32
-		rd := bytes.NewReader(meta)
-		if _, err := xdr.Unmarshal(rd, &v); err != nil {
+		header, err := l.parseLedgerHeaderFromMeta(meta)
+		if err != nil {
 			return nil, err
 		}
-
-		if v > 0 { // V0 has no extension
-			var ext xdr.LedgerCloseMetaExt
-			if _, err := xdr.Unmarshal(rd, &ext); err != nil { // skipped
-				return nil, err
-			}
-		}
-
-		if _, err := xdr.Unmarshal(rd, &batch[i].Header); err != nil {
-			return nil, err
-		}
+		batch[i] = LedgerMetadataChunk{Header: header, Lcm: meta}
 	}
 
 	return batch, nil
+}
+
+func (l ledgerReaderTx) parseLedgerHeaderFromMeta(meta []byte) (xdr.LedgerHeaderHistoryEntry, error) {
+	var v xdr.Int32
+	rd := bytes.NewReader(meta)
+	if _, err := xdr.Unmarshal(rd, &v); err != nil {
+		return xdr.LedgerHeaderHistoryEntry{}, err
+	}
+
+	if v > 0 { // V0 has no extension
+		var ext xdr.LedgerCloseMetaExt
+		if _, err := xdr.Unmarshal(rd, &ext); err != nil { // skipped
+			return xdr.LedgerHeaderHistoryEntry{}, err
+		}
+	}
+
+	var header xdr.LedgerHeaderHistoryEntry
+	if _, err := xdr.Unmarshal(rd, &header); err != nil {
+		return xdr.LedgerHeaderHistoryEntry{}, err
+	}
+	return header, nil
 }
 
 // GetLedger fetches a single ledger from the db using a transaction.

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -45,7 +45,7 @@ type LedgerWriter interface {
 }
 
 type readDB interface {
-	Select(ctx context.Context, dest interface{}, query sq.Sqlizer) error
+	Select(ctx context.Context, dest any, query sq.Sqlizer) error
 }
 
 type ledgerReader struct {
@@ -397,24 +397,23 @@ func getLedgerRawFromDB(ctx context.Context, db readDB, sequence uint32) ([]byte
 
 // Parses a raw ledger close meta blob into a LedgerHeaderHistoryEntry.
 func parseLedgerHeaderFromMeta(meta []byte) (xdr.LedgerHeaderHistoryEntry, error) {
-	var v xdr.Int32
-	rd := bytes.NewReader(meta)
-	if _, err := xdr.Unmarshal(rd, &v); err != nil {
-		return xdr.LedgerHeaderHistoryEntry{}, err
-	}
-
-	if v > 0 { // V0 has no extension
-		var ext xdr.LedgerCloseMetaExt
-		if _, err := xdr.Unmarshal(rd, &ext); err != nil { // skipped
-			return xdr.LedgerHeaderHistoryEntry{}, err
+	raw, err := xdr.Try(func() []byte {
+		m := xdr.LedgerCloseMetaView(meta)
+		switch m.MustV() {
+		case 0:
+			return m.MustV0().MustLedgerHeader().MustRaw()
+		case 1:
+			return m.MustV1().MustLedgerHeader().MustRaw()
+		default:
+			return m.MustV2().MustLedgerHeader().MustRaw()
 		}
-	}
-
+	})
 	var header xdr.LedgerHeaderHistoryEntry
-	if _, err := xdr.Unmarshal(rd, &header); err != nil {
-		return xdr.LedgerHeaderHistoryEntry{}, err
+	if err != nil {
+		return header, err
 	}
-	return header, nil
+	err = header.UnmarshalBinary(raw)
+	return header, err
 }
 
 // InsertLedger inserts a ledger in the db.

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -24,7 +24,7 @@ type StreamLedgerFn func(xdr.LedgerCloseMeta) error
 
 type LedgerReader interface {
 	GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error)
-	GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error)
+	GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, bool, error)
 	StreamAllLedgers(ctx context.Context, f StreamLedgerFn) error
 	GetLedgerRange(ctx context.Context) (ledgerbucketwindow.LedgerRange, error)
 	GetLedgerCountInRange(ctx context.Context, start uint32, end uint32) (uint32, uint32, uint32, error)
@@ -92,7 +92,7 @@ func (l ledgerReaderTx) BatchGetLedgers(
 
 	batch := make([]LedgerMetadataChunk, len(results))
 	for i, meta := range results {
-		header, err := parseLedgerHeaderFromMeta(meta)
+		header, err := ParseLedgerHeaderFromMeta(meta)
 		if err != nil {
 			return nil, err
 		}
@@ -185,19 +185,12 @@ func (r ledgerReader) GetLedger(ctx context.Context, sequence uint32) (xdr.Ledge
 }
 
 // GetLedgerRaw fetches a single ledger from the db and returns its bytes, its header, and whether it was found.
-func (r ledgerReader) GetLedgerRaw(
-	ctx context.Context,
-	sequence uint32,
-) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
+func (r ledgerReader) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, bool, error) {
 	meta, found, err := getLedgerRawFromDB(ctx, r.db, sequence)
 	if err != nil || !found {
-		return nil, xdr.LedgerHeaderHistoryEntry{}, found, err
+		return nil, found, err
 	}
-	header, err := parseLedgerHeaderFromMeta(meta)
-	if err != nil {
-		return nil, xdr.LedgerHeaderHistoryEntry{}, false, err
-	}
-	return meta, header, true, nil
+	return meta, true, nil
 }
 
 // GetLedgerRange pulls the min/max ledger sequence numbers from the meta table.
@@ -396,7 +389,7 @@ func getLedgerRawFromDB(ctx context.Context, db readDB, sequence uint32) ([]byte
 }
 
 // Parses a raw ledger close meta blob into a LedgerHeaderHistoryEntry.
-func parseLedgerHeaderFromMeta(meta []byte) (xdr.LedgerHeaderHistoryEntry, error) {
+func ParseLedgerHeaderFromMeta(meta []byte) (xdr.LedgerHeaderHistoryEntry, error) {
 	raw, err := xdr.Try(func() []byte {
 		m := xdr.LedgerCloseMetaView(meta)
 		switch m.MustV() {

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -256,7 +256,7 @@ func (r ledgerReader) GetLatestLedgerSequence(ctx context.Context) (uint32, erro
 	return getLatestLedgerSequence(ctx, r, r.db.cache)
 }
 
-// Parses a raw ledger close meta blob into a LedgerHeaderHistoryEntry.
+// ParseLedgerHeaderFromMeta parses a raw LCM object into a LedgerHeaderHistoryEntry.
 func (r RawLedger) ParseLedgerHeaderFromMeta() (xdr.LedgerHeaderHistoryEntry, error) {
 	raw, err := xdr.Try(func() []byte {
 		m := xdr.LedgerCloseMetaView(r)

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -367,37 +367,33 @@ func (l ledgerWriter) trimLedgers(latestLedgerSeq uint32, retentionWindow uint32
 // for fetching a single ledger from the database
 func getLedgerFromDB(ctx context.Context, db readDB, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {
 	raw, found, err := getLedgerRawFromDB(ctx, db, sequence)
-	if err != nil {
+	if err != nil || !found {
 		return xdr.LedgerCloseMeta{}, false, err
 	}
-	if !found {
-		return xdr.LedgerCloseMeta{}, false, nil
-	}
-
-	var results []xdr.LedgerCloseMeta
-	if _, err := xdr.Unmarshal(bytes.NewReader(raw), &results); err != nil {
+	var lcm xdr.LedgerCloseMeta
+	if _, err := xdr.Unmarshal(bytes.NewReader(raw), &lcm); err != nil {
 		return xdr.LedgerCloseMeta{}, false, err
 	}
-	switch len(results) {
-	case 0:
-		return xdr.LedgerCloseMeta{}, false, nil
-	case 1:
-		return results[0], true, nil
-	default:
-		return xdr.LedgerCloseMeta{}, false, fmt.Errorf("multiple lcm entries (%d) for sequence %d in table %q",
-			len(results), sequence, ledgerCloseMetaTableName)
-	}
+	return lcm, true, nil
 }
 
 // getLedgerRawFromDB is a helper function that encapsulates the common logic
 // for fetching a single ledger's bytes from the database
 func getLedgerRawFromDB(ctx context.Context, db readDB, sequence uint32) ([]byte, bool, error) {
 	sql := sq.Select("meta").From(ledgerCloseMetaTableName).Where(sq.Eq{"sequence": sequence})
-	var result []byte
-	if err := db.Select(ctx, &result, sql); err != nil || len(result) == 0 {
+	var results [][]byte
+	if err := db.Select(ctx, &results, sql); err != nil {
 		return nil, false, err
 	}
-	return result, true, nil
+	switch len(results) {
+	case 0:
+		return nil, false, nil
+	case 1:
+		return results[0], true, nil
+	default:
+		return nil, false, fmt.Errorf("multiple lcm entries (%d) for sequence %d in table %q",
+			len(results), sequence, ledgerCloseMetaTableName)
+	}
 }
 
 // Parses a raw ledger close meta blob into a LedgerHeaderHistoryEntry.

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -363,8 +363,7 @@ func (l ledgerWriter) trimLedgers(latestLedgerSeq uint32, retentionWindow uint32
 	return err
 }
 
-// getLedgerFromDB is a helper function that encapsulates the common logic
-// for fetching a single ledger from the database
+// getLedgerFromDB fetches a single ledger from the database.
 func getLedgerFromDB(ctx context.Context, db readDB, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {
 	raw, found, err := getLedgerRawFromDB(ctx, db, sequence)
 	if err != nil || !found {
@@ -378,7 +377,7 @@ func getLedgerFromDB(ctx context.Context, db readDB, sequence uint32) (xdr.Ledge
 }
 
 // getLedgerRawFromDB is a helper function that encapsulates the common logic
-// for fetching a single ledger's bytes from the database
+// for fetching a single ledger's bytes from the database.
 func getLedgerRawFromDB(ctx context.Context, db readDB, sequence uint32) ([]byte, bool, error) {
 	sql := sq.Select("meta").From(ledgerCloseMetaTableName).Where(sq.Eq{"sequence": sequence})
 	var results [][]byte

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -24,6 +24,7 @@ type StreamLedgerFn func(xdr.LedgerCloseMeta) error
 
 type LedgerReader interface {
 	GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error)
+	GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error)
 	StreamAllLedgers(ctx context.Context, f StreamLedgerFn) error
 	GetLedgerRange(ctx context.Context) (ledgerbucketwindow.LedgerRange, error)
 	GetLedgerCountInRange(ctx context.Context, start uint32, end uint32) (uint32, uint32, uint32, error)
@@ -91,7 +92,7 @@ func (l ledgerReaderTx) BatchGetLedgers(
 
 	batch := make([]LedgerMetadataChunk, len(results))
 	for i, meta := range results {
-		header, err := l.parseLedgerHeaderFromMeta(meta)
+		header, err := parseLedgerHeaderFromMeta(meta)
 		if err != nil {
 			return nil, err
 		}
@@ -99,27 +100,6 @@ func (l ledgerReaderTx) BatchGetLedgers(
 	}
 
 	return batch, nil
-}
-
-func (l ledgerReaderTx) parseLedgerHeaderFromMeta(meta []byte) (xdr.LedgerHeaderHistoryEntry, error) {
-	var v xdr.Int32
-	rd := bytes.NewReader(meta)
-	if _, err := xdr.Unmarshal(rd, &v); err != nil {
-		return xdr.LedgerHeaderHistoryEntry{}, err
-	}
-
-	if v > 0 { // V0 has no extension
-		var ext xdr.LedgerCloseMetaExt
-		if _, err := xdr.Unmarshal(rd, &ext); err != nil { // skipped
-			return xdr.LedgerHeaderHistoryEntry{}, err
-		}
-	}
-
-	var header xdr.LedgerHeaderHistoryEntry
-	if _, err := xdr.Unmarshal(rd, &header); err != nil {
-		return xdr.LedgerHeaderHistoryEntry{}, err
-	}
-	return header, nil
 }
 
 // GetLedger fetches a single ledger from the db using a transaction.
@@ -202,6 +182,22 @@ func (r ledgerReader) StreamLedgerRange(
 // GetLedger fetches a single ledger from the db.
 func (r ledgerReader) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {
 	return getLedgerFromDB(ctx, r.db, sequence)
+}
+
+// GetLedgerRaw fetches a single ledger from the db and returns its bytes, its header, and whether it was found.
+func (r ledgerReader) GetLedgerRaw(
+	ctx context.Context,
+	sequence uint32,
+) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
+	meta, found, err := getLedgerRawFromDB(ctx, r.db, sequence)
+	if err != nil || !found {
+		return nil, xdr.LedgerHeaderHistoryEntry{}, found, err
+	}
+	header, err := parseLedgerHeaderFromMeta(meta)
+	if err != nil {
+		return nil, xdr.LedgerHeaderHistoryEntry{}, false, err
+	}
+	return meta, header, true, nil
 }
 
 // GetLedgerRange pulls the min/max ledger sequence numbers from the meta table.
@@ -370,20 +366,59 @@ func (l ledgerWriter) trimLedgers(latestLedgerSeq uint32, retentionWindow uint32
 // getLedgerFromDB is a helper function that encapsulates the common logic
 // for fetching a single ledger from the database
 func getLedgerFromDB(ctx context.Context, db readDB, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {
-	sql := sq.Select("meta").From(ledgerCloseMetaTableName).Where(sq.Eq{"sequence": sequence})
-	var results []xdr.LedgerCloseMeta
-	if err := db.Select(ctx, &results, sql); err != nil {
+	raw, found, err := getLedgerRawFromDB(ctx, db, sequence)
+	if err != nil {
 		return xdr.LedgerCloseMeta{}, false, err
 	}
-	switch len(results) {
+	if !found {
+		return xdr.LedgerCloseMeta{}, false, nil
+	}
+
+	var lcm []xdr.LedgerCloseMeta
+	if _, err := xdr.Unmarshal(bytes.NewReader(raw), &lcm); err != nil {
+		return xdr.LedgerCloseMeta{}, false, err
+	}
+	switch len(lcm) {
 	case 0:
 		return xdr.LedgerCloseMeta{}, false, nil
 	case 1:
-		return results[0], true, nil
+		return lcm[0], true, nil
 	default:
-		return xdr.LedgerCloseMeta{}, false, fmt.Errorf("multiple lcm entries (%d) for sequence %d in table %q",
-			len(results), sequence, ledgerCloseMetaTableName)
+		return xdr.LedgerCloseMeta{}, false, fmt.Errorf("unexpectedly found %d ledgers for sequence %d", len(lcm), sequence)
 	}
+}
+
+// getLedgerRawFromDB is a helper function that encapsulates the common logic
+// for fetching a single ledger's bytes from the database
+func getLedgerRawFromDB(ctx context.Context, db readDB, sequence uint32) ([]byte, bool, error) {
+	sql := sq.Select("meta").From(ledgerCloseMetaTableName).Where(sq.Eq{"sequence": sequence})
+	var result []byte
+	if err := db.Select(ctx, &result, sql); err != nil || len(result) == 0 {
+		return nil, false, err
+	}
+	return result, true, nil
+}
+
+// Parses a raw ledger close meta blob into a LedgerHeaderHistoryEntry.
+func parseLedgerHeaderFromMeta(meta []byte) (xdr.LedgerHeaderHistoryEntry, error) {
+	var v xdr.Int32
+	rd := bytes.NewReader(meta)
+	if _, err := xdr.Unmarshal(rd, &v); err != nil {
+		return xdr.LedgerHeaderHistoryEntry{}, err
+	}
+
+	if v > 0 { // V0 has no extension
+		var ext xdr.LedgerCloseMetaExt
+		if _, err := xdr.Unmarshal(rd, &ext); err != nil { // skipped
+			return xdr.LedgerHeaderHistoryEntry{}, err
+		}
+	}
+
+	var header xdr.LedgerHeaderHistoryEntry
+	if _, err := xdr.Unmarshal(rd, &header); err != nil {
+		return xdr.LedgerHeaderHistoryEntry{}, err
+	}
+	return header, nil
 }
 
 // InsertLedger inserts a ledger in the db.

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -374,17 +374,18 @@ func getLedgerFromDB(ctx context.Context, db readDB, sequence uint32) (xdr.Ledge
 		return xdr.LedgerCloseMeta{}, false, nil
 	}
 
-	var lcm []xdr.LedgerCloseMeta
-	if _, err := xdr.Unmarshal(bytes.NewReader(raw), &lcm); err != nil {
+	var results []xdr.LedgerCloseMeta
+	if _, err := xdr.Unmarshal(bytes.NewReader(raw), &results); err != nil {
 		return xdr.LedgerCloseMeta{}, false, err
 	}
-	switch len(lcm) {
+	switch len(results) {
 	case 0:
 		return xdr.LedgerCloseMeta{}, false, nil
 	case 1:
-		return lcm[0], true, nil
+		return results[0], true, nil
 	default:
-		return xdr.LedgerCloseMeta{}, false, fmt.Errorf("unexpectedly found %d ledgers for sequence %d", len(lcm), sequence)
+		return xdr.LedgerCloseMeta{}, false, fmt.Errorf("multiple lcm entries (%d) for sequence %d in table %q",
+			len(results), sequence, ledgerCloseMetaTableName)
 	}
 }
 

--- a/cmd/stellar-rpc/internal/db/ledger.go
+++ b/cmd/stellar-rpc/internal/db/ledger.go
@@ -20,11 +20,14 @@ const (
 	ledgerCloseMetaTableName = "ledger_close_meta"
 )
 
-type StreamLedgerFn func(xdr.LedgerCloseMeta) error
+type (
+	StreamLedgerFn func(xdr.LedgerCloseMeta) error
+	RawLedger      []byte
+)
 
 type LedgerReader interface {
 	GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error)
-	GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, bool, error)
+	GetLedgerRaw(ctx context.Context, sequence uint32) (RawLedger, bool, error)
 	StreamAllLedgers(ctx context.Context, f StreamLedgerFn) error
 	GetLedgerRange(ctx context.Context) (ledgerbucketwindow.LedgerRange, error)
 	GetLedgerCountInRange(ctx context.Context, start uint32, end uint32) (uint32, uint32, uint32, error)
@@ -92,7 +95,7 @@ func (l ledgerReaderTx) BatchGetLedgers(
 
 	batch := make([]LedgerMetadataChunk, len(results))
 	for i, meta := range results {
-		header, err := ParseLedgerHeaderFromMeta(meta)
+		header, err := RawLedger(meta).ParseLedgerHeaderFromMeta()
 		if err != nil {
 			return nil, err
 		}
@@ -185,7 +188,7 @@ func (r ledgerReader) GetLedger(ctx context.Context, sequence uint32) (xdr.Ledge
 }
 
 // GetLedgerRaw fetches a single ledger from the db and returns its bytes, its header, and whether it was found.
-func (r ledgerReader) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, bool, error) {
+func (r ledgerReader) GetLedgerRaw(ctx context.Context, sequence uint32) (RawLedger, bool, error) {
 	meta, found, err := getLedgerRawFromDB(ctx, r.db, sequence)
 	if err != nil || !found {
 		return nil, found, err
@@ -251,6 +254,27 @@ func (r ledgerReader) GetLedgerCountInRange(ctx context.Context, start, end uint
 
 func (r ledgerReader) GetLatestLedgerSequence(ctx context.Context) (uint32, error) {
 	return getLatestLedgerSequence(ctx, r, r.db.cache)
+}
+
+// Parses a raw ledger close meta blob into a LedgerHeaderHistoryEntry.
+func (r RawLedger) ParseLedgerHeaderFromMeta() (xdr.LedgerHeaderHistoryEntry, error) {
+	raw, err := xdr.Try(func() []byte {
+		m := xdr.LedgerCloseMetaView(r)
+		switch m.MustV() {
+		case 0:
+			return m.MustV0().MustLedgerHeader().MustRaw()
+		case 1:
+			return m.MustV1().MustLedgerHeader().MustRaw()
+		default:
+			return m.MustV2().MustLedgerHeader().MustRaw()
+		}
+	})
+	var header xdr.LedgerHeaderHistoryEntry
+	if err != nil {
+		return header, err
+	}
+	err = header.UnmarshalBinary(raw)
+	return header, err
 }
 
 // getLedgerRangeWithCache uses the latest ledger cache to optimize the query.
@@ -386,27 +410,6 @@ func getLedgerRawFromDB(ctx context.Context, db readDB, sequence uint32) ([]byte
 		return nil, false, fmt.Errorf("multiple lcm entries (%d) for sequence %d in table %q",
 			len(results), sequence, ledgerCloseMetaTableName)
 	}
-}
-
-// Parses a raw ledger close meta blob into a LedgerHeaderHistoryEntry.
-func ParseLedgerHeaderFromMeta(meta []byte) (xdr.LedgerHeaderHistoryEntry, error) {
-	raw, err := xdr.Try(func() []byte {
-		m := xdr.LedgerCloseMetaView(meta)
-		switch m.MustV() {
-		case 0:
-			return m.MustV0().MustLedgerHeader().MustRaw()
-		case 1:
-			return m.MustV1().MustLedgerHeader().MustRaw()
-		default:
-			return m.MustV2().MustLedgerHeader().MustRaw()
-		}
-	})
-	var header xdr.LedgerHeaderHistoryEntry
-	if err != nil {
-		return header, err
-	}
-	err = header.UnmarshalBinary(raw)
-	return header, err
 }
 
 // InsertLedger inserts a ledger in the db.

--- a/cmd/stellar-rpc/internal/db/mocks.go
+++ b/cmd/stellar-rpc/internal/db/mocks.go
@@ -98,10 +98,7 @@ func (m *MockLedgerReader) GetLedger(_ context.Context, sequence uint32) (xdr.Le
 	return *lcm, true, nil
 }
 
-func (m *MockLedgerReader) GetLedgerRaw(
-	_ context.Context,
-	sequence uint32,
-) ([]byte, bool, error) {
+func (m *MockLedgerReader) GetLedgerRaw(_ context.Context, sequence uint32) (RawLedger, bool, error) {
 	lcm, ok := m.txn.ledgerSeqToMeta[sequence]
 	if !ok {
 		return nil, false, nil

--- a/cmd/stellar-rpc/internal/db/mocks.go
+++ b/cmd/stellar-rpc/internal/db/mocks.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -95,6 +96,24 @@ func (m *MockLedgerReader) GetLedger(_ context.Context, sequence uint32) (xdr.Le
 		return xdr.LedgerCloseMeta{}, false, nil
 	}
 	return *lcm, true, nil
+}
+
+func (m *MockLedgerReader) GetLedgerRaw(_ context.Context, sequence uint32) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
+	lcm, ok := m.txn.ledgerSeqToMeta[sequence]
+	if !ok {
+		return nil, xdr.LedgerHeaderHistoryEntry{}, false, nil
+	}
+	var buf bytes.Buffer
+	_, err := xdr.Marshal(&buf, lcm)
+	rawMeta := buf.Bytes()
+	if err != nil {
+		return nil, xdr.LedgerHeaderHistoryEntry{}, false, err
+	}
+	header, err := parseLedgerHeaderFromMeta(rawMeta)
+	if err != nil {
+		return nil, xdr.LedgerHeaderHistoryEntry{}, false, err
+	}
+	return rawMeta, header, true, nil
 }
 
 func (m *MockLedgerReader) StreamAllLedgers(_ context.Context, _ StreamLedgerFn) error {

--- a/cmd/stellar-rpc/internal/db/mocks.go
+++ b/cmd/stellar-rpc/internal/db/mocks.go
@@ -101,22 +101,18 @@ func (m *MockLedgerReader) GetLedger(_ context.Context, sequence uint32) (xdr.Le
 func (m *MockLedgerReader) GetLedgerRaw(
 	_ context.Context,
 	sequence uint32,
-) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
+) ([]byte, bool, error) {
 	lcm, ok := m.txn.ledgerSeqToMeta[sequence]
 	if !ok {
-		return nil, xdr.LedgerHeaderHistoryEntry{}, false, nil
+		return nil, false, nil
 	}
 	var buf bytes.Buffer
 	_, err := xdr.Marshal(&buf, lcm)
 	rawMeta := buf.Bytes()
 	if err != nil {
-		return nil, xdr.LedgerHeaderHistoryEntry{}, false, err
+		return nil, false, err
 	}
-	header, err := parseLedgerHeaderFromMeta(rawMeta)
-	if err != nil {
-		return nil, xdr.LedgerHeaderHistoryEntry{}, false, err
-	}
-	return rawMeta, header, true, nil
+	return rawMeta, true, nil
 }
 
 func (m *MockLedgerReader) StreamAllLedgers(_ context.Context, _ StreamLedgerFn) error {

--- a/cmd/stellar-rpc/internal/db/mocks.go
+++ b/cmd/stellar-rpc/internal/db/mocks.go
@@ -98,7 +98,10 @@ func (m *MockLedgerReader) GetLedger(_ context.Context, sequence uint32) (xdr.Le
 	return *lcm, true, nil
 }
 
-func (m *MockLedgerReader) GetLedgerRaw(_ context.Context, sequence uint32) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
+func (m *MockLedgerReader) GetLedgerRaw(
+	_ context.Context,
+	sequence uint32,
+) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
 	lcm, ok := m.txn.ledgerSeqToMeta[sequence]
 	if !ok {
 		return nil, xdr.LedgerHeaderHistoryEntry{}, false, nil

--- a/cmd/stellar-rpc/internal/methods/get_latest_ledger.go
+++ b/cmd/stellar-rpc/internal/methods/get_latest_ledger.go
@@ -31,7 +31,7 @@ func NewGetLatestLedgerHandler(ledgerReader db.LedgerReader) jrpc2.Handler {
 				Message: "could not get latest ledger",
 			}
 		}
-		header, err := db.ParseLedgerHeaderFromMeta(latestLedgerRaw)
+		header, err := latestLedgerRaw.ParseLedgerHeaderFromMeta()
 		if err != nil {
 			return protocol.GetLatestLedgerResponse{}, &jrpc2.Error{
 				Code:    jrpc2.InternalError,

--- a/cmd/stellar-rpc/internal/methods/get_latest_ledger.go
+++ b/cmd/stellar-rpc/internal/methods/get_latest_ledger.go
@@ -8,6 +8,7 @@ import (
 	"github.com/creachadair/jrpc2"
 
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
 )
@@ -23,39 +24,28 @@ func NewGetLatestLedgerHandler(ledgerReader db.LedgerReader) jrpc2.Handler {
 				Message: "could not get latest ledger sequence",
 			}
 		}
-		latestLedger, found, err := ledgerReader.GetLedger(ctx, latestSequence)
+		latestLedgerRaw, header, found, err := ledgerReader.GetLedgerRaw(ctx, latestSequence)
 		if (err != nil) || (!found) {
 			return protocol.GetLatestLedgerResponse{}, &jrpc2.Error{
 				Code:    jrpc2.InternalError,
 				Message: "could not get latest ledger",
 			}
 		}
-		header := latestLedger.LedgerHeaderHistoryEntry().Header
-		headerBytes, err := header.MarshalBinary()
+		headerB64, err := xdr.MarshalBase64(header.Header)
 		if err != nil {
 			return protocol.GetLatestLedgerResponse{}, &jrpc2.Error{
 				Code:    jrpc2.InternalError,
 				Message: fmt.Sprintf("could not marshal latest ledger header: %v", err),
 			}
 		}
-		response := protocol.GetLatestLedgerResponse{
-			Hash:            latestLedger.LedgerHash().HexString(),
-			ProtocolVersion: latestLedger.ProtocolVersion(),
+		return protocol.GetLatestLedgerResponse{
+			Hash:            header.Hash.HexString(),
+			ProtocolVersion: uint32(header.Header.LedgerVersion),
 			Sequence:        latestSequence,
-			LedgerCloseTime: latestLedger.LedgerCloseTime(),
-			LedgerHeader:    base64.StdEncoding.EncodeToString(headerBytes),
-		}
-
-		raw, err := latestLedger.MarshalBinary()
-		if err != nil {
-			return protocol.GetLatestLedgerResponse{}, &jrpc2.Error{
-				Code:    jrpc2.InternalError,
-				Message: fmt.Sprintf("could not marshal latest ledger metadata: %v", err),
-			}
-		}
-		response.LedgerMetadata = base64.StdEncoding.EncodeToString(raw)
-
-		return response, nil
+			LedgerCloseTime: int64(header.Header.ScpValue.CloseTime),
+			LedgerHeader:    headerB64,
+			LedgerMetadata:  base64.StdEncoding.EncodeToString(latestLedgerRaw),
+		}, nil
 	}
 	return NewHandler(coreHandler)
 }

--- a/cmd/stellar-rpc/internal/methods/get_latest_ledger.go
+++ b/cmd/stellar-rpc/internal/methods/get_latest_ledger.go
@@ -42,7 +42,7 @@ func NewGetLatestLedgerHandler(ledgerReader db.LedgerReader) jrpc2.Handler {
 			Hash:            header.Hash.HexString(),
 			ProtocolVersion: uint32(header.Header.LedgerVersion),
 			Sequence:        latestSequence,
-			LedgerCloseTime: int64(header.Header.ScpValue.CloseTime),
+			LedgerCloseTime: int64(header.Header.ScpValue.CloseTime), //nolint:gosec // safe for ~292B years
 			LedgerHeader:    headerB64,
 			LedgerMetadata:  base64.StdEncoding.EncodeToString(latestLedgerRaw),
 		}, nil

--- a/cmd/stellar-rpc/internal/methods/get_latest_ledger.go
+++ b/cmd/stellar-rpc/internal/methods/get_latest_ledger.go
@@ -24,11 +24,18 @@ func NewGetLatestLedgerHandler(ledgerReader db.LedgerReader) jrpc2.Handler {
 				Message: "could not get latest ledger sequence",
 			}
 		}
-		latestLedgerRaw, header, found, err := ledgerReader.GetLedgerRaw(ctx, latestSequence)
+		latestLedgerRaw, found, err := ledgerReader.GetLedgerRaw(ctx, latestSequence)
 		if (err != nil) || (!found) {
 			return protocol.GetLatestLedgerResponse{}, &jrpc2.Error{
 				Code:    jrpc2.InternalError,
 				Message: "could not get latest ledger",
+			}
+		}
+		header, err := db.ParseLedgerHeaderFromMeta(latestLedgerRaw)
+		if err != nil {
+			return protocol.GetLatestLedgerResponse{}, &jrpc2.Error{
+				Code:    jrpc2.InternalError,
+				Message: "could not parse latest ledger header",
 			}
 		}
 		headerB64, err := xdr.MarshalBase64(header.Header)

--- a/cmd/stellar-rpc/internal/methods/get_latest_ledger_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_latest_ledger_test.go
@@ -1,6 +1,7 @@
 package methods
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -52,6 +53,20 @@ func (ledgerReader *ConstantLedgerReader) GetLedger(_ context.Context,
 			expectedLatestLedgerProtocolVersion,
 			expectedLatestLedgerCloseTime),
 		true, nil
+}
+
+func (ledgerReader *ConstantLedgerReader) GetLedgerRaw(_ context.Context,
+	sequence uint32,
+) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
+	lcm := createLedger(expectedLatestLedgerHashBytes,
+		sequence,
+		expectedLatestLedgerProtocolVersion,
+		expectedLatestLedgerCloseTime)
+	var buf bytes.Buffer
+	if _, err := xdr.Marshal(&buf, lcm); err != nil {
+		return nil, xdr.LedgerHeaderHistoryEntry{}, false, err
+	}
+	return buf.Bytes(), lcm.V1.LedgerHeader, true, nil
 }
 
 func (ledgerReader *ConstantLedgerReader) StreamAllLedgers(_ context.Context, _ db.StreamLedgerFn) error {

--- a/cmd/stellar-rpc/internal/methods/get_latest_ledger_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_latest_ledger_test.go
@@ -55,9 +55,10 @@ func (ledgerReader *ConstantLedgerReader) GetLedger(_ context.Context,
 		true, nil
 }
 
-func (ledgerReader *ConstantLedgerReader) GetLedgerRaw(_ context.Context,
+func (ledgerReader *ConstantLedgerReader) GetLedgerRaw(
+	_ context.Context,
 	sequence uint32,
-) ([]byte, bool, error) {
+) (db.RawLedger, bool, error) {
 	lcm := createLedger(expectedLatestLedgerHashBytes,
 		sequence,
 		expectedLatestLedgerProtocolVersion,

--- a/cmd/stellar-rpc/internal/methods/get_latest_ledger_test.go
+++ b/cmd/stellar-rpc/internal/methods/get_latest_ledger_test.go
@@ -57,16 +57,16 @@ func (ledgerReader *ConstantLedgerReader) GetLedger(_ context.Context,
 
 func (ledgerReader *ConstantLedgerReader) GetLedgerRaw(_ context.Context,
 	sequence uint32,
-) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
+) ([]byte, bool, error) {
 	lcm := createLedger(expectedLatestLedgerHashBytes,
 		sequence,
 		expectedLatestLedgerProtocolVersion,
 		expectedLatestLedgerCloseTime)
 	var buf bytes.Buffer
 	if _, err := xdr.Marshal(&buf, lcm); err != nil {
-		return nil, xdr.LedgerHeaderHistoryEntry{}, false, err
+		return nil, false, err
 	}
-	return buf.Bytes(), lcm.V1.LedgerHeader, true, nil
+	return buf.Bytes(), true, nil
 }
 
 func (ledgerReader *ConstantLedgerReader) StreamAllLedgers(_ context.Context, _ db.StreamLedgerFn) error {

--- a/cmd/stellar-rpc/internal/methods/mocks.go
+++ b/cmd/stellar-rpc/internal/methods/mocks.go
@@ -28,13 +28,9 @@ func (m *MockLedgerReader) GetLedger(ctx context.Context, sequence uint32) (xdr.
 	return args.Get(0).(xdr.LedgerCloseMeta), args.Bool(1), args.Error(2) //nolint:forcetypeassert
 }
 
-func (m *MockLedgerReader) GetLedgerRaw(
-	ctx context.Context,
-	sequence uint32,
-) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
+func (m *MockLedgerReader) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, bool, error) {
 	args := m.Called(ctx, sequence)
-	return args.Get(0).([]byte), args.Get(1).(xdr.LedgerHeaderHistoryEntry), //nolint:forcetypeassert
-		args.Bool(2), args.Error(3)
+	return args.Get(0).([]byte), args.Bool(1), args.Error(2) //nolint:forcetypeassert
 }
 
 func (m *MockLedgerReader) StreamAllLedgers(ctx context.Context, f db.StreamLedgerFn) error {

--- a/cmd/stellar-rpc/internal/methods/mocks.go
+++ b/cmd/stellar-rpc/internal/methods/mocks.go
@@ -33,8 +33,8 @@ func (m *MockLedgerReader) GetLedgerRaw(
 	sequence uint32,
 ) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
 	args := m.Called(ctx, sequence)
-	return args.Get(0).([]byte), args.Get(1).(xdr.LedgerHeaderHistoryEntry),
-		args.Bool(2), args.Error(3) //nolint:forcetypeassert
+	return args.Get(0).([]byte), args.Get(1).(xdr.LedgerHeaderHistoryEntry), //nolint:forcetypeassert
+		args.Bool(2), args.Error(3)
 }
 
 func (m *MockLedgerReader) StreamAllLedgers(ctx context.Context, f db.StreamLedgerFn) error {

--- a/cmd/stellar-rpc/internal/methods/mocks.go
+++ b/cmd/stellar-rpc/internal/methods/mocks.go
@@ -28,9 +28,9 @@ func (m *MockLedgerReader) GetLedger(ctx context.Context, sequence uint32) (xdr.
 	return args.Get(0).(xdr.LedgerCloseMeta), args.Bool(1), args.Error(2) //nolint:forcetypeassert
 }
 
-func (m *MockLedgerReader) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, bool, error) {
+func (m *MockLedgerReader) GetLedgerRaw(ctx context.Context, sequence uint32) (db.RawLedger, bool, error) {
 	args := m.Called(ctx, sequence)
-	return args.Get(0).([]byte), args.Bool(1), args.Error(2) //nolint:forcetypeassert
+	return args.Get(0).(db.RawLedger), args.Bool(1), args.Error(2) //nolint:forcetypeassert
 }
 
 func (m *MockLedgerReader) StreamAllLedgers(ctx context.Context, f db.StreamLedgerFn) error {

--- a/cmd/stellar-rpc/internal/methods/mocks.go
+++ b/cmd/stellar-rpc/internal/methods/mocks.go
@@ -28,6 +28,15 @@ func (m *MockLedgerReader) GetLedger(ctx context.Context, sequence uint32) (xdr.
 	return args.Get(0).(xdr.LedgerCloseMeta), args.Bool(1), args.Error(2) //nolint:forcetypeassert
 }
 
+func (m *MockLedgerReader) GetLedgerRaw(
+	ctx context.Context,
+	sequence uint32,
+) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error) {
+	args := m.Called(ctx, sequence)
+	return args.Get(0).([]byte), args.Get(1).(xdr.LedgerHeaderHistoryEntry),
+		args.Bool(2), args.Error(3) //nolint:forcetypeassert
+}
+
 func (m *MockLedgerReader) StreamAllLedgers(ctx context.Context, f db.StreamLedgerFn) error {
 	args := m.Called(ctx, f)
 	return args.Error(0)


### PR DESCRIPTION
### What

Uses the new raw-bytes patterning used in `getLedger` in `getLatestLedger`:
- Add `GetLedgerRaw(ctx, sequence) ([]byte, xdr.LedgerHeaderHistoryEntry, bool, error)` to `LedgerReader`
    - Returns raw bytes of ledger meta, the header, and whether it was found/if the request error'd
- Updates the `getLatestLedger` handler to call `GetLedgerRaw`
- Updates mocks/tests with `GetLedgerRaw`

### Why

`getLatestLedger` currently wastes time calling GetLedgers to get a single `LedgerCloseMeta`, which causes an `Unmarshal` to XDR. The handler then marshals this XDR to binary. On each call, we pay for a ~2.8Mb `Unmarshal` and `Marshal` that can be completely bypassed.

### Known limitations

N/A
