### PR TITLE
backfill: cap prefetch memory per chunk task

### DIFF
--- a/cmd/stellar-rpc/internal/rpcv2/backfill/backend.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/backend.go
@@ -36,21 +36,48 @@ type Backend interface {
 // Default buffered-storage tuning. Exported because the config package fills
 // them into an unset [backfill.bsb] section and the bench command uses them as
 // its flag defaults — the values are defined once, here.
-//
-// The buffer and worker values are the BACKFILL-workload numbers the rpc-hack
-// bulk-ingest benchmarking converged on: the pubnet lake stores one ledger per
-// object, so download throughput is request-latency-bound and scales with
-// workers, and a deep prefetch buffer keeps the download overlapped with
-// ingest. They apply PER BSB INSTANCE — each backfill chunk task opens its own
-// stream — so aggregate connections and prefetch RAM scale with
-// [backfill].workers. TODO: revisit once the #800 ingestion experiments sweep
-// buffer depth and worker count for real.
 const (
-	DefaultBSBBufferSize = 5000
-	DefaultBSBNumWorkers = 50
+	// Every value below is PER CHUNK TASK, and backfill runs [backfill].workers
+	// tasks at once — totals multiply by the worker count.
+
+	// DefaultBSBPrefetchBytes caps one task's prefetch in bytes — the bound
+	// that tracks memory, since object size varies ~700x across pubnet history
+	// while a count does not. Throughput is flat across an 8x range around it.
+	DefaultBSBPrefetchBytes = 32 << 20
+
+	// DefaultBSBDownloads is one task's concurrent object downloads. 12-50
+	// measure identically, and aggregates to 1600 requests are error-free, so
+	// it is chosen small.
+	DefaultBSBDownloads = 25
+
+	// DefaultBSBPrefetchObjects is one task's prefetch depth in objects. It
+	// bounds per-object overhead; memory is DefaultBSBPrefetchBytes' job.
+	DefaultBSBPrefetchObjects = 5000
+
 	DefaultBSBMaxRetries = 3
 	DefaultBSBRetryWait  = 5 * time.Second
 )
+
+// FillBSBDefaults fills unset (zero) fields; explicitly set fields are
+// honored. There is no way to disable the byte cap: zero means unset, and a
+// caller wanting it effectively unbounded sets a huge value.
+func FillBSBDefaults(
+	bsb ledgerbackend.BufferedStorageBackendConfig,
+) ledgerbackend.BufferedStorageBackendConfig {
+	if bsb.BufferSize == 0 {
+		bsb.BufferSize = DefaultBSBPrefetchObjects
+	}
+	if bsb.BufferBytes == 0 {
+		bsb.BufferBytes = DefaultBSBPrefetchBytes
+	}
+	if bsb.NumWorkers == 0 {
+		bsb.NumWorkers = DefaultBSBDownloads
+	}
+	if bsb.NumWorkers > bsb.BufferSize {
+		bsb.NumWorkers = bsb.BufferSize
+	}
+	return bsb
+}
 
 // bsbSource is the Backend over an SDK datastore (the pubnet lake): a
 // buffered-storage stream for the ledgers, plus a long-lived datastore handle used
@@ -79,17 +106,8 @@ func NewBSBBackend(
 	cfg datastore.DataStoreConfig,
 	bsb ledgerbackend.BufferedStorageBackendConfig,
 ) Backend {
-	if bsb.BufferSize == 0 {
-		bsb.BufferSize = DefaultBSBBufferSize
-	}
-	if bsb.NumWorkers == 0 {
-		bsb.NumWorkers = DefaultBSBNumWorkers
-	}
-	if bsb.NumWorkers > bsb.BufferSize {
-		bsb.NumWorkers = bsb.BufferSize
-	}
 	return &bsbSource{
-		LedgerStream: ledgerbackend.NewBufferedStorageStream(bsb, cfg, nil),
+		LedgerStream: ledgerbackend.NewBufferedStorageStream(FillBSBDefaults(bsb), cfg, nil),
 		ds:           ds,
 	}
 }

--- a/cmd/stellar-rpc/internal/rpcv2/backfill/backend_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/backend_test.go
@@ -107,3 +107,30 @@ func TestNewBSBBackendFromConfig_ManifestlessLakeNeedsSchema(t *testing.T) {
 		assert.Contains(t, err.Error(), "manifest")
 	})
 }
+
+// TestFillBSBDefaults pins the per-task defaults: fill only what is unset,
+// honor explicit values, and keep downloads within the object bound.
+func TestFillBSBDefaults(t *testing.T) {
+	got := FillBSBDefaults(ledgerbackend.BufferedStorageBackendConfig{})
+	assert.EqualValues(t, DefaultBSBPrefetchObjects, got.BufferSize)
+	assert.EqualValues(t, DefaultBSBDownloads, got.NumWorkers)
+	assert.EqualValues(t, DefaultBSBPrefetchBytes, got.BufferBytes,
+		"zero means unset — there is no way to disable the byte cap")
+
+	got = FillBSBDefaults(ledgerbackend.BufferedStorageBackendConfig{BufferSize: 1000, BufferBytes: 7 << 20})
+	assert.EqualValues(t, 1000, got.BufferSize, "an explicit depth must survive")
+	assert.EqualValues(t, 7<<20, got.BufferBytes)
+
+	got = FillBSBDefaults(ledgerbackend.BufferedStorageBackendConfig{BufferSize: 3})
+	assert.EqualValues(t, 3, got.NumWorkers,
+		"more downloads than buffer slots would leave workers with nowhere to put results")
+}
+
+// TestByteBudgetCoversItsDownloads: the default budget must at least hold what
+// its downloads dispatch, or concurrency silently drops below NumWorkers. The
+// worst tip object measured 457 KB; its pooled buffer is ~571 KB.
+func TestByteBudgetCoversItsDownloads(t *testing.T) {
+	const worstCaseBuffer = (457 << 10) * 5 / 4
+	perDownload := int64(DefaultBSBPrefetchBytes) / int64(DefaultBSBDownloads)
+	assert.GreaterOrEqual(t, perDownload, int64(worstCaseBuffer))
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/bench_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/bench_test.go
@@ -261,6 +261,9 @@ func TestBenchRejectsInvalidSourceEarly(t *testing.T) {
 	require.ErrorContains(t, err, "expected pack|bsb")
 
 	require.ErrorContains(t, sourceConfig{Kind: sourceBSB}.validate(), "--bucket-path is required")
+	require.ErrorContains(t,
+		sourceConfig{Kind: sourceBSB, BucketPath: "b", BufferBytes: -1}.validate(),
+		"cannot be negative")
 
 	for _, dir := range []string{coldRoot, hotRoot, outDir} {
 		require.NoDirExists(t, dir, "invalid invocation must not create %s", dir)

--- a/cmd/stellar-rpc/internal/rpcv2/bench/command.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/command.go
@@ -29,15 +29,16 @@ func NewCommand() *cobra.Command {
 
 // sourceFlags is the ledger-source flag set shared by both subcommands.
 type sourceFlags struct {
-	source        string
-	packDir       string
-	bucketPath    string
-	bsbBufferSize uint32
-	bsbNumWorkers uint32
-	retryLimit    uint32
-	retryWait     time.Duration
-	datastoreType string
-	region        string
+	source         string
+	packDir        string
+	bucketPath     string
+	bsbBufferSize  uint32
+	bsbBufferBytes int64
+	bsbNumWorkers  uint32
+	retryLimit     uint32
+	retryWait      time.Duration
+	datastoreType  string
+	region         string
 }
 
 func (f *sourceFlags) bind(cmd *cobra.Command) {
@@ -48,10 +49,13 @@ func (f *sourceFlags) bind(cmd *cobra.Command) {
 	fs.StringVar(&f.bucketPath, "bucket-path", "sdf-ledger-close-meta/v1/ledgers/pubnet",
 		"datastore destination_bucket_path, or the lake's local directory for "+
 			"--datastore-type=Filesystem (used iff --source=bsb)")
+	fs.Int64Var(&f.bsbBufferBytes, "bsb-buffer-bytes", 0,
+		"prefetch budget in bytes for each chunk task "+
+			"(sizes the download queue, not a hard memory ceiling); 0 = default 32 MiB")
 	fs.Uint32Var(&f.bsbBufferSize, "bsb-buffer-size", 0,
-		"BSB prefetch buffer depth PER worker (0 = backfill default)")
+		"BSB prefetch depth of one stream, in objects (0 = backfill default)")
 	fs.Uint32Var(&f.bsbNumWorkers, "bsb-num-workers", 0,
-		"BSB download workers PER worker (0 = backfill default)")
+		"concurrent object downloads inside each chunk task (0 = default 25)")
 	fs.Uint32Var(&f.retryLimit, "retry-limit", backfill.DefaultBSBMaxRetries,
 		"BSB retry attempts per object download (0 = no retries)")
 	fs.DurationVar(&f.retryWait, "retry-wait", backfill.DefaultBSBRetryWait,
@@ -67,6 +71,7 @@ func (f *sourceFlags) config() sourceConfig {
 		PackDir:       f.packDir,
 		BucketPath:    f.bucketPath,
 		BufferSize:    f.bsbBufferSize,
+		BufferBytes:   f.bsbBufferBytes,
 		NumWorkers:    f.bsbNumWorkers,
 		RetryLimit:    f.retryLimit,
 		RetryWait:     f.retryWait,

--- a/cmd/stellar-rpc/internal/rpcv2/bench/sources.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/sources.go
@@ -43,14 +43,17 @@ type sourceConfig struct {
 	// (destination_path). Required when Kind is sourceBSB.
 	BucketPath string
 
-	// BufferSize is the BSB prefetch buffer depth PER WORKER: total prefetch
-	// multiplies by the cold driver's Workers. Zero falls back to the backfill
-	// package's default.
+	// BufferSize overrides one chunk task's prefetch depth, in datastore
+	// objects. Zero takes the default.
 	BufferSize uint32
 
-	// NumWorkers is the BSB download concurrency PER WORKER: total downloads
-	// in flight multiply by the cold driver's Workers. Zero falls back to the
-	// backfill package's default.
+	// BufferBytes is one chunk task's prefetch budget in bytes; zero takes the
+	// default. It is the bound that tracks memory, since object size varies
+	// ~700x across pubnet history while a count does not.
+	BufferBytes int64
+
+	// NumWorkers overrides one chunk task's download concurrency. Zero takes
+	// the default.
 	NumWorkers uint32
 
 	// RetryLimit caps BSB download retries on transient datastore errors,
@@ -83,6 +86,10 @@ func (c sourceConfig) validate() error {
 	case sourceBSB:
 		if c.BucketPath == "" {
 			return errors.New("--bucket-path is required when --source=bsb")
+		}
+		if c.BufferBytes < 0 {
+			return fmt.Errorf("--bsb-buffer-bytes (%d) cannot be negative; "+
+				"drop the flag to use the default", c.BufferBytes)
 		}
 	default:
 		return fmt.Errorf("--source=%s; expected %s|%s", c.Kind, sourcePack, sourceBSB)
@@ -118,12 +125,13 @@ func openSource(ctx context.Context, cfg sourceConfig) (backfill.Backend, func()
 		}
 		backend, release, err := backfill.NewBSBBackendFromConfig(ctx,
 			datastore.DataStoreConfig{Type: cfg.DatastoreType, Params: params},
-			ledgerbackend.BufferedStorageBackendConfig{
-				BufferSize: cfg.BufferSize,
-				NumWorkers: cfg.NumWorkers,
-				RetryLimit: cfg.RetryLimit,
-				RetryWait:  cfg.RetryWait,
-			})
+			backfill.FillBSBDefaults(ledgerbackend.BufferedStorageBackendConfig{
+				BufferSize:  cfg.BufferSize,
+				BufferBytes: cfg.BufferBytes,
+				NumWorkers:  cfg.NumWorkers,
+				RetryLimit:  cfg.RetryLimit,
+				RetryWait:   cfg.RetryWait,
+			}))
 		if err != nil {
 			return nil, noop, fmt.Errorf("open BSB backend: %w", err)
 		}

--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -302,11 +302,17 @@ func (d DataStoreConfig) SDKConfig(networkPassphrase string) datastore.DataStore
 // key is named max_retries to match [backfill].max_retries instead of the SDK's
 // retry_limit. SDKConfig converts to the SDK type at the daemon boundary.
 type BSBConfig struct {
-	// BufferSize is how many downloaded ledgers are buffered in memory, keeping
-	// the download ahead of ingest; >= 1. Default backfill.DefaultBSBBufferSize.
+	// BufferSize is the prefetch depth of one chunk task, in datastore OBJECTS
+	// (an object holds ledgersPerFile ledgers). >= 1. It bounds per-object
+	// overhead, not memory.
 	BufferSize *uint32 `toml:"buffer_size"`
-	// NumWorkers is how many object downloads run concurrently; >= 1. Default
-	// backfill.DefaultBSBNumWorkers.
+	// BufferBytes is one chunk task's prefetch budget in bytes — the bound
+	// that tracks memory, since object size varies ~700x across pubnet history
+	// while a count does not. >= 1; unset takes the default.
+	BufferBytes *int64 `toml:"buffer_bytes"`
+
+	// NumWorkers is how many object downloads run concurrently for one chunk
+	// task; >= 1 and <= buffer_size.
 	NumWorkers *uint32 `toml:"num_workers"`
 	// MaxRetries caps how many times ONE object download (a single ledger file
 	// fetched from the datastore) is retried after a transient error, waiting
@@ -325,10 +331,11 @@ type BSBConfig struct {
 // type. Call it only after WithDefaults, when every field is non-nil.
 func (b BSBConfig) SDKConfig() ledgerbackend.BufferedStorageBackendConfig {
 	return ledgerbackend.BufferedStorageBackendConfig{
-		BufferSize: *b.BufferSize,
-		NumWorkers: *b.NumWorkers,
-		RetryLimit: *b.MaxRetries,
-		RetryWait:  *b.RetryWait,
+		BufferSize:  *b.BufferSize,
+		BufferBytes: *b.BufferBytes,
+		NumWorkers:  *b.NumWorkers,
+		RetryLimit:  *b.MaxRetries,
+		RetryWait:   *b.RetryWait,
 	}
 }
 
@@ -556,8 +563,13 @@ func (cfg Config) WithDefaults() Config {
 		v := DefaultMaxRetries
 		cfg.Backfill.MaxRetries = &v
 	}
-	fillUint32(&cfg.Backfill.BSB.BufferSize, backfill.DefaultBSBBufferSize)
-	fillUint32(&cfg.Backfill.BSB.NumWorkers, backfill.DefaultBSBNumWorkers)
+	// Resolve through backfill.FillBSBDefaults so this path and the bench
+	// cannot drift apart.
+	resolved := backfill.FillBSBDefaults(ledgerbackend.BufferedStorageBackendConfig{})
+	fillUint32(&cfg.Backfill.BSB.BufferSize, resolved.BufferSize)
+	fillInt64(&cfg.Backfill.BSB.BufferBytes, backfill.DefaultBSBPrefetchBytes)
+	fillUint32(&cfg.Backfill.BSB.NumWorkers,
+		min(resolved.NumWorkers, *cfg.Backfill.BSB.BufferSize))
 	fillUint32(&cfg.Backfill.BSB.MaxRetries, backfill.DefaultBSBMaxRetries)
 	fillDuration(&cfg.Backfill.BSB.RetryWait, backfill.DefaultBSBRetryWait)
 	if cfg.Retention.RetentionChunks == nil {
@@ -684,6 +696,12 @@ func fillUint(p **uint, v uint) {
 }
 
 func fillBool(p **bool, v bool) {
+	if *p == nil {
+		*p = &v
+	}
+}
+
+func fillInt64(p **int64, v int64) {
 	if *p == nil {
 		*p = &v
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
@@ -134,8 +134,9 @@ func TestParseConfig_MinimalAppliesDefaults(t *testing.T) {
 	// Documented defaults filled.
 	assert.Equal(t, runtime.GOMAXPROCS(0), *cfg.Backfill.Workers)
 	assert.Equal(t, DefaultMaxRetries, *cfg.Backfill.MaxRetries)
-	assert.Equal(t, uint32(backfill.DefaultBSBBufferSize), *cfg.Backfill.BSB.BufferSize)
-	assert.Equal(t, uint32(backfill.DefaultBSBNumWorkers), *cfg.Backfill.BSB.NumWorkers)
+	assert.Equal(t, uint32(backfill.DefaultBSBPrefetchObjects), *cfg.Backfill.BSB.BufferSize)
+	assert.Equal(t, uint32(backfill.DefaultBSBDownloads), *cfg.Backfill.BSB.NumWorkers)
+	assert.Equal(t, int64(backfill.DefaultBSBPrefetchBytes), *cfg.Backfill.BSB.BufferBytes)
 	assert.Equal(t, uint32(backfill.DefaultBSBMaxRetries), *cfg.Backfill.BSB.MaxRetries)
 	assert.Equal(t, backfill.DefaultBSBRetryWait, *cfg.Backfill.BSB.RetryWait)
 	assert.Equal(t, uint32(0), *cfg.Retention.RetentionChunks)

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags.go
@@ -38,6 +38,7 @@ type FlagOverrides interface {
 	GetUint(name string) (uint, error)
 	GetUint32(name string) (uint32, error)
 	GetInt(name string) (int, error)
+	GetInt64(name string) (int64, error)
 	GetDuration(name string) (time.Duration, error)
 	GetStringSlice(name string) ([]string, error)
 	GetStringToString(name string) (map[string]string, error)
@@ -62,6 +63,8 @@ func BindFlags(fs *pflag.FlagSet) {
 			fs.Uint32(path, 0, usage)
 		case kindInt:
 			fs.Int(path, 0, usage)
+		case kindInt64:
+			fs.Int64(path, 0, usage)
 		case kindDuration:
 			fs.Duration(path, 0, usage)
 		case kindStringSlice:
@@ -93,68 +96,58 @@ func ApplyFlags(cfg *Config, fs FlagOverrides) error {
 	return firstErr
 }
 
-//nolint:cyclop // one case per supported leaf type; splitting hides the correspondence
 func setLeaf(f reflect.Value, path string, fs FlagOverrides) error {
-	fail := func(err error) error { return fmt.Errorf("apply flag --%s: %w", path, err) }
+	// Every scalar kind does the same three things and differs only in which
+	// getter it calls, so each case is that one call and the shared get-check-
+	// assign lives once, below.
+	var (
+		v   any
+		err error
+	)
 	switch leafKind(f.Type()) {
 	case kindString:
-		v, err := fs.GetString(path)
-		if err != nil {
-			return fail(err)
-		}
-		setPossiblyPointer(f, reflect.ValueOf(v))
+		v, err = fs.GetString(path)
 	case kindBool:
-		v, err := fs.GetBool(path)
-		if err != nil {
-			return fail(err)
-		}
-		setPossiblyPointer(f, reflect.ValueOf(v))
+		v, err = fs.GetBool(path)
 	case kindUint:
-		v, err := fs.GetUint(path)
-		if err != nil {
-			return fail(err)
-		}
-		setPossiblyPointer(f, reflect.ValueOf(v))
+		v, err = fs.GetUint(path)
 	case kindUint32:
-		v, err := fs.GetUint32(path)
-		if err != nil {
-			return fail(err)
-		}
-		setPossiblyPointer(f, reflect.ValueOf(v))
+		v, err = fs.GetUint32(path)
 	case kindInt:
-		v, err := fs.GetInt(path)
-		if err != nil {
-			return fail(err)
-		}
-		setPossiblyPointer(f, reflect.ValueOf(v))
+		v, err = fs.GetInt(path)
+	case kindInt64:
+		v, err = fs.GetInt64(path)
 	case kindDuration:
-		v, err := fs.GetDuration(path)
-		if err != nil {
-			return fail(err)
-		}
-		setPossiblyPointer(f, reflect.ValueOf(v))
+		v, err = fs.GetDuration(path)
 	case kindStringSlice:
-		v, err := fs.GetStringSlice(path)
-		if err != nil {
-			return fail(err)
-		}
-		setPossiblyPointer(f, reflect.ValueOf(v))
+		v, err = fs.GetStringSlice(path)
 	case kindStringMap:
-		v, err := fs.GetStringToString(path)
-		if err != nil {
-			return fail(err)
-		}
-		// Merge per key, don't replace the map: a map flag names individual
-		// entries, and clobbering the file's sibling entries is never what the
-		// operator meant.
-		if f.IsNil() {
-			f.Set(reflect.MakeMap(f.Type()))
-		}
-		for k, val := range v {
-			f.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(val))
-		}
+		// The one kind that is not a plain assignment.
+		return setMapLeaf(f, path, fs)
 	case kindUnsupported:
 		// unreachable: walkLeaves panics on an unsupported leaf before visiting
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("apply flag --%s: %w", path, err)
+	}
+	setPossiblyPointer(f, reflect.ValueOf(v))
+	return nil
+}
+
+// setMapLeaf merges per key rather than replacing the map: a map flag names
+// individual entries, and clobbering the file's sibling entries is never what
+// the operator meant.
+func setMapLeaf(f reflect.Value, path string, fs FlagOverrides) error {
+	v, err := fs.GetStringToString(path)
+	if err != nil {
+		return fmt.Errorf("apply flag --%s: %w", path, err)
+	}
+	if f.IsNil() {
+		f.Set(reflect.MakeMap(f.Type()))
+	}
+	for k, val := range v {
+		f.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(val))
 	}
 	return nil
 }
@@ -181,6 +174,7 @@ const (
 	kindUint
 	kindUint32
 	kindInt
+	kindInt64
 	kindDuration
 	kindStringSlice
 	kindStringMap
@@ -210,6 +204,9 @@ func leafKind(t reflect.Type) kind {
 		return kindUint32
 	case reflect.Int:
 		return kindInt
+	case reflect.Int64:
+		// time.Duration is also Int64-kinded and is matched above, before this.
+		return kindInt64
 	case reflect.Slice:
 		if t.Elem().Kind() == reflect.String {
 			return kindStringSlice

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
@@ -108,6 +108,7 @@ func TestApplyFlags_OverridesFileValues(t *testing.T) {
 		"--backfill.workers=3",
 		"--ingestion.history_archive_urls=https://a.example,https://b.example",
 		"--backfill.bsb.retry_wait=7s",
+		"--backfill.bsb.buffer_bytes=1024",
 	}))
 
 	cfg, err := DecodeConfig([]byte(minimalValidConfig))
@@ -121,6 +122,8 @@ func TestApplyFlags_OverridesFileValues(t *testing.T) {
 	assert.Equal(t, 3, *cfg.Backfill.Workers)
 	assert.Equal(t, []string{"https://a.example", "https://b.example"}, cfg.Ingestion.HistoryArchiveURLs)
 	assert.Equal(t, 7*time.Second, *cfg.Backfill.BSB.RetryWait)
+	assert.EqualValues(t, 1024, *cfg.Backfill.BSB.BufferBytes,
+		"an explicit budget must survive WithDefaults, not be replaced by the default")
 }
 
 func TestApplyFlags_BoolOverride(t *testing.T) {

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -206,6 +206,13 @@ func validateBSB(bsb config.BSBConfig) error {
 	if *bsb.BufferSize < 1 {
 		return errors.New("[backfill.bsb].buffer_size must be >= 1")
 	}
+	// There is no off switch: unset (nil, filled with the default by
+	// WithDefaults) or a positive budget. An operator wanting it effectively
+	// unbounded sets a huge value — visibly, in bytes.
+	if bytes := deref(bsb.BufferBytes); bytes < 1 {
+		return fmt.Errorf("[backfill.bsb].buffer_bytes (%d) must be >= 1; "+
+			"delete the key to use the default", bytes)
+	}
 	if *bsb.NumWorkers < 1 {
 		return errors.New("[backfill.bsb].num_workers must be >= 1")
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
@@ -248,6 +248,7 @@ func TestValidateConfig_RejectsMalformedService(t *testing.T) {
 
 func TestValidateConfig_RejectsMalformedBSB(t *testing.T) {
 	uint32Ptr := func(v uint32) *uint32 { return &v }
+	int64Ptr := func(v int64) *int64 { return &v }
 	durPtr := func(v time.Duration) *time.Duration { return &v }
 
 	tests := []struct {
@@ -278,6 +279,18 @@ func TestValidateConfig_RejectsMalformedBSB(t *testing.T) {
 				c.Backfill.BSB.NumWorkers = uint32Ptr(50)
 			},
 			"num_workers",
+		},
+		{
+			"negative buffer_bytes",
+			func(c *config.Config) { c.Backfill.BSB.BufferBytes = int64Ptr(-1) },
+			"[backfill.bsb].buffer_bytes",
+		},
+		{
+			// There is no off switch; zero would silently mean "cap off" at the
+			// SDK, which is the configuration that caused #895.
+			"zero buffer_bytes",
+			func(c *config.Config) { c.Backfill.BSB.BufferBytes = int64Ptr(0) },
+			"[backfill.bsb].buffer_bytes",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -255,14 +255,30 @@ ledgers_per_file = 1
 files_per_partition = 64000
 
 # --- Buffered reads over the datastore ---------------------------------------
-# Tunes the buffered-storage stream that downloads ledger objects from
-# [backfill.datastore]. max_retries here retries ONE object download (a single
-# ledger file) after a transient datastore error, waiting retry_wait between
-# attempts — a different knob from [backfill].max_retries above, which re-runs
-# a whole chunk task.
+# Tunes how each of the [backfill].workers chunk tasks downloads ledger objects
+# from [backfill.datastore]. max_retries here retries ONE object download (a
+# single ledger file) after a transient datastore error, waiting retry_wait
+# between attempts — a different knob from [backfill].max_retries above, which
+# re-runs a whole chunk task.
 [backfill.bsb]
-buffer_size = 5000   # downloaded ledgers buffered in memory; >= 1
-num_workers = 50     # concurrent object downloads; >= 1 and <= buffer_size
+# Every key below is per chunk task, so totals multiply by [backfill].workers.
+# Unset is the intended configuration.
+#
+# buffer_bytes: prefetch budget in bytes for one chunk task — sizes how far
+# downloads run ahead, and is the bound that tracks memory: a pubnet object
+# grew from 295 bytes in early history to ~210 KB near the tip, so an object
+# count says nothing about bytes. Not a hard ceiling — in-flight downloads and
+# reused buffers sit on top.
+#buffer_bytes = 33_554_432 # 32 MiB (the default)
+#
+# num_workers: concurrent object downloads inside one chunk task.
+#num_workers = 25
+#
+# buffer_size: prefetch depth of one chunk task in datastore OBJECTS (not
+# ledgers — an object holds ledgers_per_file of them). Bounds per-object
+# overhead; memory is buffer_bytes' job.
+#buffer_size = 5000
+
 max_retries = 3      # retries per object download; 0 = fail on first error
 retry_wait = "5s"    # pause between retries of one object download
 

--- a/cmd/stellar-rpc/rpcv2/sample_config_test.go
+++ b/cmd/stellar-rpc/rpcv2/sample_config_test.go
@@ -49,8 +49,9 @@ func TestSampleConfig_ParsesStrict(t *testing.T) {
 	assert.Equal(t, "http://localhost:11626", cfg.Ingestion.CoreURL,
 		"the sample leaves core_url commented out, so it derives from core_http_port")
 
-	assert.Equal(t, uint32(backfill.DefaultBSBBufferSize), *cfg.Backfill.BSB.BufferSize)
-	assert.Equal(t, uint32(backfill.DefaultBSBNumWorkers), *cfg.Backfill.BSB.NumWorkers)
+	assert.Equal(t, uint32(backfill.DefaultBSBPrefetchObjects), *cfg.Backfill.BSB.BufferSize)
+	assert.Equal(t, uint32(backfill.DefaultBSBDownloads), *cfg.Backfill.BSB.NumWorkers)
+	assert.Equal(t, int64(backfill.DefaultBSBPrefetchBytes), *cfg.Backfill.BSB.BufferBytes)
 	assert.Equal(t, uint32(backfill.DefaultBSBMaxRetries), *cfg.Backfill.BSB.MaxRetries)
 	assert.Equal(t, backfill.DefaultBSBRetryWait, *cfg.Backfill.BSB.RetryWait)
 }

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
-	github.com/stellar/go-stellar-sdk v0.7.3-0.20260819053947-7cf218897cec
+	github.com/stellar/go-stellar-sdk v0.7.4-0.20260825061852-f479ee9335f3
 	github.com/stellar/streamhash v0.0.0-20260713164615-c72a4e6f578d
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -445,6 +445,8 @@ github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMps
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stellar/go-stellar-sdk v0.7.3-0.20260819053947-7cf218897cec h1:Qlvfsrx3pbdhDpkKvBQ8WWz3EK+6MU94ld5X6TsIw7w=
 github.com/stellar/go-stellar-sdk v0.7.3-0.20260819053947-7cf218897cec/go.mod h1:YTYl7/zFt7oIX5Y4WRgL+3d2upWQDLywlHunZ4fOxvc=
+github.com/stellar/go-stellar-sdk v0.7.4-0.20260825061852-f479ee9335f3 h1:UZH3dIn0PHPqF4ZkuZ6DkhVKtP7UmC0BXuFyInEtbwI=
+github.com/stellar/go-stellar-sdk v0.7.4-0.20260825061852-f479ee9335f3/go.mod h1:YTYl7/zFt7oIX5Y4WRgL+3d2upWQDLywlHunZ4fOxvc=
 github.com/stellar/go-xdr v0.0.0-20260806060815-dc590f17552a h1:40YIhQusSioBKDW5Tr+YdjoXphcVeu7eXUS2ibMQBTs=
 github.com/stellar/go-xdr v0.0.0-20260806060815-dc590f17552a/go.mod h1:If+U9Z1W5xU97VrOgJandQT+2dN7/iOpkCrxBJEyF80=
 github.com/stellar/streamhash v0.0.0-20260713164615-c72a4e6f578d h1:KOjgc+0Q2hsqnOa7Zn6sPiGMNDB/wyVC5WpriJV54s4=


### PR DESCRIPTION
> [!NOTE]
> stellar/go-stellar-sdk#5988 (`BufferBytes`) is **merged**; `go.mod` pins its merge commit (`f479ee93`).

## What

BSB prefetch was 5,000 objects per chunk task with 50 concurrent downloads each, and a pubnet object grew ~700× across history — so the setting costing ~12 MB at genesis cost ~8.4 GB near the tip on an 8-core box. Doubled by GOGC, that is #895's memory finding.

This caps each task's prefetch in **bytes** instead:

| `[backfill.bsb]` key | default (per chunk task) |
|---|---|
| `buffer_bytes` (new in the SDK) | 32 MiB |
| `num_workers` | 25 |
| `buffer_size` | 5,000 objects (bounds per-object overhead, not memory) |

**Every key is per chunk task; totals multiply by `[backfill].workers`.** One rule on every surface: unset takes the default; there is no off switch — `0` and negatives are rejected at config load, since an uncapped prefetch is the configuration that caused #895. Set a huge value for effectively-unbounded.

## Results

16 pubnet tip chunks, 8 workers, `GOMEMLIMIT` unset, both sides built from this base ref:

| | peak RSS | swap | events_total |
|---|---|---|---|
| base (defaults) | 26.49 GB | 0 | 8m41s |
| this PR | **7.11 / 7.13 / 7.33 GB** (three reps, one on the exact final commit) | 0 | 8m43s / 8m45s |

For scale, #895 measured this base at ~29 GB + 8 GB swap over full history. On the campaign branch (#902), whose memory work stacks with this, the same fix measures 5.8 GB.

Supporting measurements: throughput is flat across a 100× object-count range and an 8× byte-budget range; 12–50 downloads per task measure identically; and at 32 workers, aggregate download concurrency of 256 / 800 / **1,600** concurrent GCS requests is throughput-identical and error-free — which is why a flat per-task default is safe and no cross-worker budget pooling is needed.

## Scope

The prefetch half of #895. The other memory driver named there — cross-window index builds at `NumCPU/2` — is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zyTXU8wkocJgN6mBafnou


