### PR TITLE
Delete the supervised loop: crash-only daemon, runner-shaped read server

### DIFF
--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -73,46 +73,43 @@ type HandlerSpec struct {
 	RequestDurationLimit time.Duration
 }
 
-// HandlerMetrics is the set of collectors a Handler writes to. Create it ONCE
-// per process with NewHandlerMetrics — creating it is what registers the
-// collectors, and registering the same collector twice on one registry panics.
-// NewHandler only writes to it, so a daemon that rebuilds its handler (the
-// full-history daemon does, per supervised attempt) keeps counting on the same
-// series across rebuilds instead of resetting them.
-type HandlerMetrics struct {
-	requestDuration *prometheus.SummaryVec
-}
-
-// NewHandlerMetrics creates the handler collectors and registers them on reg.
-func NewHandlerMetrics(namespace string, reg prometheus.Registerer) *HandlerMetrics {
-	m := &HandlerMetrics{
-		requestDuration: prometheus.NewSummaryVec(prometheus.SummaryOpts{
-			Namespace:  namespace,
-			Subsystem:  "json_rpc",
-			Name:       "request_duration_seconds",
-			Help:       "JSON RPC request duration",
-			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-		}, []string{"endpoint", labelStatus}),
-	}
-	reg.MustRegister(m.requestDuration)
-	return m
-}
-
 // Params carries everything NewHandler needs besides the method specs: the
-// daemon (for metric namespacing), the per-process handler metrics, the
-// logger, and the global request limits applied across all methods.
+// daemon (for metric namespacing and registry), the logger, and the global
+// request limits applied across all methods.
 type Params struct {
 	Daemon                host.Daemon
 	Logger                *log.Entry
-	Metrics               *HandlerMetrics
 	Specs                 []HandlerSpec
 	GlobalQueueLimit      uint
 	GlobalDurationWarning time.Duration
 	GlobalDurationLimit   time.Duration
 }
 
-func decorateHandlers(metrics *HandlerMetrics, logger *log.Entry, m handler.Map) handler.Map {
-	requestMetric := metrics.requestDuration
+// decorateHandlers wraps every method with request logging and the duration
+// summary. Each daemon builds its handler once, so creating and registering
+// the collector here happens once per registry.
+func decorateHandlers(daemon host.Daemon, logger *log.Entry, m handler.Map) handler.Map {
+	requestMetric := prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace:  daemon.MetricsNamespace(),
+		Subsystem:  "json_rpc",
+		Name:       "request_duration_seconds",
+		Help:       "JSON RPC request duration",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	}, []string{"endpoint", labelStatus})
+	// Register-or-reuse: each daemon builds its handler once today, but a
+	// second build on the same registry (a future reload or re-bind) must keep
+	// counting on the existing series, not panic on duplicate registration.
+	if rerr := daemon.MetricsRegistry().Register(requestMetric); rerr != nil {
+		are := prometheus.AlreadyRegisteredError{}
+		if !errors.As(rerr, &are) {
+			panic(rerr)
+		}
+		existing, ok := are.ExistingCollector.(*prometheus.SummaryVec)
+		if !ok {
+			panic(rerr)
+		}
+		requestMetric = existing
+	}
 	decorated := handler.Map{}
 	for endpoint, h := range m {
 		decorated[endpoint] = handler.New(func(ctx context.Context, r *jrpc2.Request) (any, error) {
@@ -227,9 +224,6 @@ func wrapWithLimiters(spec HandlerSpec, daemon host.Daemon, logger *log.Entry) j
 
 // NewHandler constructs a Handler instance from the given method specs
 func NewHandler(params Params) Handler {
-	if params.Metrics == nil {
-		panic("jsonrpc: Params.Metrics is required — create it once per process with NewHandlerMetrics")
-	}
 	bridgeOptions := jhttp.BridgeOptions{
 		Server: &jrpc2.ServerOptions{
 			Logger: func(text string) { params.Logger.Debug(text) },
@@ -244,7 +238,7 @@ func NewHandler(params Params) Handler {
 		handlersMap[spec.MethodName] = wrapWithLimiters(spec, params.Daemon, params.Logger)
 	}
 	bridge := jhttp.NewBridge(decorateHandlers(
-		params.Metrics,
+		params.Daemon,
 		params.Logger,
 		handlersMap),
 		&bridgeOptions)

--- a/cmd/stellar-rpc/internal/rpcv1/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/rpcv1/jsonrpc.go
@@ -108,7 +108,6 @@ func NewJSONRPCHandler(cfg *config.Config, params HandlerParams) Handler {
 	return jsonrpc.NewHandler(jsonrpc.Params{
 		Daemon:                params.Daemon,
 		Logger:                params.Logger,
-		Metrics:               jsonrpc.NewHandlerMetrics(params.Daemon.MetricsNamespace(), params.Daemon.MetricsRegistry()),
 		Specs:                 specs,
 		GlobalQueueLimit:      cfg.RequestBacklogGlobalQueueLimit,
 		GlobalDurationWarning: cfg.RequestExecutionWarningThreshold,

--- a/cmd/stellar-rpc/internal/rpcv2/adapters/seed.go
+++ b/cmd/stellar-rpc/internal/rpcv2/adapters/seed.go
@@ -1,6 +1,8 @@
 package adapters
 
 import (
+	"errors"
+
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 )
 
@@ -20,15 +22,19 @@ func SeedCloseTimes(registry *query.Registry) error {
 	if oldest > latest {
 		return nil
 	}
-	firstCT, err := readCloseTime(view, oldest, "oldest")
-	if err != nil {
-		return err
+	// The edges live in independent stores (cold pack vs hot DB), so attempt
+	// both even when one fails: the joined error shows every broken edge in
+	// the caller's one failure instead of one edge per restart.
+	var errs []error
+	if firstCT, err := readCloseTime(view, oldest, "oldest"); err != nil {
+		errs = append(errs, err)
+	} else {
+		view.RecordOldestCloseTime(firstCT)
 	}
-	view.RecordOldestCloseTime(firstCT)
-	lastCT, err := readCloseTime(view, latest, "latest")
-	if err != nil {
-		return err
+	if lastCT, err := readCloseTime(view, latest, "latest"); err != nil {
+		errs = append(errs, err)
+	} else {
+		registry.SetLatestLedger(latest, lastCT)
 	}
-	registry.SetLatestLedger(latest, lastCT)
-	return nil
+	return errors.Join(errs...)
 }

--- a/cmd/stellar-rpc/internal/rpcv2/backfill/backend.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/backend.go
@@ -157,8 +157,8 @@ func waitForCoverage(ctx context.Context, b Backend, target uint32, interval, ti
 		tip, err := b.Tip(tipCtx)
 		if err != nil {
 			// A tip-query failure stops this poll loop immediately (no point
-			// re-polling a broken backend); the error surfaces to the pass,
-			// which supervise restarts.
+			// re-polling a broken backend); the error surfaces and fails the
+			// pass (the process exits; the orchestrator restarts).
 			return backoff.Permanent(fmt.Errorf("backend tip query: %w", err))
 		}
 		if tip >= target {

--- a/cmd/stellar-rpc/internal/rpcv2/backfill/execute.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/execute.go
@@ -240,8 +240,9 @@ func (cfg ExecConfig) retryBackOff() backoff.BackOff {
 
 // RunBackfill resolves the missing work, then executePlans the diff. No upfront
 // producibility gate: an unproducible chunk surfaces as a backfillSource error when
-// the executor reaches it — retried under withRetries, then failing the pass so
-// supervise restarts (its bounded coverage wait handles a lagging-but-advancing backend).
+// the executor reaches it — retried under withRetries, then failing the pass
+// (the process exits and startup re-derives the remaining work on the next run;
+// the bounded coverage wait handles a lagging-but-advancing backend).
 func RunBackfill(ctx context.Context, cfg ExecConfig, rangeStart, rangeEnd chunk.ID) error {
 	cfg = cfg.WithDefaults()
 	if err := cfg.validate(); err != nil {

--- a/cmd/stellar-rpc/internal/rpcv2/backfill/process.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/process.go
@@ -143,7 +143,7 @@ func processChunk(ctx context.Context, chunkID chunk.ID, artifacts catalog.Artif
 // no-op otherwise), in preference order:
 //  1. a ready, COMPLETE hot tier (decision (a): maxCommittedSeq >= last ledger);
 //     incomplete-but-present is staleness that falls through (re-derivation
-//     recovers it); a "ready" DB that won't open is an ordinary restartable error
+//     recovers it); a "ready" DB that won't open is an ordinary run-failing error
 //     (read-only open, never auto-healed);
 //  2. the frozen local .pack, unless ledgers is itself requested (circular);
 //  3. the bulk backend, gated by a bounded waitForCoverage on its Tip.
@@ -158,7 +158,7 @@ func backfillSource(
 	// or recovery-demoted) is not a read source; an absent key falls through.
 	src, closer, used, herr := resolveHotSource(chunkID, cfg)
 	if herr != nil {
-		return nil, noClose, herr // hot-DB open failure — restartable, never auto-healed
+		return nil, noClose, herr // hot-DB open failure — fails the run, never auto-healed
 	}
 	if used {
 		cfg.Logger.Debugf("backfillSource: chunk %s from complete hot tier", chunkID)
@@ -203,7 +203,7 @@ func backfillSource(
 // resolveHotSource applies the hot branch end to end: it reads the hot key and,
 // only when "ready", tries the hot tier. used=true → src/closer are the hot
 // source; used=false → no "ready" key or present-but-incomplete (caller falls
-// through); err → a "ready" DB that won't open (restartable). Keeps backfillSource's
+// through); err → a "ready" DB that won't open (fails the run). Keeps backfillSource's
 // hot branch flat.
 func resolveHotSource(
 	chunkID chunk.ID, cfg ProcessConfig,
@@ -229,7 +229,7 @@ func resolveHotSource(
 // shared hot DB read-only (never auto-healed) straight from its Layout path.
 // used=true when present AND complete; used=false when present-but-incomplete
 // (staleness, caller falls through); err when a "ready" DB is absent or unopenable
-// — an ordinary restartable error, detected lazily on the open.
+// — an ordinary run-failing error, detected lazily on the open.
 func tryHotSource(
 	state geometry.HotState, chunkID chunk.ID, cfg ProcessConfig,
 ) (ledgerbackend.LedgerStream, func() error, bool, error) {
@@ -238,7 +238,7 @@ func tryHotSource(
 	// enforcement site: the freeze reads its ledgers to re-derive the cold artifacts
 	// and must never mutate it (the read-only open replays any un-synced WAL into
 	// memtables but persists nothing). An absent or gutted "ready" DB fails the open
-	// — restartable, never auto-created.
+	// — fails the run, never auto-created.
 	hot, err := hotchunk.OpenReadyView(state, dir, chunkID, cfg.Logger)
 	if err != nil {
 		return nil, nil, false, err
@@ -247,7 +247,7 @@ func tryHotSource(
 	if merr != nil {
 		_ = hot.Close()
 		// A read error against an opened DB: the DB opened but cannot answer its
-		// own progress. Surface it (restartable), don't treat as staleness.
+		// own progress. Surface it (fails the run), don't treat as staleness.
 		return nil, nil, false, fmt.Errorf("chunk %s: read hot max committed seq: %w", chunkID, merr)
 	}
 	// decision (a): complete iff the single DB's maxCommittedSeq reaches the chunk's

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/support/storage"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/host"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/jsonrpc"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/preflight"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/backfill"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/catalog"
@@ -30,16 +29,29 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/ingest"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/observability"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 )
 
 // RunDaemon is the full-history daemon's process entrypoint: load config, lock
 // storage roots, open the catalog, validateConfig, build boundaries, then run
-// the supervised run loop. flags carries the CLI overrides main registered via
+// the daemon body. flags carries the CLI overrides main registered via
 // config.BindFlags (nil = none); each set flag overlays its TOML key before
 // defaults resolve.
 func RunDaemon(ctx context.Context, configPath string, flags config.FlagOverrides) error {
-	return runDaemonWith(ctx, configPath, daemonOptions{Flags: flags})
+	// The whole daemon — including the pre-run startup phase (archive dial, tip
+	// sampling, core wiring) — runs on the signal-derived ctx, so a drain that
+	// lands mid-startup unwinds with ctx-shaped errors. Classify those as the
+	// clean shutdown they are; a nonzero exit must keep meaning failure.
+	err := runDaemonWith(ctx, configPath, daemonOptions{Flags: flags})
+	if ctx.Err() == nil {
+		return err
+	}
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		// A real startup failure raced the shutdown request: exit 0 is still
+		// right (the shutdown was asked for), but the failure must not vanish.
+		// stderr, not the structured logger — the earliest failures precede it.
+		fmt.Fprintln(os.Stderr, "shutdown requested while startup was failing:", err)
+	}
+	return nil
 }
 
 // daemonOptions carries the daemon's injectable seams; production leaves every field zero.
@@ -55,15 +67,11 @@ type daemonOptions struct {
 	// [ingestion] (a complete production opener). Tests inject a fake getter.
 	Core CoreOpener
 
-	// ServeReads launches the RPC read server over one supervised attempt's
-	// query registry (the contract lives on StartConfig.ServeReads).
+	// ServeReads overrides the read server (contract on StartConfig.ServeReads).
 	// nil ⇒ the production server (newServeReads): the shared method table over
 	// the router-backed adapters, listening on [service].endpoint. Tests inject
 	// recorders.
-	ServeReads func(ctx context.Context, reg *query.Registry) (func(), <-chan error, error)
-
-	// RestartBackoff is the supervised loop's inter-restart sleep; zero ⇒ defaultRestartBackoff.
-	RestartBackoff time.Duration
+	ServeReads serveReadsFn
 
 	// Logger overrides the daemon logger; nil ⇒ built from [logging].level/.format.
 	Logger *supportlog.Entry
@@ -87,8 +95,6 @@ type daemonOptions struct {
 	// discard/prune set it small so the end-of-run destroy does not park.
 	lifecycleGrace time.Duration
 }
-
-const defaultRestartBackoff = 5 * time.Second
 
 // runDaemonWith is RunDaemon with explicit options — the seam tests drive.
 //
@@ -189,9 +195,10 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 
 	// The getFeeStats windows, sized by [service.fee_stats] (validated 1..1000
 	// by validateConfig just above). Owned here at daemon level: live ingestion
-	// feeds them per committed ledger, each run's restart replay (#888) refills
-	// them, and the hot loop's per-boundary HotService rebuilds only borrow them
-	// — so chunk boundaries and supervised restarts never lose fee history.
+	// feeds them per committed ledger, the startup replay (#888) refills them
+	// from committed history, and the hot loop's per-boundary HotService
+	// rebuilds only borrow them. Owned here because one instance is wired into
+	// both the serve deps and the ingestion loop below.
 	// The method table serves them as the store.FeeStats behind getFeeStats.
 	feeWindows := feewindow.NewFeeWindows(
 		deref(cfg.Service.FeeStats.ClassicFeeWindowLedgers),
@@ -205,8 +212,8 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	metrics, sink := buildSinks(opts, registry)
 
 	// --- Captive-core state access for the three endpoints that need it, plus
-	// simulateTransaction's preflight pool. Built once, outside the supervised
-	// loop: the pool registers collectors on the registry above, and registering
+	// simulateTransaction's preflight pool. Built once, before the daemon body:
+	// the pool registers collectors on the registry above, and registering
 	// the same collector twice panics. The method table consumes both. ---
 	coreDaemon, err := corestate.New(ctx, corestate.Config{
 		CoreURL:               cfg.Ingestion.CoreURL,
@@ -230,8 +237,8 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	}).Info("wired the captive-core-backed endpoints")
 
 	// --- The two HTTP servers. The admin server (pprof, /metrics) is
-	// process-wide; the JSON-RPC server is per supervised attempt (its handlers
-	// hold that attempt's query registry), so ServeReads builds it inside run(). ---
+	// process-wide; the JSON-RPC server is per run(): its handlers hold run()'s
+	// query registry, so ServeReads builds it there. ---
 	if cfg.Service.AdminEndpoint != "" {
 		stopAdmin, aerr := startAdminServer(ctx, cfg.Service.AdminEndpoint, logger, registry)
 		if aerr != nil {
@@ -241,22 +248,18 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	}
 	serveReads := opts.ServeReads
 	if serveReads == nil {
-		serveReads = newServeReads(readServerDeps{
-			cfg: cfg,
-			params: handlerParams{
-				daemon:            coreDaemon,
-				logger:            logger,
-				handlerMetrics:    jsonrpc.NewHandlerMetrics(host.PrometheusNamespace, registry),
-				metrics:           metrics,
-				preflightGetter:   preflightPool,
-				feeWindows:        feeWindows,
-				networkPassphrase: core.networkPassphrase,
-				retentionWindow:   retention.RetentionWindow(),
-			},
+		serveReads = newServeReads(cfg, handlerParams{
+			daemon:            coreDaemon,
+			logger:            logger,
+			metrics:           metrics,
+			preflightGetter:   preflightPool,
+			feeWindows:        feeWindows,
+			networkPassphrase: core.networkPassphrase,
+			retentionWindow:   retention.RetentionWindow(),
 		})
 	}
 
-	// --- Assemble the StartConfig and run the supervised run loop. ---
+	// --- Assemble the StartConfig and run the daemon body once. ---
 	start := startConfig(
 		cfg, cat, logger, backend, core.live, serveReads, metrics, sink, retention)
 	start.lifecycleGrace = opts.lifecycleGrace
@@ -265,11 +268,27 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	}
 	start.FeeWindows = feeWindows
 
-	backoff := opts.RestartBackoff
-	if backoff <= 0 {
-		backoff = defaultRestartBackoff
+	return runBody(ctx, start, logger)
+}
+
+// runBody executes the daemon body once, mapping a canceled ctx to nil so
+// main exits 0 on SIGTERM; any other error surfaces and crashes the process
+// (the crash-only rationale lives on run). The exit path is the failure
+// contract now, so the crash reason is logged structurally here — stderr in
+// main is not a structured sink — and a real failure that raced a shutdown
+// request is logged too instead of being discarded by the clean-exit mapping.
+func runBody(ctx context.Context, start StartConfig, logger *supportlog.Entry) error {
+	err := run(ctx, start)
+	if ctx.Err() == nil {
+		if err != nil {
+			logger.WithError(err).Error("daemon run failed; exiting for the orchestrator to restart")
+		}
+		return err
 	}
-	return supervise(ctx, start, logger, backoff)
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		logger.WithError(err).Warn("shutdown requested while a run failure was in flight")
+	}
+	return nil
 }
 
 // openCatalog resolves the tx-hash index width (test override, else the fixed
@@ -327,7 +346,7 @@ func resolveCore(opts daemonOptions, cfg config.Config, logger *supportlog.Entry
 func startConfig(
 	cfg config.Config, cat *catalog.Catalog, logger *supportlog.Entry,
 	backend backfill.Backend, core CoreOpener,
-	serveReads func(context.Context, *query.Registry) (func(), <-chan error, error),
+	serveReads serveReadsFn,
 	metrics observability.Metrics, sink ingest.MetricSink, retention geometry.Retention,
 ) StartConfig {
 	exec := backfill.ExecConfig{
@@ -378,45 +397,6 @@ func buildSinks(opts daemonOptions, registry *prometheus.Registry) (observabilit
 		sink = ingest.NewPrometheusSink(registry, host.PrometheusNamespace)
 	}
 	return metrics, sink
-}
-
-// supervise is the daemon's clean-vs-restart decision point ("startup is the
-// recovery path"): a ctx cancel is a clean shutdown, everything else is warned and
-// retried after a backoff. run() never returns nil (a clean shutdown surfaces as a
-// ctx-canceled error), so clean-vs-restart keys solely off ctx.Err(). There is
-// deliberately no fatal-and-exit class — genuine loss presents as a crash-loop with
-// a clear warn line. The never-auto-heal guarantee lives in the must-exist open
-// (openHotDBForChunk), not here.
-//
-//nolint:unparam // error-shaped for the caller's contract; nil-on-shutdown is the design above
-func supervise(
-	ctx context.Context, start StartConfig, logger *supportlog.Entry, backoff time.Duration,
-) error {
-	for {
-		err := run(ctx, start)
-		if ctx.Err() != nil {
-			return nil //nolint:nilerr // ctx canceled is a clean shutdown, not a run failure
-		}
-		logger.WithError(err).Warnf("daemon run failed; restarting in %s", backoff)
-		if sleepCtx(ctx, backoff) != nil {
-			return nil //nolint:nilerr // ctx canceled mid-backoff is a clean shutdown, not a failure
-		}
-	}
-}
-
-// sleepCtx blocks for d or until ctx is canceled, returning ctx.Err() if canceled
-// first and nil otherwise. supervise's clean-vs-restart loop can't be
-// a backoff.Retry, so it keeps a hand-rolled sleep — but shares this one helper
-// rather than re-rolling the timer/select (and its easy-to-forget timer.Stop).
-func sleepCtx(ctx context.Context, d time.Duration) error {
-	timer := time.NewTimer(d)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
 }
 
 // ---------------------------------------------------------------------------
@@ -503,7 +483,7 @@ func (s *captiveSource) Tip(context.Context) (uint32, error) {
 
 // captiveCoreOpener is the production CoreOpener. It holds a resolved
 // CaptiveCoreConfig and hands back a captive-core LedgerStream that builds a FRESH
-// core per run (each supervised restart reopens core anew) — the stream owns the
+// core per run (each process restart reopens core anew) — the stream owns the
 // process lifecycle, so there is no eager prepare or explicit closer here.
 // Construction mirrors the RPC daemon's newCaptiveCore so the full-history daemon
 // runs captive core and the ledgerbackend the same way (#772 can unify them at
@@ -704,7 +684,7 @@ func newCaptiveCoreOpener(
 }
 
 // OpenCore returns the live ingestion stream backed by captive stellar-core. A
-// fresh core per run keeps supervised restarts clean.
+// fresh core per run keeps process restarts clean.
 func (c *captiveCoreOpener) OpenCore(ctx context.Context) (ledgerbackend.LedgerStream, error) {
 	cfg := c.config
 	cfg.Context = ctx

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,6 +30,7 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/ingest"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/observability"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 )
 
 // RunDaemon is the full-history daemon's process entrypoint: load config, lock
@@ -69,9 +71,9 @@ type daemonOptions struct {
 
 	// ServeReads overrides the read server (contract on StartConfig.ServeReads).
 	// nil ⇒ the production server (newServeReads): the shared method table over
-	// the router-backed adapters, listening on [service].endpoint. Tests inject
-	// recorders.
-	ServeReads serveReadsFn
+	// the router-backed adapters, served on run()'s bound listener. Tests
+	// inject recorders.
+	ServeReads func(ctx context.Context, reg *query.Registry, l net.Listener) error
 
 	// Logger overrides the daemon logger; nil ⇒ built from [logging].level/.format.
 	Logger *supportlog.Entry
@@ -346,7 +348,7 @@ func resolveCore(opts daemonOptions, cfg config.Config, logger *supportlog.Entry
 func startConfig(
 	cfg config.Config, cat *catalog.Catalog, logger *supportlog.Entry,
 	backend backfill.Backend, core CoreOpener,
-	serveReads serveReadsFn,
+	serveReads func(context.Context, *query.Registry, net.Listener) error,
 	metrics observability.Metrics, sink ingest.MetricSink, retention geometry.Retention,
 ) StartConfig {
 	exec := backfill.ExecConfig{
@@ -365,6 +367,7 @@ func startConfig(
 		Retention:  retention,
 		Core:       core,
 		ServeReads: serveReads,
+		Endpoint:   cfg.Service.Endpoint,
 	}
 }
 

--- a/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
@@ -354,10 +354,9 @@ func TestRunDaemon_NowFloorRequiresTip(t *testing.T) {
 		// A never-ready bulk source (sub-genesis tip ⇒ fast permanent failure) means
 		// the network tip can't resolve "now". Core injected: the opener now resolves
 		// up front and the stub captive_core_config would otherwise error first.
-		Backend:        &fakeBackend{tip: 0},
-		Core:           &fakeCore{},
-		Logger:         silentLogger(),
-		RestartBackoff: time.Millisecond,
+		Backend: &fakeBackend{tip: 0},
+		Core:    &fakeCore{},
+		Logger:  silentLogger(),
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "now")
@@ -401,71 +400,44 @@ func TestRunDaemon_MissingConfigFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// supervise — the top-level restart loop.
+// runBody — the one-shot daemon body and its clean-vs-crash classification.
 // ---------------------------------------------------------------------------
 
-// A restartable error retries on a backoff, then a clean ctx cancel during the
-// backoff returns nil (no restart after a shutdown request).
-func TestSupervise_RetriesThenCleanShutdown(t *testing.T) {
+// A ctx cancel during the run classifies as a clean shutdown (nil), not an
+// error — main exits 0 on SIGTERM.
+func TestRunBody_CleanShutdownOnCancel(t *testing.T) {
 	cat, _ := testCatalog(t)
 	pinGenesis(t, cat)
-
-	var attempts atomic.Int32
 	tip := &fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq + 10}} // young: no backfill
 	start := startTestConfig(t, cat, tip, &fakeCore{}, nil)
-	// An always-erroring ServeReads makes each attempt a restartable failure.
-	start.ServeReads = func(context.Context, *query.Registry) (func(), <-chan error, error) {
-		attempts.Add(1)
-		return nil, nil, errors.New("transient serve failure")
-	}
+	served := make(chan struct{}, 1)
+	start.ServeReads = signalingServeReads(served)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
-	go func() { errCh <- supervise(ctx, start, silentLogger(), 5*time.Millisecond) }()
-
-	// Let a few restarts happen, then cancel.
-	require.Eventually(t, func() bool {
-		return attempts.Load() >= 2
-	}, 3*time.Second, 5*time.Millisecond)
-	cancel()
-
-	select {
-	case err := <-errCh:
-		require.NoError(t, err, "ctx cancel during backoff returns nil")
-	case <-time.After(3 * time.Second):
-		t.Fatal("supervise did not return after cancel")
-	}
-	assert.GreaterOrEqual(t, attempts.Load(), int32(2), "restarted on the transient failure")
+	go func() { errCh <- runBody(ctx, start, silentLogger()) }()
+	<-served
+	waitClean(t, cancel, errCh)
 }
 
-// A first start with no reachable tip is now RESTARTABLE (previously a fatal
-// sentinel): supervise retries it on a backoff rather than surfacing it, and a
-// ctx cancel returns clean. Loss/misconfig can't be told from a transient inside
-// the process, so there is no fatal-and-exit class.
-func TestSupervise_FirstStartNoTipRetries(t *testing.T) {
+// Crash-only: a failing run with a live ctx surfaces its error to the caller —
+// the process exits and the orchestrator owns the restart; there is no
+// in-process retry.
+func TestRunBody_FailureSurfacesOnce(t *testing.T) {
 	cat, _ := testCatalog(t)
 	pinGenesis(t, cat)
-	// A never-ready tip (sub-genesis ⇒ one permanent-failure poll per run, no
-	// retry sleeps) + no local progress: every run fails the first-start check,
-	// so callCount tracks the restart count.
-	tip := &fakeTipBackend{tips: []uint32{0}}
+	var binds atomic.Int32
+	tip := &fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq + 10}}
 	start := startTestConfig(t, cat, tip, &fakeCore{}, nil)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	errCh := make(chan error, 1)
-	go func() { errCh <- supervise(ctx, start, silentLogger(), 5*time.Millisecond) }()
-
-	require.Eventually(t, func() bool {
-		return tip.callCount() >= 2
-	}, 3*time.Second, 5*time.Millisecond, "first-start-no-tip is retried, not surfaced as fatal")
-	cancel()
-
-	select {
-	case err := <-errCh:
-		require.NoError(t, err, "ctx cancel returns clean, even though runs kept failing")
-	case <-time.After(3 * time.Second):
-		t.Fatal("supervise did not return after cancel")
+	start.ServeReads = func(context.Context, *query.Registry) (readRunner, error) {
+		binds.Add(1)
+		return nil, errors.New("bind failure")
 	}
+
+	err := runBody(context.Background(), start, silentLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bind failure")
+	assert.Equal(t, int32(1), binds.Load(), "one attempt, no in-process retry")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -429,14 +430,14 @@ func TestRunBody_FailureSurfacesOnce(t *testing.T) {
 	var binds atomic.Int32
 	tip := &fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq + 10}}
 	start := startTestConfig(t, cat, tip, &fakeCore{}, nil)
-	start.ServeReads = func(context.Context, *query.Registry) (readRunner, error) {
+	start.ServeReads = func(context.Context, *query.Registry, net.Listener) error {
 		binds.Add(1)
-		return nil, errors.New("bind failure")
+		return errors.New("serve failure")
 	}
 
 	err := runBody(context.Background(), start, silentLogger())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "bind failure")
+	assert.Contains(t, err.Error(), "serve failure")
 	assert.Equal(t, int32(1), binds.Load(), "one attempt, no in-process retry")
 }
 

--- a/cmd/stellar-rpc/internal/rpcv2/e2e_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/e2e_test.go
@@ -8,7 +8,7 @@ package rpcv2
 //     - runDaemonWith (the true daemon entrypoint): TOML load + form-validate,
 //       root prep, catalog open (its own KV store, holding the single-process
 //       lock), the stateful validateConfig gate (pins the floor), and the
-//       supervised run loop.
+//       daemon body.
 //     - run → backfillToTip → openHotDBForChunk → runIngestionLoop (the real
 //       atomic per-ledger WriteBatch across all CFs of the real per-chunk
 //       hotchunk RocksDB), the real boundary handoff, the real boundary signal.
@@ -220,7 +220,6 @@ func runDaemonInBackground(
 		ServeReads:           countingServeReads(served),
 		Logger:               silentLogger(),
 		Metrics:              metrics,
-		RestartBackoff:       10 * time.Millisecond,
 		chunksPerTxhashIndex: 1,
 		lifecycleGrace:       time.Millisecond, // don't park the run on the 5m default
 	}
@@ -354,7 +353,7 @@ func TestE2E_DaemonLifecycle_FirstStartIngestFreezeLookupRestartPrune(t *testing
 		"first start resumes the ingestion stream at genesis (last committed ledger + 1)")
 
 	// =====================================================================
-	// STEP 2 — clean shutdown. The supervised loop returns nil on ctx cancel.
+	// STEP 2 — clean shutdown. runDaemonWith returns nil on ctx cancel.
 	// =====================================================================
 	waitClean(t, cancel, done)
 

--- a/cmd/stellar-rpc/internal/rpcv2/feereplay.go
+++ b/cmd/stellar-rpc/internal/rpcv2/feereplay.go
@@ -29,11 +29,11 @@ func replayFeeWindows(registry *query.Registry, windows *feewindow.FeeWindows, l
 	if windows == nil {
 		return nil // no fee consumer (tests) → nothing to refill
 	}
-	// A supervised in-process restart re-enters run() with the daemon-owned
-	// windows still holding the previous run's fees. The replay recomputes the
-	// full window from committed history, so reset first — appending on top
+	// The replay recomputes the full window from committed history, so start
+	// from empty regardless of the windows' current state — appending on top
 	// would double-count the overlap (and trip the windows' ledger-contiguity
-	// check).
+	// check). This keeps the function correct on any input, not just the
+	// freshly built windows run() hands it.
 	windows.Reset()
 
 	view, err := registry.NewReadView()

--- a/cmd/stellar-rpc/internal/rpcv2/feereplay_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/feereplay_test.go
@@ -56,9 +56,8 @@ func TestFeeWindowReplay_SpansChunkBoundary(t *testing.T) {
 	require.NoError(t, err)
 	defer registry.Close()
 
-	// Stale fees from "the previous run": a supervised in-process restart
-	// re-enters run() with the daemon-owned windows still populated. The replay
-	// must recompute from scratch, not stack on top.
+	// Already-populated windows: the replay's contract is to recompute from
+	// scratch on any input, not stack on top — pinned here on dirty windows.
 	windows := feewindow.NewFeeWindows(6, 4)
 	require.NoError(t, windows.AppendLedgerFees(c0.LastLedger(),
 		sdkingest.LedgerFees{ClassicFeesPerOp: []uint64{9999}}))

--- a/cmd/stellar-rpc/internal/rpcv2/helpers_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"iter"
+	"net"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -24,34 +25,30 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rpcv2test"
 )
 
-// blockingRunner is the no-op read-server runner: it serves nothing and
-// returns when its context cancels, like the production runner's clean path.
-func blockingRunner(rc context.Context) error {
-	<-rc.Done()
-	return rc.Err()
+// nopServeReads is the no-op ServeReads: it serves nothing and returns when
+// its context cancels, like the production serve's clean path.
+func nopServeReads(ctx context.Context, _ *query.Registry, _ net.Listener) error {
+	<-ctx.Done()
+	return ctx.Err()
 }
 
-// nopServeReads is the no-op ServeReads for tests that need serving wired but
-// never exercise it.
-func nopServeReads(context.Context, *query.Registry) (readRunner, error) {
-	return blockingRunner, nil
-}
-
-// countingServeReads is a no-op ServeReads that counts its binds — for tests
-// that only care that serving started.
-func countingServeReads(served *atomic.Int32) serveReadsFn {
-	return func(context.Context, *query.Registry) (readRunner, error) {
+// countingServeReads is a no-op ServeReads that counts its invocations — for
+// tests that only care that serving started.
+func countingServeReads(served *atomic.Int32) func(context.Context, *query.Registry, net.Listener) error {
+	return func(ctx context.Context, _ *query.Registry, _ net.Listener) error {
 		served.Add(1)
-		return blockingRunner, nil
+		<-ctx.Done()
+		return ctx.Err()
 	}
 }
 
 // signalingServeReads is countingServeReads' channel twin, for tests that
 // sequence on the moment serving starts.
-func signalingServeReads(servedCh chan struct{}) serveReadsFn {
-	return func(context.Context, *query.Registry) (readRunner, error) {
+func signalingServeReads(servedCh chan struct{}) func(context.Context, *query.Registry, net.Listener) error {
+	return func(ctx context.Context, _ *query.Registry, _ net.Listener) error {
 		servedCh <- struct{}{}
-		return blockingRunner, nil
+		<-ctx.Done()
+		return ctx.Err()
 	}
 }
 

--- a/cmd/stellar-rpc/internal/rpcv2/helpers_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/helpers_test.go
@@ -24,21 +24,34 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rpcv2test"
 )
 
-// countingServeReads is a no-op ServeReads that counts its calls — for tests
+// blockingRunner is the no-op read-server runner: it serves nothing and
+// returns when its context cancels, like the production runner's clean path.
+func blockingRunner(rc context.Context) error {
+	<-rc.Done()
+	return rc.Err()
+}
+
+// nopServeReads is the no-op ServeReads for tests that need serving wired but
+// never exercise it.
+func nopServeReads(context.Context, *query.Registry) (readRunner, error) {
+	return blockingRunner, nil
+}
+
+// countingServeReads is a no-op ServeReads that counts its binds — for tests
 // that only care that serving started.
-func countingServeReads(served *atomic.Int32) func(context.Context, *query.Registry) (func(), <-chan error, error) {
-	return func(context.Context, *query.Registry) (func(), <-chan error, error) {
+func countingServeReads(served *atomic.Int32) serveReadsFn {
+	return func(context.Context, *query.Registry) (readRunner, error) {
 		served.Add(1)
-		return func() {}, nil, nil
+		return blockingRunner, nil
 	}
 }
 
 // signalingServeReads is countingServeReads' channel twin, for tests that
 // sequence on the moment serving starts.
-func signalingServeReads(servedCh chan struct{}) func(context.Context, *query.Registry) (func(), <-chan error, error) {
-	return func(context.Context, *query.Registry) (func(), <-chan error, error) {
+func signalingServeReads(servedCh chan struct{}) serveReadsFn {
+	return func(context.Context, *query.Registry) (readRunner, error) {
 		servedCh <- struct{}{}
-		return func() {}, nil, nil
+		return blockingRunner, nil
 	}
 }
 

--- a/cmd/stellar-rpc/internal/rpcv2/hotloop.go
+++ b/cmd/stellar-rpc/internal/rpcv2/hotloop.go
@@ -31,9 +31,9 @@ import (
 // the durable hot:chunk state:
 //   - "ready": open it must-exist (create-if-missing OFF). A missing or gutted DB
 //     FAILS the open — never auto-heal into a fresh empty DB (which would silently
-//     regress the last-committed ledger). The open failure is an ordinary restartable error:
-//     a transient self-heals on the next attempt, genuine loss becomes a
-//     supervised crash-loop with the wrapped context.
+//     regress the last-committed ledger). The open failure fails the run: a
+//     transient self-heals on the orchestrator's restart, genuine loss becomes
+//     a crash-loop with the wrapped context.
 //   - "transient" or absent: wipe any leftover dir and create fresh
 //     (transient -> fsync dir+parent -> ready), so a crash mid-create can't
 //     fabricate a "ready but DB gone" open failure above.
@@ -148,12 +148,12 @@ func runIngestionLoop(ctx context.Context, cfg ingestionLoopConfig) error {
 	// On a normal exit it is the live chunk; completed chunks are the sink's to
 	// close. One exception: when openHotDBForChunk fails at a boundary, hotDB
 	// still points at the just-completed, registry-published chunk, so the
-	// defer closes a handle the registry also holds while reads are still live.
-	// Until the restart's stopReads runs moments later, reads hitting that
-	// chunk fail as store-closed. This is safe — Close blocks, draining any
-	// in-flight freeze read, and is idempotent; the restart rebuilds the
-	// registry — but briefly visible, not a no-op. No writer races the close:
-	// the loop has stopped on every exit path.
+	// defer closes a handle the registry also holds while the read server is
+	// still draining; reads hitting that chunk in the drain window fail as
+	// store-closed. This is safe — Close blocks, draining any in-flight freeze
+	// read, and is idempotent; the process exits right after and the next run
+	// rebuilds the registry — but briefly visible, not a no-op. No writer
+	// races the close: the loop has stopped on every exit path.
 	hotDB := cfg.HotDB
 	defer func() {
 		if hotDB != nil {
@@ -225,8 +225,8 @@ func runIngestionLoop(ctx context.Context, cfg ingestionLoopConfig) error {
 	// The unbounded production stream ends only on ctx cancellation or a source
 	// error, both surfaced as the stream's error element above. Falling through here
 	// means the source stopped WITHOUT an error while the daemon ctx is still live —
-	// abnormal; surface a restartable error. (run()'s guard owns the clean-vs-restart
-	// classification.)
+	// abnormal; surface an error and fail the run (runBody owns the
+	// clean-vs-crash classification).
 	return errStreamEnded
 }
 
@@ -257,7 +257,7 @@ type BoundedIngestConfig struct {
 // opens the resume chunk's hot DB through openHotDBForChunk and runs
 // runIngestionLoop until the stream ends. A bounded stream ending is the
 // expected termination (errStreamEnded), so unlike the daemon's unbounded run
-// it is remapped to a nil error rather than surfaced as a restartable failure.
+// it is remapped to a nil error rather than surfaced as a run failure.
 func RunBoundedIngestionLoop(ctx context.Context, cfg BoundedIngestConfig) error {
 	hotDB, err := openHotDBForChunk(cfg.Catalog, chunk.IDFromLedger(cfg.Resume), cfg.Logger)
 	if err != nil {

--- a/cmd/stellar-rpc/internal/rpcv2/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/rpcv2/jsonrpc.go
@@ -21,12 +21,11 @@ import (
 )
 
 // handlerParams carries everything newJSONRPCHandler composes into the method
-// table besides the config: the per-attempt readers over the query router, the
+// table besides the config: the per-run readers over the query router, the
 // process-wide core-backed pieces, and the sinks.
 type handlerParams struct {
 	daemon            host.Daemon
 	logger            *supportlog.Entry
-	handlerMetrics    *jsonrpc.HandlerMetrics
 	metrics           observability.Metrics
 	registry          *query.Registry
 	ledgerReader      store.LedgerReader
@@ -86,7 +85,6 @@ func newJSONRPCHandler(cfg config.Config, p handlerParams) jsonrpc.Handler {
 	return jsonrpc.NewHandler(jsonrpc.Params{
 		Daemon:                p.daemon,
 		Logger:                p.logger,
-		Metrics:               p.handlerMetrics,
 		Specs:                 specs,
 		GlobalQueueLimit:      deref(cfg.Service.MaxConcurrentRequests),
 		GlobalDurationWarning: deref(cfg.Service.RequestExecutionWarningThreshold),

--- a/cmd/stellar-rpc/internal/rpcv2/jsonrpc_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/jsonrpc_test.go
@@ -8,12 +8,10 @@ import (
 	"time"
 
 	"github.com/creachadair/jrpc2"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/host"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/jsonrpc"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/adapters"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/config"
@@ -51,7 +49,6 @@ func testHandlerParams(t *testing.T, r *query.Registry) handlerParams {
 	return handlerParams{
 		daemon:            host.MakeNoOpDaemon(),
 		logger:            silentLogger(),
-		handlerMetrics:    jsonrpc.NewHandlerMetrics("test", prometheus.NewRegistry()),
 		metrics:           observability.NopMetrics{},
 		registry:          r,
 		ledgerReader:      adapters.NewLedgerReader(),

--- a/cmd/stellar-rpc/internal/rpcv2/lifecycle/lifecycle.go
+++ b/cmd/stellar-rpc/internal/rpcv2/lifecycle/lifecycle.go
@@ -91,7 +91,7 @@ func (cfg Config) WithLifecycleDefaults() Config {
 // errgroup and forcing a whole-daemon restart (which relaunches captive core) for
 // a retryable file operation. It checks ctx between ops (and the backoff aborts on
 // ctx cancellation) so a shutdown mid-scan stops promptly; the ctx error surfaces
-// up through Loop for supervise to classify as clean.
+// up through Loop, and the caller classifies it as clean via ctx.Err().
 //
 // It returns how many ops ran to success (all of them on a nil error) so the caller
 // can meter the work actually done even when a later op fails — the completed ops
@@ -131,8 +131,8 @@ func runOps(ctx context.Context, cfg Config, ops []func() error) (int, error) {
 // stage 1. A canceled ctx still aborts everything, including the grace wait.
 //
 // It returns the joined stage errors WITHOUT classifying them: Loop propagates
-// them to run's errgroup and supervise decides clean-vs-restart (a canceled ctx
-// surfaces as a ctx error supervise treats as a clean shutdown).
+// them to run's errgroup, and the daemon classifies via ctx.Err() (a canceled
+// ctx surfaces as a ctx error, read as a clean shutdown).
 func runLifecycle(ctx context.Context, cfg Config, cat *catalog.Catalog, lastChunk chunk.ID) error {
 	metrics := observability.MetricsOrNop(cfg.Metrics)
 	logger := cfg.Logger
@@ -150,7 +150,7 @@ func runLifecycle(ctx context.Context, cfg Config, cat *catalog.Catalog, lastChu
 	// Stage 1 — plan-and-execute (freeze + index rebuild) over [floor, lastChunk], via
 	// the same entry point backfill uses (resolve → executePlan → Freeze metric,
 	// recorded internally). A canceled ctx makes RunBackfill return ctx.Err(), which
-	// propagates up for supervise to treat as a clean shutdown. lastChunk is always
+	// propagates up and classifies as a clean shutdown. lastChunk is always
 	// a completed chunk (boundary fence + post-backfill seed), so the only guard
 	// needed is the empty-range check (floor above lastChunk when retention outran
 	// production). An empty range emits no Freeze sample — the Discard/Prune samples
@@ -271,10 +271,11 @@ func (s *BoundarySignal) Publish() {
 // boundary that woke it, which only pulls the next tick's work forward. It
 // selects on ctx.Done() too, so it never blocks past shutdown.
 //
-// It returns the first tick error to its caller (run() joins it with ingestion in
-// an errgroup, so supervise decides clean-vs-restart). A cancellation observed at
-// the select returns nil; a cancellation mid-tick returns the tick's wrapped ctx
-// error — both are clean, since supervise keys off the daemon ctx, not this return.
+// It returns the first tick error to its caller (run() joins it with ingestion
+// in an errgroup; a failure exits the process and the orchestrator restarts). A
+// cancellation observed at the select returns nil; a cancellation mid-tick
+// returns the tick's wrapped ctx error — both are clean, since the daemon keys
+// off its own ctx, not this return.
 func Loop(ctx context.Context, cfg Config, cat *catalog.Catalog, sig *BoundarySignal) error {
 	for {
 		select {

--- a/cmd/stellar-rpc/internal/rpcv2/lifecycle/lifecycle_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/lifecycle/lifecycle_test.go
@@ -270,13 +270,13 @@ func TestRunLifecycleTick_PrunesTransientIndexDebris(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // ERROR PLUMBING: a failing tick RETURNS its error (no Fatalf / os.Exit).
-// supervise — not the tick — classifies ctx-cancel-is-clean vs restart (tested at
-// the daemon level: TestRunDaemon_LoadValidateWireStartCleanShutdown, TestSupervise_*).
+// The daemon — not the tick — classifies ctx-cancel-is-clean vs crash (tested at
+// the daemon level: TestRunDaemon_LoadValidateWireStartCleanShutdown, TestRunBody_*).
 // ---------------------------------------------------------------------------
 
 // TestRunLifecycleTick_FailureReturnsError: when a plan op fails, runLifecycle
 // returns the wrapped error rather than aborting the process — so Loop can
-// propagate it up through the errgroup to supervise. The chunk-0 build is
+// propagate it up through the errgroup to the daemon. The chunk-0 build is
 // GENUINELY unproducible: chunk 0 sits below a READY live chunk 1 (so it counts as
 // complete and the plan range [0,0] is non-empty), has no frozen artifacts, and
 // its hot key is "transient" (not a ready read source). With no bulk Backend

--- a/cmd/stellar-rpc/internal/rpcv2/main_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/main_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestMain runs this package's tests under goleak: a goroutine that outlives its
-// test — a daemon supervisor that didn't unwind on ctx cancel, an unjoined
+// test — a daemon body that didn't unwind on ctx cancel, an unjoined
 // backfill goroutine — fails the suite instead of silently leaking.
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)

--- a/cmd/stellar-rpc/internal/rpcv2/progress.go
+++ b/cmd/stellar-rpc/internal/rpcv2/progress.go
@@ -67,7 +67,7 @@ func lastCommittedLedger(cat *catalog.Catalog) (uint32, error) {
 // refineWithHotDB opens the highest ready hot chunk read-only straight from its
 // Layout path and returns its MaxCommittedSeq, or LastLedgerOf(live-1) on an
 // empty DB. A "ready" key whose dir/DB is gone surfaces as an ordinary
-// (restartable) error — the read-only open never auto-heals it into a fresh empty
+// (run-failing) error — the read-only open never auto-heals it into a fresh empty
 // DB. A read-only open replays any crash-left synced WAL into memtables, so
 // MaxCommittedSeq is correct even after an ungraceful crash.
 func refineWithHotDB(cat *catalog.Catalog, live int64) (uint32, error) {

--- a/cmd/stellar-rpc/internal/rpcv2/serve.go
+++ b/cmd/stellar-rpc/internal/rpcv2/serve.go
@@ -18,72 +18,64 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 )
 
-// readShutdownTimeout bounds the graceful drain when a supervised attempt
-// ends; whatever is still in flight after it is cut off. The next attempt
-// cannot bind the port until this returns, so it stays short.
+// readShutdownTimeout bounds the graceful drain at shutdown; whatever is
+// still in flight after it is cut off.
 const readShutdownTimeout = 5 * time.Second
 
-// readServerDeps is everything the production ServeReads needs besides the
-// per-attempt query.Registry. All of it is built once per process in
-// runDaemonWith; only the registry changes across supervised attempts.
-type readServerDeps struct {
-	// params carries the process-wide handler inputs; newServeReads overrides
-	// the per-attempt pieces (the registry and the two readers) on its copy
-	// each attempt.
-	params handlerParams
-	cfg    config.Config
-}
-
-// newServeReads returns the production ServeReads (the contract lives on
-// StartConfig.ServeReads): per supervised attempt it builds the method table
-// over that attempt's registry, binds [service].endpoint, and serves until the
-// returned stop runs — releasing the port before the next attempt binds. A
-// Serve failure that is NOT the graceful shutdown (v1 treats these as fatal)
-// lands on the returned channel.
-func newServeReads(deps readServerDeps) func(context.Context, *query.Registry) (func(), <-chan error, error) {
-	return func(ctx context.Context, reg *query.Registry) (func(), <-chan error, error) {
-		p := deps.params
+// newServeReads returns the production ServeReads — method table over the
+// registry, bound to [service].endpoint; the contract lives on
+// StartConfig.ServeReads. params carries the handler inputs; the registry and
+// the two readers are filled here.
+func newServeReads(cfg config.Config, params handlerParams) serveReadsFn {
+	return func(ctx context.Context, reg *query.Registry) (readRunner, error) {
+		p := params
 		p.registry = reg
 		p.ledgerReader = adapters.NewLedgerReader()
 		p.transactionReader = adapters.NewTransactionReader(p.networkPassphrase, p.metrics)
-		handler := newJSONRPCHandler(deps.cfg, p)
+		handler := newJSONRPCHandler(cfg, p)
 
 		var lc net.ListenConfig
-		listener, err := lc.Listen(ctx, "tcp", deps.cfg.Service.Endpoint)
+		listener, err := lc.Listen(ctx, "tcp", cfg.Service.Endpoint)
 		if err != nil {
 			handler.Close()
-			return nil, nil, fmt.Errorf("read server listen on %q: %w", deps.cfg.Service.Endpoint, err)
+			return nil, fmt.Errorf("read server listen on %q: %w", cfg.Service.Endpoint, err)
 		}
-
 		server := &http.Server{Handler: handler, ReadTimeout: jsonrpc.DefaultHTTPReadTimeout}
-		// Buffered so the send never blocks: after a graceful stop the watcher
-		// in run() is already gone. ErrServerClosed (the graceful path) is
-		// filtered here, so nothing is ever sent for a clean shutdown.
-		died := make(chan error, 1)
-		go func() {
-			if serr := server.Serve(listener); serr != nil && !errors.Is(serr, http.ErrServerClosed) {
-				died <- serr
-			}
-		}()
-		deps.params.logger.WithField("endpoint", deps.cfg.Service.Endpoint).Info("read server listening")
+		params.logger.WithField("endpoint", cfg.Service.Endpoint).Info("read server listening")
 
-		// stop runs during teardown, when the attempt's ctx is typically already
-		// canceled — a fresh Background timeout is what bounds the drain.
-		stop := func() { //nolint:contextcheck
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), readShutdownTimeout)
-			defer cancel()
-			if serr := server.Shutdown(shutdownCtx); serr != nil {
-				_ = server.Close()
+		run := func(runCtx context.Context) error {
+			// Both exits close the server: on death this reaps established
+			// keep-alive conns Serve abandoned; after the graceful path's
+			// Shutdown it is a no-op.
+			defer func() { _ = server.Close() }()
+			defer handler.Close()
+			died := make(chan error, 1)
+			go func() { died <- server.Serve(listener) }()
+			select {
+			case serr := <-died:
+				// Before any shutdown, Serve can only exit on a real failure
+				// (nothing else closes the server), so this fails the errgroup
+				// and the process.
+				return fmt.Errorf("read server died: %w", serr)
+			case <-runCtx.Done():
+				// Graceful drain, bounded: runCtx is already canceled, so a
+				// fresh Background timeout bounds the drain.
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), readShutdownTimeout)
+				defer cancel()
+				if serr := server.Shutdown(shutdownCtx); serr != nil { //nolint:contextcheck // ctx is canceled
+					_ = server.Close()
+				}
+				<-died // ErrServerClosed, by construction
+				return runCtx.Err()
 			}
-			handler.Close()
 		}
-		return stop, died, nil
+		return run, nil
 	}
 }
 
 // startAdminServer binds [service].admin_endpoint and serves pprof plus
 // /metrics over the process registry, where the serving collectors also live.
-// One per process — nothing here depends on a supervised attempt. The caller
+// One per process — nothing here depends on run()'s query registry. The caller
 // owns the returned stop.
 func startAdminServer(
 	ctx context.Context, endpoint string, logger *supportlog.Entry,

--- a/cmd/stellar-rpc/internal/rpcv2/serve.go
+++ b/cmd/stellar-rpc/internal/rpcv2/serve.go
@@ -22,54 +22,45 @@ import (
 // still in flight after it is cut off.
 const readShutdownTimeout = 5 * time.Second
 
-// newServeReads returns the production ServeReads — method table over the
-// registry, bound to [service].endpoint; the contract lives on
+// newServeReads returns the production ServeReads — the method table over the
+// registry, served on run()'s bound listener; the contract lives on
 // StartConfig.ServeReads. params carries the handler inputs; the registry and
 // the two readers are filled here.
-func newServeReads(cfg config.Config, params handlerParams) serveReadsFn {
-	return func(ctx context.Context, reg *query.Registry) (readRunner, error) {
+func newServeReads(
+	cfg config.Config, params handlerParams,
+) func(context.Context, *query.Registry, net.Listener) error {
+	return func(ctx context.Context, reg *query.Registry, listener net.Listener) error {
 		p := params
 		p.registry = reg
 		p.ledgerReader = adapters.NewLedgerReader()
 		p.transactionReader = adapters.NewTransactionReader(p.networkPassphrase, p.metrics)
 		handler := newJSONRPCHandler(cfg, p)
-
-		var lc net.ListenConfig
-		listener, err := lc.Listen(ctx, "tcp", cfg.Service.Endpoint)
-		if err != nil {
-			handler.Close()
-			return nil, fmt.Errorf("read server listen on %q: %w", cfg.Service.Endpoint, err)
-		}
 		server := &http.Server{Handler: handler, ReadTimeout: jsonrpc.DefaultHTTPReadTimeout}
-		params.logger.WithField("endpoint", cfg.Service.Endpoint).Info("read server listening")
 
-		run := func(runCtx context.Context) error {
-			// Both exits close the server: on death this reaps established
-			// keep-alive conns Serve abandoned; after the graceful path's
-			// Shutdown it is a no-op.
-			defer func() { _ = server.Close() }()
-			defer handler.Close()
-			died := make(chan error, 1)
-			go func() { died <- server.Serve(listener) }()
-			select {
-			case serr := <-died:
-				// Before any shutdown, Serve can only exit on a real failure
-				// (nothing else closes the server), so this fails the errgroup
-				// and the process.
-				return fmt.Errorf("read server died: %w", serr)
-			case <-runCtx.Done():
-				// Graceful drain, bounded: runCtx is already canceled, so a
-				// fresh Background timeout bounds the drain.
-				shutdownCtx, cancel := context.WithTimeout(context.Background(), readShutdownTimeout)
-				defer cancel()
-				if serr := server.Shutdown(shutdownCtx); serr != nil { //nolint:contextcheck // ctx is canceled
-					_ = server.Close()
-				}
-				<-died // ErrServerClosed, by construction
-				return runCtx.Err()
+		// Both exits close the server: on death this reaps established
+		// keep-alive conns Serve abandoned; after the graceful path's
+		// Shutdown it is a no-op.
+		defer func() { _ = server.Close() }()
+		defer handler.Close()
+		died := make(chan error, 1)
+		go func() { died <- server.Serve(listener) }()
+		select {
+		case serr := <-died:
+			// Before any shutdown, Serve can only exit on a real failure
+			// (nothing else closes the server), so this fails the errgroup
+			// and the process.
+			return fmt.Errorf("read server died: %w", serr)
+		case <-ctx.Done():
+			// Graceful drain, bounded: ctx is already canceled, so a fresh
+			// Background timeout bounds the drain.
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), readShutdownTimeout)
+			defer cancel()
+			if serr := server.Shutdown(shutdownCtx); serr != nil { //nolint:contextcheck // ctx is canceled
+				_ = server.Close()
 			}
+			<-died // ErrServerClosed, by construction
+			return ctx.Err()
 		}
-		return run, nil
 	}
 }
 

--- a/cmd/stellar-rpc/internal/rpcv2/serve_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/serve_test.go
@@ -39,14 +39,14 @@ func TestServeReads_ServesAndDrainsOnCancel(t *testing.T) {
 		retentionWindow:   1,
 	})
 
-	url := "http://" + cfg.Service.Endpoint
-
-	run, err := serve(context.Background(), r)
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "tcp", cfg.Service.Endpoint)
 	require.NoError(t, err)
+	url := "http://" + listener.Addr().String()
 
 	runCtx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
-	go func() { done <- run(runCtx) }()
+	go func() { done <- serve(runCtx, r, listener) }()
 
 	out := rpcv2test.PostRPC(t, url, "getVersionInfo", `{}`)
 	assert.Nil(t, out.Error)

--- a/cmd/stellar-rpc/internal/rpcv2/serve_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/serve_test.go
@@ -6,12 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/host"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/jsonrpc"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/feewindow"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/observability"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rpcv2test"
@@ -27,47 +25,39 @@ func freeEndpoint(t *testing.T) string {
 	return addr
 }
 
-func TestServeReads_ServesAndRebindsAcrossAttempts(t *testing.T) {
+func TestServeReads_ServesAndDrainsOnCancel(t *testing.T) {
 	r := seedServingRegistry(t)
 	cfg := defaultsConfig(t)
 	cfg.Service.Endpoint = freeEndpoint(t)
 
-	serve := newServeReads(readServerDeps{
-		cfg: cfg,
-		params: handlerParams{
-			daemon:            host.MakeNoOpDaemon(),
-			logger:            silentLogger(),
-			handlerMetrics:    jsonrpc.NewHandlerMetrics("test", prometheus.NewRegistry()),
-			metrics:           observability.NopMetrics{},
-			feeWindows:        feewindow.NewFeeWindows(10, 10),
-			networkPassphrase: "test passphrase",
-			retentionWindow:   1,
-		},
+	serve := newServeReads(cfg, handlerParams{
+		daemon:            host.MakeNoOpDaemon(),
+		logger:            silentLogger(),
+		metrics:           observability.NopMetrics{},
+		feeWindows:        feewindow.NewFeeWindows(10, 10),
+		networkPassphrase: "test passphrase",
+		retentionWindow:   1,
 	})
 
 	url := "http://" + cfg.Service.Endpoint
 
-	// First attempt serves; stop releases the port.
-	stop, died, err := serve(context.Background(), r)
+	run, err := serve(context.Background(), r)
 	require.NoError(t, err)
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- run(runCtx) }()
+
 	out := rpcv2test.PostRPC(t, url, "getVersionInfo", `{}`)
 	assert.Nil(t, out.Error)
-	stop()
 
-	// A graceful stop must not read as the server dying — a false death here
-	// would make every teardown restart the attempt it is tearing down.
+	// Cancel is a graceful drain: the runner returns its ctx error, never a
+	// death — a false death here would crash a process that is shutting down.
+	cancel()
 	select {
-	case serr := <-died:
-		t.Fatalf("graceful stop reported a server death: %v", serr)
-	case <-time.After(100 * time.Millisecond):
+	case rerr := <-done:
+		require.ErrorIs(t, rerr, context.Canceled, "a graceful shutdown is not a server death")
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner did not return after cancel")
 	}
-
-	// Second attempt on the same port: rebinding must succeed, and rebuilding
-	// the method table over the shared per-process metrics must not panic on a
-	// duplicate collector registration.
-	stop, _, err = serve(context.Background(), r)
-	require.NoError(t, err)
-	defer stop()
-	out = rpcv2test.PostRPC(t, url, "getVersionInfo", `{}`)
-	assert.Nil(t, out.Error)
 }

--- a/cmd/stellar-rpc/internal/rpcv2/startup.go
+++ b/cmd/stellar-rpc/internal/rpcv2/startup.go
@@ -26,12 +26,13 @@ import (
 // (injected), begin serving reads (injected), then run the live ingestion loop
 // (handed the open hot DB) and the lifecycle loop as a joined errgroup pair
 // (whichever returns first cancels the other; g.Wait surfaces the first
-// error). Never returns nil: a clean
-// shutdown (ctx canceled mid-run) surfaces as a ctx-canceled error that supervise
-// classifies via ctx.Err(); any other return is a restartable error the supervisor
-// warns on and retries with backoff (a first start with no reachable backend, a
-// backfill/ingest/lifecycle failure, or a "ready" hot DB that won't open — none are
-// auto-healed, all are re-attempted).
+// error). run() is the process body — crash-only: a clean shutdown (ctx
+// canceled mid-run) surfaces as a ctx-canceled error the caller classifies via
+// ctx.Err(); any other return exits the process, and the orchestrator owns the
+// restart. Backfill's bounded retries and the lifecycle's rediscovery absorb
+// the expected transients, so an error escaping them (a first start with no
+// reachable backend, an ingest failure, a "ready" hot DB that won't open) is
+// persistent or unknown and belongs in a visible crash-loop.
 //
 //nolint:funlen // linear startup sequence; each step is one wiring stage
 func run(ctx context.Context, cfg StartConfig) error {
@@ -137,7 +138,11 @@ func run(ctx context.Context, cfg StartConfig) error {
 	defer registry.Close()
 
 	// Stamp both window edges' close times before serving begins, so the first
-	// requests don't pay the point reads (see adapters.SeedCloseTimes).
+	// requests don't pay the point reads (see adapters.SeedCloseTimes). An
+	// unreadable edge fails startup: every response stamps these edges, so a
+	// node that cannot read one would serve errors on every method while
+	// looking alive — crash-only says that surfaces as a visible crash-loop
+	// instead. A transient read blip at boot costs one orchestrator restart.
 	if err := adapters.SeedCloseTimes(registry); err != nil {
 		return fmt.Errorf("startup seed close times: %w", err)
 	}
@@ -159,22 +164,24 @@ func run(ctx context.Context, cfg StartConfig) error {
 		Grace:      cfg.lifecycleGrace,
 	}.WithLifecycleDefaults()
 
-	// Begin serving reads (injected) BEFORE launching the loops. The deferred
-	// stop runs before the deferred registry.Close above (LIFO), so the server
-	// is down before its stores go.
-	stopReads, readsDied, err := cfg.ServeReads(ctx, registry)
+	// Bind the read server (injected) BEFORE launching the loops; the contract
+	// lives on StartConfig.ServeReads. The runner owns the listener and bridge
+	// release, so it must reach the g.Go below — keep this gap free of fallible
+	// steps, or a failure here leaks the bound endpoint for the process's life.
+	serveRun, err := cfg.ServeReads(ctx, registry)
 	if err != nil {
 		return fmt.Errorf("startup serve reads: %w", err)
 	}
-	defer stopReads()
+	if serveRun == nil {
+		return errors.New("startup serve reads: nil runner")
+	}
 
 	// Ingestion and the lifecycle run as a joined pair under errgroup.WithContext:
 	// gctx cancels as soon as EITHER returns — and WithContext records the returning
 	// goroutine's error BEFORE canceling, so g.Wait surfaces the real cause, not the
-	// sibling's induced context-canceled. g.Wait joins both before run returns,
-	// restoring the single-lifecycle-goroutine invariant across supervisor restarts.
-	// supervise is the one clean-vs-restart decision point; a canceled parent ctx
-	// classifies as clean.
+	// sibling's induced context-canceled. g.Wait joins every goroutine before run
+	// returns. runBody is the one clean-vs-crash decision point; a canceled
+	// parent ctx classifies as clean.
 	g, gctx := errgroup.WithContext(ctx)
 	// The loop's deferred close now owns hotDB; g.Wait joins it before run returns.
 	loopOwnsDB = true
@@ -195,7 +202,7 @@ func run(ctx context.Context, cfg StartConfig) error {
 			// WithContext cancels gctx (unblocking the lifecycle sibling in g.Wait)
 			// ONLY on a non-nil return. runIngestionLoop upholds that — every exit is
 			// an error, including a clean stream end — but guard it so a future nil
-			// return degrades to a supervised restart, never a silent g.Wait hang.
+			// return degrades to a process exit, never a silent g.Wait hang.
 			return errors.New("ingestion loop returned nil unexpectedly")
 		}
 		return err
@@ -204,16 +211,13 @@ func run(ctx context.Context, cfg StartConfig) error {
 		return lifecycle.Loop(gctx, lifecycleCfg, cat, boundary)
 	})
 	g.Go(func() error {
-		// A dying read server fails the whole attempt (see
-		// StartConfig.ServeReads). Graceful shutdown never sends here —
-		// stopReads runs after g.Wait joins, and its ErrServerClosed is
-		// filtered at the sender.
-		select {
-		case serr := <-readsDied:
-			return fmt.Errorf("read server died: %w", serr)
-		case <-gctx.Done():
-			return gctx.Err()
-		}
+		// Serves until gctx cancels or the accept loop dies (contract on
+		// StartConfig.ServeReads). The endpoint therefore drains at the FIRST
+		// sibling failure or SIGTERM; the rest of the unwind (an in-flight
+		// freeze finalize) runs without serving. Accepted under crash-only:
+		// the process is exiting, and serving through a doomed unwind is not
+		// worth the stop-after-Wait machinery it used to require.
+		return serveRun(gctx)
 	})
 	return g.Wait()
 }
@@ -260,7 +264,7 @@ func backfillToTip(ctx context.Context, cfg StartConfig, lastCommitted uint32) (
 		// The backend owns its frontier (the lake for bsbSource, the archives for
 		// captiveSource). A tip still unavailable after the bounded retry errors the
 		// pass rather than proceeding — the daemon must never serve behind an unknown
-		// frontier — and each supervised restart re-samples (a transient outage
+		// frontier — and each process restart re-samples (a transient outage
 		// self-heals).
 		tip, err := sampleTipWithRetry(
 			ctx, cfg.Exec.Process.Backend.Tip, defaultTipBackoff, defaultTipMaxAttempts)
@@ -370,17 +374,14 @@ type StartConfig struct {
 	// Core starts captive core and yields the ingestion getter. Required.
 	Core CoreOpener
 
-	// ServeReads begins serving reads over this run's registry; it must return
-	// promptly, not block. The returned stop shuts the server down — run() calls
-	// it (via defer) before the registry closes, so no handler outlives its
-	// stores and the listener is released before the next supervised attempt
-	// binds it again. The returned channel reports the server dying on its own
-	// (a Serve failure that is not the graceful shutdown): run() joins it into
-	// the attempt's errgroup, so a dead accept loop fails the attempt and the
-	// supervisor rebinds — instead of the endpoint staying down while ingestion
-	// keeps running. A nil channel means the server never reports (tests).
-	// Required.
-	ServeReads func(ctx context.Context, reg *query.Registry) (func(), <-chan error, error)
+	// ServeReads binds the read server over this run's registry and returns a
+	// runner; the bind must be synchronous (a taken port fails startup) and the
+	// runner must serve until its context cancels — draining before returning,
+	// so no handler outlives the stores — or return the accept loop's death as
+	// its error. run() joins the runner into the errgroup, so a dead accept
+	// loop fails the process (v1 classifies it fatal too). This comment is the
+	// contract's one authoritative statement. Required, non-nil runner.
+	ServeReads serveReadsFn
 
 	// runBackfill is a test-only seam for one backfill pass; nil ⇒ backfill.RunBackfill.
 	runBackfill func(ctx context.Context, exec backfill.ExecConfig, lo, hi chunk.ID) error
@@ -392,10 +393,18 @@ type StartConfig struct {
 
 	// FeeWindows is the daemon-owned getFeeStats state ([service.fee_stats]
 	// sizes) the ingestion loop feeds per committed ledger. The daemon builds it
-	// once, outside the supervised run loop; nil (tests without a fee consumer)
+	// once, before the daemon body; nil (tests without a fee consumer)
 	// means the loop never computes fees.
 	FeeWindows *feewindow.FeeWindows
 }
+
+// readRunner serves the bound read server until its context cancels; the
+// contract lives on StartConfig.ServeReads.
+type readRunner func(context.Context) error
+
+// serveReadsFn binds the read server over a run's registry and returns its
+// runner; the contract lives on StartConfig.ServeReads.
+type serveReadsFn func(ctx context.Context, reg *query.Registry) (readRunner, error)
 
 // withDefaults fills the embedded Exec defaults (Workers -> GOMAXPROCS). The
 // lifecycle.Config is assembled from Exec + Retention in run(); the tip retry

--- a/cmd/stellar-rpc/internal/rpcv2/startup.go
+++ b/cmd/stellar-rpc/internal/rpcv2/startup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -164,17 +165,17 @@ func run(ctx context.Context, cfg StartConfig) error {
 		Grace:      cfg.lifecycleGrace,
 	}.WithLifecycleDefaults()
 
-	// Bind the read server (injected) BEFORE launching the loops; the contract
-	// lives on StartConfig.ServeReads. The runner owns the listener and bridge
-	// release, so it must reach the g.Go below — keep this gap free of fallible
-	// steps, or a failure here leaks the bound endpoint for the process's life.
-	serveRun, err := cfg.ServeReads(ctx, registry)
+	// Bind the read endpoint BEFORE launching the loops, so a taken port fails
+	// startup here with nothing else running. The defer covers every exit path
+	// (a failure below, or teardown after ServeReads' own drain already closed
+	// it), so the bound port can never outlive run().
+	var lc net.ListenConfig
+	listener, err := lc.Listen(ctx, "tcp", cfg.Endpoint)
 	if err != nil {
-		return fmt.Errorf("startup serve reads: %w", err)
+		return fmt.Errorf("startup read listener on %q: %w", cfg.Endpoint, err)
 	}
-	if serveRun == nil {
-		return errors.New("startup serve reads: nil runner")
-	}
+	defer func() { _ = listener.Close() }()
+	cfg.Exec.Logger.WithField("endpoint", listener.Addr().String()).Info("read server listening")
 
 	// Ingestion and the lifecycle run as a joined pair under errgroup.WithContext:
 	// gctx cancels as soon as EITHER returns — and WithContext records the returning
@@ -211,13 +212,14 @@ func run(ctx context.Context, cfg StartConfig) error {
 		return lifecycle.Loop(gctx, lifecycleCfg, cat, boundary)
 	})
 	g.Go(func() error {
-		// Serves until gctx cancels or the accept loop dies (contract on
-		// StartConfig.ServeReads). The endpoint therefore drains at the FIRST
-		// sibling failure or SIGTERM; the rest of the unwind (an in-flight
-		// freeze finalize) runs without serving. Accepted under crash-only:
-		// the process is exiting, and serving through a doomed unwind is not
-		// worth the stop-after-Wait machinery it used to require.
-		return serveRun(gctx)
+		// Serves on the bound listener until gctx cancels or the accept loop
+		// dies (contract on StartConfig.ServeReads). The endpoint therefore
+		// drains at the FIRST sibling failure or SIGTERM; the rest of the
+		// unwind (an in-flight freeze finalize) runs without serving. Accepted
+		// under crash-only: the process is exiting, and serving through a
+		// doomed unwind is not worth the stop-after-Wait machinery it used to
+		// require.
+		return cfg.ServeReads(gctx, registry, listener)
 	})
 	return g.Wait()
 }
@@ -374,14 +376,19 @@ type StartConfig struct {
 	// Core starts captive core and yields the ingestion getter. Required.
 	Core CoreOpener
 
-	// ServeReads binds the read server over this run's registry and returns a
-	// runner; the bind must be synchronous (a taken port fails startup) and the
-	// runner must serve until its context cancels — draining before returning,
-	// so no handler outlives the stores — or return the accept loop's death as
-	// its error. run() joins the runner into the errgroup, so a dead accept
-	// loop fails the process (v1 classifies it fatal too). This comment is the
-	// contract's one authoritative statement. Required, non-nil runner.
-	ServeReads serveReadsFn
+	// Endpoint is the read server's listen address. run() carries it because
+	// run() owns the bind (a taken port fails startup before the loops
+	// launch); everything else about serving belongs to the ServeReads
+	// implementation. Required.
+	Endpoint string
+
+	// ServeReads serves the read surface for this run's registry on the bound
+	// listener, blocking until its context cancels — draining before
+	// returning, so no handler outlives the stores — or until the accept loop
+	// dies, returned as its error. run() joins it into the errgroup, so a dead
+	// accept loop fails the process (v1 classifies it fatal too). This comment
+	// is the contract's one authoritative statement. Required.
+	ServeReads func(ctx context.Context, reg *query.Registry, l net.Listener) error
 
 	// runBackfill is a test-only seam for one backfill pass; nil ⇒ backfill.RunBackfill.
 	runBackfill func(ctx context.Context, exec backfill.ExecConfig, lo, hi chunk.ID) error
@@ -397,14 +404,6 @@ type StartConfig struct {
 	// means the loop never computes fees.
 	FeeWindows *feewindow.FeeWindows
 }
-
-// readRunner serves the bound read server until its context cancels; the
-// contract lives on StartConfig.ServeReads.
-type readRunner func(context.Context) error
-
-// serveReadsFn binds the read server over a run's registry and returns its
-// runner; the contract lives on StartConfig.ServeReads.
-type serveReadsFn func(ctx context.Context, reg *query.Registry) (readRunner, error)
 
 // withDefaults fills the embedded Exec defaults (Workers -> GOMAXPROCS). The
 // lifecycle.Config is assembled from Exec + Retention in run(); the tip retry
@@ -431,6 +430,9 @@ func (cfg StartConfig) validate() error {
 	}
 	if cfg.ServeReads == nil {
 		return errors.New("nil StartConfig.ServeReads")
+	}
+	if cfg.Endpoint == "" {
+		return errors.New("empty StartConfig.Endpoint")
 	}
 	return nil
 }

--- a/cmd/stellar-rpc/internal/rpcv2/startup_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/startup_test.go
@@ -104,7 +104,7 @@ func startTestConfig(
 		Exec:       exec,
 		Retention:  rpcv2test.RetentionFor(t, cat, 0),
 		Core:       core,
-		ServeReads: func(context.Context, *query.Registry) (func(), <-chan error, error) { return func() {}, nil, nil },
+		ServeReads: nopServeReads,
 	}
 	if recordPlan != nil {
 		cfg.runBackfill = func(_ context.Context, _ backfill.ExecConfig, lo, hi chunk.ID) error {
@@ -194,8 +194,8 @@ func TestSampleTip_CtxCancelAbortsWait(t *testing.T) {
 // backfillToTip — backfill loop edge cases.
 // ---------------------------------------------------------------------------
 
-// First start (genesis, no local history) with no usable tip errors out
-// (restartable — no sentinel; the supervisor retries). Sub-genesis reads as a
+// First start (genesis, no local history) with no usable tip errors out (no
+// sentinel; the process exits and the orchestrator retries). Sub-genesis reads as a
 // permanent "not ready", so the sample fails fast instead of burning the
 // production retry backoff backfillToTip now applies.
 func TestBackfill_FirstStartTipAbsentErrors(t *testing.T) {
@@ -344,7 +344,7 @@ func TestBackfill_LongDowntimeRePass(t *testing.T) {
 
 // Restart with no usable tip errors out even when local progress exists: the
 // synthetic tip:=lastCommitted degraded mode is gone. No backfill pass runs; the
-// supervisor restarts and re-samples. Sub-genesis reads as a permanent "not
+// restarted process re-samples. Sub-genesis reads as a permanent "not
 // ready" — one poll, no retry sleeps — and resolves to the same "tip
 // unavailable" outcome as an erroring tip (whose retry exhaustion
 // TestSampleTip_ExhaustedRetriesErrors covers at a fast interval).
@@ -451,38 +451,38 @@ func TestRun_IngestionCleanEndSurfacesErrorNotHang(t *testing.T) {
 	select {
 	case err := <-errCh:
 		require.Error(t, err, "a graceful stream end surfaces as an error, not a nil clean shutdown")
-		require.NotErrorIs(t, err, context.Canceled, "a graceful end is restartable, not a clean shutdown")
+		require.NotErrorIs(t, err, context.Canceled, "a graceful end is a failure, not a clean shutdown")
 	case <-time.After(10 * time.Second):
 		t.Fatal("run did not return on a graceful stream end — g.Wait hung on a silent nil")
 	}
 }
 
-func TestRun_ReadServerDeathFailsTheAttempt(t *testing.T) {
+func TestRun_ReadServerDeathFailsRun(t *testing.T) {
 	cat, _ := testCatalog(t)
 	pinGenesis(t, cat)
 	tip := &fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq + 10}} // young ⇒ no backfill
 	cfg := startTestConfig(t, cat, tip, &fakeCore{}, nil)
 
-	died := make(chan error, 1)
-	cfg.ServeReads = func(context.Context, *query.Registry) (func(), <-chan error, error) {
-		return func() {}, died, nil
+	// The runner returning before its ctx cancels is the accept loop dying;
+	// run must surface it (crash-only: the process exits, k8s restarts).
+	cfg.ServeReads = func(context.Context, *query.Registry) (readRunner, error) {
+		return func(context.Context) error { return errors.New("accept loop broke") }, nil
 	}
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- run(context.Background(), cfg) }()
-	died <- errors.New("accept loop broke")
 
 	select {
 	case err := <-errCh:
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "read server died")
-		require.NotErrorIs(t, err, context.Canceled, "a dead read server is restartable, not a clean shutdown")
+		require.Contains(t, err.Error(), "accept loop broke")
+		require.NotErrorIs(t, err, context.Canceled, "a dead read server is a failure, not a clean shutdown")
 	case <-time.After(10 * time.Second):
 		t.Fatal("run did not fail after the read server died")
 	}
 }
 
-// A ServeReads error is surfaced wrapped as a restartable failure (NOT clean).
+// A ServeReads error is surfaced wrapped as a run failure (NOT clean).
 // run() opens the resume hot DB and starts core BEFORE serving; a serve error
 // after those returns via run()'s defer, which closes the DB (the loop never took
 // ownership), so a restart can reopen it — asserted by the reopen below.
@@ -492,14 +492,14 @@ func TestRun_ServeReadsErrorSurfaces(t *testing.T) {
 	core := &fakeCore{stream: &fakeCoreStream{frames: map[uint32][]byte{}, blockOnCtx: true}}
 	tip := &fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq + 10}}
 	cfg := startTestConfig(t, cat, tip, core, nil)
-	cfg.ServeReads = func(context.Context, *query.Registry) (func(), <-chan error, error) {
-		return nil, nil, errors.New("rpc bind failed")
+	cfg.ServeReads = func(context.Context, *query.Registry) (readRunner, error) {
+		return nil, errors.New("rpc bind failed")
 	}
 
 	err := run(context.Background(), cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "serve reads")
-	require.NotErrorIs(t, err, context.Canceled, "a ServeReads error is restartable, not a clean shutdown")
+	require.NotErrorIs(t, err, context.Canceled, "a ServeReads error is a failure, not a clean shutdown")
 	require.Equal(t, int32(1), core.openedCount.Load(), "core was started before serving")
 
 	// run() opened the resume hot DB before serving and closed it on the error path
@@ -524,12 +524,12 @@ func TestRun_OpensHotDBAndCoreBeforeServe(t *testing.T) {
 
 	var stateAtServe geometry.HotState
 	var coreAtServe int32
-	cfg.ServeReads = func(context.Context, *query.Registry) (func(), <-chan error, error) {
+	cfg.ServeReads = func(context.Context, *query.Registry) (readRunner, error) {
 		st, herr := cat.HotState(resumeChunk)
 		require.NoError(t, herr)
 		stateAtServe = st
 		coreAtServe = core.openedCount.Load()
-		return nil, nil, errors.New("stop before the blocking loop")
+		return nil, errors.New("stop before the blocking loop")
 	}
 
 	err := run(context.Background(), cfg)
@@ -539,7 +539,7 @@ func TestRun_OpensHotDBAndCoreBeforeServe(t *testing.T) {
 	assert.Equal(t, int32(1), coreAtServe, "core is opened before serve")
 }
 
-// run errors on a first start with an unavailable tip (restartable, no sentinel);
+// run errors on a first start with an unavailable tip (no sentinel);
 // reads are never served and ingestion never starts. Sub-genesis ⇒ one
 // permanent-failure poll, no retry sleeps.
 func TestRun_FirstStartNoTipErrors(t *testing.T) {

--- a/cmd/stellar-rpc/internal/rpcv2/startup_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/startup_test.go
@@ -3,6 +3,7 @@ package rpcv2
 import (
 	"context"
 	"errors"
+	"net"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -105,6 +106,7 @@ func startTestConfig(
 		Retention:  rpcv2test.RetentionFor(t, cat, 0),
 		Core:       core,
 		ServeReads: nopServeReads,
+		Endpoint:   "127.0.0.1:0",
 	}
 	if recordPlan != nil {
 		cfg.runBackfill = func(_ context.Context, _ backfill.ExecConfig, lo, hi chunk.ID) error {
@@ -463,10 +465,10 @@ func TestRun_ReadServerDeathFailsRun(t *testing.T) {
 	tip := &fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq + 10}} // young ⇒ no backfill
 	cfg := startTestConfig(t, cat, tip, &fakeCore{}, nil)
 
-	// The runner returning before its ctx cancels is the accept loop dying;
+	// ServeReads returning before its ctx cancels is the accept loop dying;
 	// run must surface it (crash-only: the process exits, k8s restarts).
-	cfg.ServeReads = func(context.Context, *query.Registry) (readRunner, error) {
-		return func(context.Context) error { return errors.New("accept loop broke") }, nil
+	cfg.ServeReads = func(context.Context, *query.Registry, net.Listener) error {
+		return errors.New("accept loop broke")
 	}
 
 	errCh := make(chan error, 1)
@@ -482,25 +484,29 @@ func TestRun_ReadServerDeathFailsRun(t *testing.T) {
 	}
 }
 
-// A ServeReads error is surfaced wrapped as a run failure (NOT clean).
-// run() opens the resume hot DB and starts core BEFORE serving; a serve error
-// after those returns via run()'s defer, which closes the DB (the loop never took
-// ownership), so a restart can reopen it — asserted by the reopen below.
-func TestRun_ServeReadsErrorSurfaces(t *testing.T) {
+// A bind failure (the endpoint already taken) is surfaced wrapped as a run
+// failure (NOT clean). run() opens the resume hot DB and starts core BEFORE
+// binding; the bind error returns via run()'s defer, which closes the DB (the
+// loop never took ownership), so a restart can reopen it — asserted by the
+// reopen below.
+func TestRun_BindFailureSurfaces(t *testing.T) {
 	cat, _ := testCatalog(t)
 	pinGenesis(t, cat)
 	core := &fakeCore{stream: &fakeCoreStream{frames: map[uint32][]byte{}, blockOnCtx: true}}
 	tip := &fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq + 10}}
 	cfg := startTestConfig(t, cat, tip, core, nil)
-	cfg.ServeReads = func(context.Context, *query.Registry) (readRunner, error) {
-		return nil, errors.New("rpc bind failed")
-	}
+	// Occupy a port so run()'s own bind fails with a real address-in-use.
+	var lc net.ListenConfig
+	taken, lerr := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, lerr)
+	defer func() { _ = taken.Close() }()
+	cfg.Endpoint = taken.Addr().String()
 
 	err := run(context.Background(), cfg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "serve reads")
-	require.NotErrorIs(t, err, context.Canceled, "a ServeReads error is a failure, not a clean shutdown")
-	require.Equal(t, int32(1), core.openedCount.Load(), "core was started before serving")
+	require.Contains(t, err.Error(), "read listener")
+	require.NotErrorIs(t, err, context.Canceled, "a bind failure is a failure, not a clean shutdown")
+	require.Equal(t, int32(1), core.openedCount.Load(), "core was started before binding")
 
 	// run() opened the resume hot DB before serving and closed it on the error path
 	// (the loop never took ownership): reopening it succeeds (LOCK released).
@@ -511,9 +517,10 @@ func TestRun_ServeReadsErrorSurfaces(t *testing.T) {
 
 // The resume hot DB and core are opened BEFORE reads are served (the design's
 // fail-fast order): by the time ServeReads runs, the resume chunk's hot key is
-// already "ready" and core has started — so a broken hot tier / core fails startup
-// instead of serving behind a crash-looping loop. Asserted from inside ServeReads,
-// which then errors to avoid entering the blocking loop.
+// already "ready" and core has started — so a broken hot tier / core fails
+// startup instead of serving behind a crash-looping loop. Asserted from inside
+// the serve fake (whose invocation follows run()'s own bind), which then
+// errors to end the run; the blocking stream keeps the observed state stable.
 func TestRun_OpensHotDBAndCoreBeforeServe(t *testing.T) {
 	cat, _ := testCatalog(t)
 	pinGenesis(t, cat)
@@ -524,17 +531,17 @@ func TestRun_OpensHotDBAndCoreBeforeServe(t *testing.T) {
 
 	var stateAtServe geometry.HotState
 	var coreAtServe int32
-	cfg.ServeReads = func(context.Context, *query.Registry) (readRunner, error) {
+	cfg.ServeReads = func(context.Context, *query.Registry, net.Listener) error {
 		st, herr := cat.HotState(resumeChunk)
 		require.NoError(t, herr)
 		stateAtServe = st
 		coreAtServe = core.openedCount.Load()
-		return nil, errors.New("stop before the blocking loop")
+		return errors.New("stop the run after asserting")
 	}
 
 	err := run(context.Background(), cfg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "serve reads")
+	require.Contains(t, err.Error(), "stop the run after asserting")
 	assert.Equal(t, geometry.HotReady, stateAtServe, "resume hot DB is open+ready before serve")
 	assert.Equal(t, int32(1), coreAtServe, "core is opened before serve")
 }

--- a/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk/hotchunk.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk/hotchunk.go
@@ -110,7 +110,7 @@ func Open(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) 
 // ingestion's handle for a chunk whose "ready" key promises the DB already exists.
 // A missing or gutted DB fails the open instead of silently fabricating a fresh
 // empty one (the "never auto-heal" rule); the caller treats that failure as an
-// ordinary restartable error.
+// ordinary run-failing error.
 func OpenExisting(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) {
 	return open(path, chunkID, logger, false, true)
 }

--- a/cmd/stellar-rpc/rpcv2/main.go
+++ b/cmd/stellar-rpc/rpcv2/main.go
@@ -21,7 +21,7 @@ func main() {
 		Use:   "stellar-rpc-v2",
 		Short: "Run the full-history streaming ingestion daemon",
 		Run: func(cmd *cobra.Command, _ []string) {
-			// Cancel the supervised run loop on SIGINT/SIGTERM for a clean shutdown.
+			// Cancel the daemon on SIGINT/SIGTERM for a clean shutdown.
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()
 			if err := rpcv2.RunDaemon(ctx, configPath, cmd.Flags()); err != nil {

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -632,7 +632,7 @@ func backfillTarget(tip, lastCommitted uint32) int64 {
 }
 ```
 
-A pass with no reachable tip fails the run rather than proceeding: the daemon never serves behind an unknown frontier, and the next run re-samples, so a transient backend outage self-heals.
+A pass with no reachable tip fails the run rather than proceeding: the daemon never serves behind an unknown frontier, and the restarted process re-samples (the daemon exits on failure; the orchestrator restarts it), so a transient backend outage self-heals.
 
 `validateConfig` checks the config and, on the first start, resolves and pins `earliest_ledger`. `fail` here rejects startup outright — including a first start whose backend is unreachable at pin time; unlike the per-pass tip sampling, nothing here retries in-process, so the daemon refuses to start rather than run against a wrong or unresolvable pin:
 


### PR DESCRIPTION
# What this PR does

The follow-up promised on #908's serve.go review thread: the in-process supervised restart loop is deleted in favor of crash-only. run() is the process body, called once; a ctx cancel is a clean shutdown (exit 0), and any other failure exits the process for the orchestrator to restart. Backfill's bounded retries and the lifecycle's rediscovery absorb the expected transients, so an error escaping them is persistent or unknown and belongs in a visible crash-loop, not an invisible in-process retry.

## The pieces

| Piece | What changed |
|---|---|
| Supervisor | `supervise`, `sleepCtx`, `RestartBackoff`, and the never-returns-nil contract are deleted. `runBody` classifies clean-vs-crash at one site and logs the crash reason structurally, including a real failure that races a shutdown request (previously discardable to a silent exit 0). `RunDaemon` applies the same classification to the pre-run startup phase, so a drain landing mid-startup (archive dial, tip sampling) exits 0 instead of registering a false crash; a non-ctx startup failure racing the drain still prints before the clean exit. |
| Read server | run() owns the bind: it listens on `StartConfig.Endpoint` inline before the loops launch, so a taken port fails startup with nothing else running, and its deferred close covers every exit path — the bound port can never outlive run(). `ServeReads` shrinks to one blocking function over `(ctx, registry, listener)` (the contract's one authoritative statement lives on `StartConfig.ServeReads`): it serves until its context cancels, draining before it returns so no handler outlives the stores, or returns an accept-loop death as its error, which is process-fatal (v1's classification), closing the server on both exits so established keep-alives are reaped on the death path too. The died channel with its buffered-send, sender-filter, and nil-channel-for-tests conventions, the stop/LIFO ordering, and the rebind-across-attempts test all delete. `Endpoint` rides `StartConfig` as data because run() is the one who binds — the same data-next-to-seams rule the struct already applies to `FeeWindows` and `lifecycleGrace`. One accepted behavior delta, documented at the errgroup leg: the endpoint drains at the first sibling failure, and the remaining unwind (an in-flight freeze finalize) runs without serving, on the grounds that the process is exiting and serving through a doomed unwind is not worth the stop-after-Wait machinery it used to require. |
| Handler metrics | The `HandlerMetrics` carrier is deleted: each daemon builds its handler once, and `decorateHandlers` registers the request-duration summary with Register-or-reuse, so a future second build on one registry keeps counting on the existing series instead of panicking. |
| Close-time seed | `SeedCloseTimes` seeds both window edges (joined error, so one crash log shows every broken edge) and an unreadable edge fails startup: every response stamps the edges, so a node that cannot read one would error on every method while looking alive, and crash-only surfaces that as a crash-loop instead. |
| Vocabulary | The supervised-loop language ("restartable", "supervise classifies", "per supervised attempt") is swept from comments across the tree, and the design doc's self-heal sentence now names the orchestrator as the restart mechanism. |

## Why crash-only

Steady-state write-side failures are environmental or deterministic (OOM, disk full, a stale core binary at a protocol upgrade), which is the crash class; backfill, the one phase dominated by genuinely transient network I/O, already carries three bounded retry layers and does not serve, so crash-looping through an outage there is harmless. The captive core the loop appeared to protect is torn down per attempt anyway (the stream owns it), and the codebase is process-boot-shaped by design: fee replay, watermark derivation, and boundary seeding all recover from durable state. Deleting the loop also deletes the per-process/per-attempt partition and its bug classes outright.

## Testing

- Full `internal/rpcv2/...` + `internal/jsonrpc` + `internal/methods` suites green; `golangci-lint --new-from-rev origin/feature/full-history` 0 issues.
- The supervise tests became `runBody` tests (clean-shutdown-on-cancel via the shared `waitClean`; a failing run surfaces once, with a no-retry assertion). The rebind test became a serve-and-drain-on-cancel test. The death test pins that ServeReads returning early fails run(); the bind-failure test occupies a real port and asserts run()'s own address-in-use error.
- Post-change review passes: a four-angle cleanup review (applied), a high-effort correctness review (10 verified findings, 8 applied, 1 accepted and documented, 1 resolved by restoring the fail-fast seed), and a targeted follow-up on the fix hunks (no correctness bugs; defer ordering verified load-bearing; the `errors.Is` classification traced through the SDK's actual cancel-error shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



