### PR TITLE
rpcv2: fold the events package into stores/event

### DIFF
--- a/cmd/stellar-rpc/internal/rpcv2/ingest/doc.go
+++ b/cmd/stellar-rpc/internal/rpcv2/ingest/doc.go
@@ -3,7 +3,7 @@
 // and writes the three data types — ledgers, txhashes, contract events —
 // into the full-history stores, one chunk at a time, via the zero-copy
 // view extractors in the go-stellar-sdk ingest package and the RPC-side
-// events.PayloadsFromLedgerEvents emitter.
+// event.PayloadsFromLedgerEvents emitter.
 //
 // Both tiers extract each ledger with a SINGLE ExtractLedgerTxParts walk
 // (the hot DB's IngestLedger, the cold coldChunk.ingest) — txhash reads

--- a/cmd/stellar-rpc/internal/rpcv2/ingest/events.go
+++ b/cmd/stellar-rpc/internal/rpcv2/ingest/events.go
@@ -10,7 +10,6 @@ import (
 	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
 )
 
@@ -18,14 +17,14 @@ import (
 
 // eventsCold models the backfill path: shared-walk output → payloads →
 // term-index accumulate + cold append, then chunk-end Finish + WriteColdIndex.
-// No HotStore is involved — it maintains an in-memory events.Bitmaps mirror via
-// NewBitmaps + per-event TermsForBytes, and an events.LedgerOffsets to assign
+// No HotStore is involved — it maintains an in-memory event.Bitmaps mirror via
+// NewBitmaps + per-event TermsForBytes, and an event.LedgerOffsets to assign
 // chunk-relative event IDs.
 type eventsCold struct {
 	chunkID   chunk.ID
 	writer    *event.ColdWriter
-	mirror    events.Bitmaps
-	offsets   *events.LedgerOffsets
+	mirror    event.Bitmaps
+	offsets   *event.LedgerOffsets
 	bucketDir string
 	metrics   coldMetrics
 	// failed latches any write error. A failed write can leave the mirror
@@ -56,8 +55,8 @@ func newEventsCold(bucketDir string, chunkID chunk.ID, sink MetricSink) (*events
 	return &eventsCold{
 		chunkID:   chunkID,
 		writer:    w,
-		mirror:    events.NewBitmaps(),
-		offsets:   events.NewLedgerOffsets(chunkID.FirstLedger()),
+		mirror:    event.NewBitmaps(),
+		offsets:   event.NewLedgerOffsets(chunkID.FirstLedger()),
 		bucketDir: bucketDir,
 		metrics:   newColdMetrics(sink, dataTypeEvents),
 	}, nil
@@ -121,13 +120,13 @@ func (e *eventsCold) close() error {
 
 // ingestSeq writes one ledger's events and returns the count written. It shapes
 // coldChunk's shared ExtractLedgerTxParts walk output into cursor-ordered payloads
-// via events.PayloadsFromLedgerEvents — the SAME function the hot tier uses, so
+// via event.PayloadsFromLedgerEvents — the SAME function the hot tier uses, so
 // event-ID assignment is byte-identical to the hot path (same shaping). A
 // pre-Soroban (V0) ledger yields zero payloads, recorded like any event-free
 // ledger. Shaping folds into the per-writer ColdIngest total; the extraction
 // itself is metered once, ledger-scoped, as the ColdExtract signal.
 func (e *eventsCold) ingestSeq(seq uint32, closedAt int64, txParts []sdkingest.LedgerTxParts) (int, error) {
-	payloads, err := events.PayloadsFromLedgerEvents(txParts, seq, closedAt)
+	payloads, err := event.PayloadsFromLedgerEvents(txParts, seq, closedAt)
 	if err != nil {
 		return 0, fmt.Errorf("shape events seq %d: %w", seq, err)
 	}
@@ -154,7 +153,7 @@ func (e *eventsCold) ingestSeq(seq uint32, closedAt int64, txParts []sdkingest.L
 	var termDur, writeDur time.Duration
 	for i := range payloads {
 		tstart := time.Now()
-		keys, terr := events.TermsForBytes(payloads[i].ContractEventBytes)
+		keys, terr := event.TermsForBytes(payloads[i].ContractEventBytes)
 		if terr != nil {
 			return 0, fmt.Errorf("TermsForBytes seq %d eventIdx %d: %w", seq, i, terr)
 		}

--- a/cmd/stellar-rpc/internal/rpcv2/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/ingest/ingest_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/feewindow"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rpcv2test"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
@@ -266,7 +265,7 @@ const eventTopic = "ingest_test"
 // operation-level contract event (topic=eventTopic). It returns the wire bytes,
 // the transaction hash (for txhash lookups), and the event's term key (for event
 // index lookups).
-func marshalLCMWithEvent(t *testing.T, seq uint32) ([]byte, [32]byte, events.TermKey) {
+func marshalLCMWithEvent(t *testing.T, seq uint32) ([]byte, [32]byte, event.TermKey) {
 	t.Helper()
 	ev := buildContractEvent(eventTopic)
 	meta := xdr.TransactionMeta{
@@ -279,7 +278,7 @@ func marshalLCMWithEvent(t *testing.T, seq uint32) ([]byte, [32]byte, events.Ter
 
 	evBytes, err := ev.MarshalBinary()
 	require.NoError(t, err)
-	keys, err := events.TermsForBytes(evBytes)
+	keys, err := event.TermsForBytes(evBytes)
 	require.NoError(t, err)
 	require.NotEmpty(t, keys)
 	return rawBytes, hash, keys[0]
@@ -527,7 +526,7 @@ func TestEventsColdWriter_Readback(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ing.close()) }()
 
-	var term events.TermKey
+	var term event.TermKey
 	for _, seq := range []uint32{first, first + 1} {
 		raw, _, tk := marshalLCMWithEvent(t, seq)
 		term = tk
@@ -543,7 +542,7 @@ func TestEventsColdWriter_Readback(t *testing.T) {
 	cnt, err := cr.EventCount()
 	require.NoError(t, err)
 	require.Equal(t, uint32(2), cnt)
-	bms, err := cr.LookupKeys(context.Background(), []events.TermKey{term})
+	bms, err := cr.LookupKeys(context.Background(), []event.TermKey{term})
 	require.NoError(t, err)
 	require.NotNil(t, bms[0])
 	require.Equal(t, uint64(2), bms[0].GetCardinality())
@@ -599,7 +598,7 @@ func TestEventsColdWriter_V0KeepsOffsetsContiguous(t *testing.T) {
 	require.Equal(t, uint32(1), evEnd)
 
 	// And the event is queryable by its term.
-	bms, err := cr.LookupKeys(context.Background(), []events.TermKey{term})
+	bms, err := cr.LookupKeys(context.Background(), []event.TermKey{term})
 	require.NoError(t, err)
 	require.NotNil(t, bms[0])
 	require.Equal(t, uint64(1), bms[0].GetCardinality())
@@ -644,8 +643,8 @@ func TestWriteColdChunk_EventlessChunk_FullyReadable(t *testing.T) {
 	cnt, err := cr.EventCount()
 	require.NoError(t, err)
 	require.Zero(t, cnt)
-	anyKey := events.ComputeTermKey([]byte("any"), events.FieldContractID)
-	bms, lerr := cr.LookupKeys(context.Background(), []events.TermKey{anyKey})
+	anyKey := event.ComputeTermKey([]byte("any"), event.FieldContractID)
+	bms, lerr := cr.LookupKeys(context.Background(), []event.TermKey{anyKey})
 	require.NoError(t, lerr)
 	require.Nil(t, bms[0], "a term with no matching events misses cleanly (nil bitmap)")
 
@@ -670,7 +669,7 @@ func TestColdChunk_Success(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cc.close()) }()
 
-	var term events.TermKey
+	var term event.TermKey
 	for _, seq := range []uint32{first, first + 1} {
 		raw, _, tk := marshalLCMWithEvent(t, seq)
 		term = tk
@@ -695,7 +694,7 @@ func TestColdChunk_Success(t *testing.T) {
 		chunkID, filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID()), event.ColdReaderOptions{})
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ecr.Close()) }()
-	bms, err := ecr.LookupKeys(context.Background(), []events.TermKey{term})
+	bms, err := ecr.LookupKeys(context.Background(), []event.TermKey{term})
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), bms[0].GetCardinality())
 
@@ -962,7 +961,7 @@ func TestWriteColdChunk_ByteIdentity_SharedWalk(t *testing.T) {
 
 	// Reference #2 — events: PayloadsFromLedgerEvents with chunk-relative IDs
 	// assigned in ingest (ascending-seq) order, mapped to their term keys.
-	wantTermIDs := map[events.TermKey][]uint32{}
+	wantTermIDs := map[event.TermKey][]uint32{}
 	var nextID uint32
 	for _, seq := range sentinels {
 		view := xdr.LedgerCloseMetaView(raws[seq])
@@ -970,10 +969,10 @@ func TestWriteColdChunk_ByteIdentity_SharedWalk(t *testing.T) {
 		require.NoError(t, err)
 		closedAt, err := view.LedgerCloseTime()
 		require.NoError(t, err)
-		payloads, err := events.PayloadsFromLedgerEvents(txParts, seq, closedAt)
+		payloads, err := event.PayloadsFromLedgerEvents(txParts, seq, closedAt)
 		require.NoError(t, err)
 		for i := range payloads {
-			keys, kerr := events.TermsForBytes(payloads[i].ContractEventBytes)
+			keys, kerr := event.TermsForBytes(payloads[i].ContractEventBytes)
 			require.NoError(t, kerr)
 			for _, k := range keys {
 				wantTermIDs[k] = append(wantTermIDs[k], nextID)
@@ -992,7 +991,7 @@ func TestWriteColdChunk_ByteIdentity_SharedWalk(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, nextID, cnt, "cold event count must match the reference payload count")
 
-	terms := make([]events.TermKey, 0, len(wantTermIDs))
+	terms := make([]event.TermKey, 0, len(wantTermIDs))
 	for k := range wantTermIDs {
 		terms = append(terms, k)
 	}
@@ -1061,7 +1060,7 @@ func TestWriteColdChunk_EventsCold_Readback(t *testing.T) {
 	logger := testLogger()
 
 	evSeqs := map[uint32]bool{first: true, first + 1: true}
-	var term events.TermKey
+	var term event.TermKey
 	gen := func(tt *testing.T, seq uint32) []byte {
 		if evSeqs[seq] {
 			raw, _, tk := marshalLCMWithEvent(tt, seq)
@@ -1084,7 +1083,7 @@ func TestWriteColdChunk_EventsCold_Readback(t *testing.T) {
 	cnt, err := cr.EventCount()
 	require.NoError(t, err)
 	require.Equal(t, uint32(len(evSeqs)), cnt)
-	bms, err := cr.LookupKeys(context.Background(), []events.TermKey{term})
+	bms, err := cr.LookupKeys(context.Background(), []event.TermKey{term})
 	require.NoError(t, err)
 	require.NotNil(t, bms[0])
 	require.Equal(t, uint64(len(evSeqs)), bms[0].GetCardinality())

--- a/cmd/stellar-rpc/internal/rpcv2/query/event_page.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/event_page.go
@@ -17,7 +17,6 @@ import (
 	"math"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
 )
 
@@ -66,7 +65,7 @@ const (
 // is present only while it leads the watermark (assemblePage drops a
 // passed one).
 type EventPage struct {
-	Events []events.Payload
+	Events []event.Payload
 	Next   EventCursor
 	Status ScanStatus
 }
@@ -259,7 +258,7 @@ func resumeBounds(cursor *EventCursor) (uint32, uint32, *EventPosition) {
 // walkResult accumulates the chunks' results; see chunkResult for the
 // stop-fact fields. finished means every part was consumed.
 type walkResult struct {
-	events         []events.Payload
+	events         []event.Payload
 	last           *EventPosition
 	nextUnserved   *uint32
 	coveredThrough *uint32
@@ -320,7 +319,7 @@ func (a *ReadView) walkChunks(
 
 // chunkResult is one chunk's contribution to a page.
 type chunkResult struct {
-	events []events.Payload
+	events []event.Payload
 	last   *EventPosition
 	// nextUnserved is set when the page filled while the stream still
 	// had matches: the ledger of the first match the client has not
@@ -398,7 +397,7 @@ func scanChunk(
 // QueryEvents refuses to serve when a bookmark is above the view's
 // latest, and resumeBounds starts the window at the position's ledger.
 func chunkWindow(
-	ctx context.Context, r event.Reader, ofs *events.LedgerOffsets,
+	ctx context.Context, r event.Reader, ofs *event.LedgerOffsets,
 	pLo, pHi uint32, reenter *EventPosition, desc bool,
 ) (event.IDRange, error) {
 	window, err := event.IDRangeForLedgers(ofs, pLo, pHi)
@@ -427,7 +426,7 @@ func chunkWindow(
 // fixed inclusion rule), so a mismatch is a wrong cursor, not
 // something to recover from.
 func resumeOrdinal(
-	ctx context.Context, r event.Reader, ofs *events.LedgerOffsets, pos *EventPosition,
+	ctx context.Context, r event.Reader, ofs *event.LedgerOffsets, pos *EventPosition,
 ) (uint32, error) {
 	lStart, lEnd, err := ofs.EventIDs(pos.Ledger)
 	if err != nil {

--- a/cmd/stellar-rpc/internal/rpcv2/query/event_page_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/event_page_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rpcv2test"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
@@ -136,7 +135,7 @@ func fullChunkSeamFixture(t *testing.T) (*Registry, uint32, uint32) {
 	return r, lo, f6
 }
 
-func labels(t *testing.T, payloads []events.Payload) []string {
+func labels(t *testing.T, payloads []event.Payload) []string {
 	t.Helper()
 	out := make([]string, len(payloads))
 	for i := range payloads {
@@ -395,7 +394,7 @@ func TestQueryEvents_UncoveredWindowFailsLoud(t *testing.T) {
 	// Head side: ingest enforces chunk-aligned starts, so this state
 	// cannot be staged through a real store; scanChunk is checked
 	// directly with offsets that begin past the part's From.
-	ofs := events.NewLedgerOffsets(f + 8)
+	ofs := event.NewLedgerOffsets(f + 8)
 	require.NoError(t, ofs.Append(f+8, 1))
 	_, err = scanChunk(context.Background(),
 		eventPart{Chunk: c, Reader: &fakeEventReader{chunkID: c, ofs: ofs}, From: f, To: f + 8},
@@ -920,9 +919,9 @@ func TestQueryEvents_CursorValidation(t *testing.T) {
 // another package's store internals.
 type fakeEventReader struct {
 	chunkID  chunk.ID
-	ofs      *events.LedgerOffsets
-	payloads []events.Payload // indexed by ordinal
-	bitmaps  map[events.TermKey]*roaring.Bitmap
+	ofs      *event.LedgerOffsets
+	payloads []event.Payload // indexed by ordinal
+	bitmaps  map[event.TermKey]*roaring.Bitmap
 }
 
 func (f *fakeEventReader) ChunkID() chunk.ID { return f.chunkID }
@@ -931,9 +930,9 @@ func (f *fakeEventReader) EventCount() (uint32, error) {
 	return uint32(len(f.payloads)), nil
 }
 
-func (f *fakeEventReader) Offsets() (*events.LedgerOffsets, error) { return f.ofs, nil }
+func (f *fakeEventReader) Offsets() (*event.LedgerOffsets, error) { return f.ofs, nil }
 
-func (f *fakeEventReader) LookupKeys(_ context.Context, keys []events.TermKey) ([]*roaring.Bitmap, error) {
+func (f *fakeEventReader) LookupKeys(_ context.Context, keys []event.TermKey) ([]*roaring.Bitmap, error) {
 	out := make([]*roaring.Bitmap, len(keys))
 	for i, k := range keys {
 		out[i] = f.bitmaps[k]
@@ -941,16 +940,16 @@ func (f *fakeEventReader) LookupKeys(_ context.Context, keys []events.TermKey) (
 	return out, nil
 }
 
-func (f *fakeEventReader) FetchEvents(_ context.Context, ids []uint32) ([]events.Payload, error) {
-	out := make([]events.Payload, len(ids))
+func (f *fakeEventReader) FetchEvents(_ context.Context, ids []uint32) ([]event.Payload, error) {
+	out := make([]event.Payload, len(ids))
 	for i, id := range ids {
 		out[i] = f.payloads[id]
 	}
 	return out, nil
 }
 
-func (f *fakeEventReader) FetchRange(_ context.Context, start, count uint32) iter.Seq2[events.Payload, error] {
-	return func(yield func(events.Payload, error) bool) {
+func (f *fakeEventReader) FetchRange(_ context.Context, start, count uint32) iter.Seq2[event.Payload, error] {
+	return func(yield func(event.Payload, error) bool) {
 		for i := start; i < start+count; i++ {
 			if !yield(f.payloads[i], nil) {
 				return
@@ -959,7 +958,7 @@ func (f *fakeEventReader) FetchRange(_ context.Context, start, count uint32) ite
 	}
 }
 
-func (f *fakeEventReader) All(ctx context.Context) iter.Seq2[events.Payload, error] {
+func (f *fakeEventReader) All(ctx context.Context) iter.Seq2[event.Payload, error] {
 	return f.FetchRange(ctx, 0, uint32(len(f.payloads)))
 }
 
@@ -973,11 +972,11 @@ func TestEventScan_DropsDoNotStallTheChunk(t *testing.T) {
 	f := c.FirstLedger()
 	const total = 10
 
-	ofs := events.NewLedgerOffsets(f)
+	ofs := event.NewLedgerOffsets(f)
 	require.NoError(t, ofs.Append(f, total))
 	fake := &fakeEventReader{
 		chunkID: c, ofs: ofs,
-		bitmaps: map[events.TermKey]*roaring.Bitmap{},
+		bitmaps: map[event.TermKey]*roaring.Bitmap{},
 	}
 	for i := range total {
 		label := fmt.Sprintf("noise%d", i)
@@ -988,7 +987,7 @@ func TestEventScan_DropsDoNotStallTheChunk(t *testing.T) {
 		ev := symEvent(cid, label)
 		raw, err := ev.MarshalBinary()
 		require.NoError(t, err)
-		fake.payloads = append(fake.payloads, events.Payload{
+		fake.payloads = append(fake.payloads, event.Payload{
 			LedgerSequence: f, TxIdx: 1, OpIdx: 1, EventIdx: uint32(i),
 			ContractEventBytes: raw,
 		})
@@ -997,7 +996,7 @@ func TestEventScan_DropsDoNotStallTheChunk(t *testing.T) {
 	// are collision-style false positives the post-filter must drop.
 	all := roaring.New()
 	all.AddRange(0, total)
-	fake.bitmaps[events.ComputeTermKey(cidA[:], events.FieldContractID)] = all
+	fake.bitmaps[event.ComputeTermKey(cidA[:], event.FieldContractID)] = all
 
 	got, err := scanChunk(context.Background(),
 		eventPart{Chunk: c, Reader: fake, From: f, To: f},

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/benchmark_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/benchmark_test.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"fmt"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/bitmaps.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/bitmaps.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"github.com/RoaringBitmap/roaring/v2"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_format.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_format.go
@@ -10,7 +10,7 @@ package event
 //   2. events.pack record codec: ItemsPerRecord, the zstd encoder
 //      constructor, and the shared zstd decoder.
 //
-//   3. events.LedgerOffsets app-data encoding (encodeLedgerOffsets /
+//   3. LedgerOffsets app-data encoding (encodeLedgerOffsets /
 //      DecodeLedgerOffsets). The writer embeds the encoded form in
 //      events.pack's app-data slot; the reader decodes it on open.
 //
@@ -33,7 +33,6 @@ import (
 	"github.com/stellar/streamhash"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/packfile"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/zstd"
 )
@@ -121,7 +120,7 @@ func newEventsPackEncoder() packfile.RecordEncoder { return zstd.NewCompressor()
 var eventsPackDecoder = zstd.NewDecompressor()
 
 // ──────────────────────────────────────────────────────────────────
-// events.LedgerOffsets app-data wire format.
+// LedgerOffsets app-data wire format.
 //
 // Embedded in events.pack's app-data slot:
 //
@@ -134,7 +133,7 @@ var eventsPackDecoder = zstd.NewDecompressor()
 //	                    startLedger + i)
 //
 // Cumulative counts (rather than per-ledger counts) match the
-// in-memory representation of events.LedgerOffsets and let the cold reader
+// in-memory representation of LedgerOffsets and let the cold reader
 // resolve ledger range → eventID range in two array lookups.
 //
 // The version byte makes future format additions safe across
@@ -143,23 +142,23 @@ var eventsPackDecoder = zstd.NewDecompressor()
 // ──────────────────────────────────────────────────────────────────
 
 // LedgerOffsetsFormatVersion is the current on-disk version for the
-// events.LedgerOffsets app-data block.
+// LedgerOffsets app-data block.
 const LedgerOffsetsFormatVersion byte = 0x01
 
 const ledgerOffsetsHeaderLen = 1 + 4 + 4
 
 // ErrUnknownLedgerOffsetsVersion is returned when decoding app data
 // whose leading version byte isn't recognized by this binary.
-var ErrUnknownLedgerOffsetsVersion = errors.New("events: unknown events.LedgerOffsets format version")
+var ErrUnknownLedgerOffsetsVersion = errors.New("events: unknown LedgerOffsets format version")
 
 // ErrShortLedgerOffsets is returned when the app data buffer is
 // shorter than the declared header or trailing cumulative array.
-var ErrShortLedgerOffsets = errors.New("events: events.LedgerOffsets app data too short")
+var ErrShortLedgerOffsets = errors.New("events: LedgerOffsets app data too short")
 
 // encodeLedgerOffsets serializes o for packfile app-data embedding.
-func encodeLedgerOffsets(o *events.LedgerOffsets) ([]byte, error) {
+func encodeLedgerOffsets(o *LedgerOffsets) ([]byte, error) {
 	if o == nil {
-		return nil, errors.New("events: nil events.LedgerOffsets")
+		return nil, errors.New("events: nil LedgerOffsets")
 	}
 	cumulative := o.Offsets()
 	n := uint32(len(cumulative)) //nolint:gosec // bounded by chunk's ledger count
@@ -175,9 +174,9 @@ func encodeLedgerOffsets(o *events.LedgerOffsets) ([]byte, error) {
 }
 
 // DecodeLedgerOffsets parses the packfile app-data block written by
-// encodeLedgerOffsets back into a *events.LedgerOffsets. Used by the cold
+// encodeLedgerOffsets back into a *LedgerOffsets. Used by the cold
 // reader (PR-3a).
-func DecodeLedgerOffsets(data []byte) (*events.LedgerOffsets, error) {
+func DecodeLedgerOffsets(data []byte) (*LedgerOffsets, error) {
 	if len(data) < ledgerOffsetsHeaderLen {
 		return nil, ErrShortLedgerOffsets
 	}
@@ -191,7 +190,7 @@ func DecodeLedgerOffsets(data []byte) (*events.LedgerOffsets, error) {
 		return nil, fmt.Errorf("%w: want %d bytes, got %d", ErrShortLedgerOffsets, expected, len(data))
 	}
 
-	offsets := events.NewLedgerOffsets(startLedger)
+	offsets := NewLedgerOffsets(startLedger)
 	var prev uint32
 	for i := range n {
 		cumulative := binary.BigEndian.Uint32(data[ledgerOffsetsHeaderLen+int(i)*4:])
@@ -199,7 +198,7 @@ func DecodeLedgerOffsets(data []byte) (*events.LedgerOffsets, error) {
 			return nil, fmt.Errorf("events: non-monotonic cumulative count at ledger %d", startLedger+i)
 		}
 		if err := offsets.Append(startLedger+i, cumulative-prev); err != nil {
-			return nil, fmt.Errorf("events: decode events.LedgerOffsets: %w", err)
+			return nil, fmt.Errorf("events: decode LedgerOffsets: %w", err)
 		}
 		prev = cumulative
 	}
@@ -209,11 +208,11 @@ func DecodeLedgerOffsets(data []byte) (*events.LedgerOffsets, error) {
 // ──────────────────────────────────────────────────────────────────
 // MPHF wrapper around github.com/stellar/streamhash.
 //
-// The MPHF maps each events.TermKey (16 bytes of xxh3-128 over
+// The MPHF maps each TermKey (16 bytes of xxh3-128 over
 // `field || value`) to a unique slot in [0, N), where N is the
 // number of unique terms in a Chunk. index.pack is laid out as one
 // roaring-bitmap record per slot. The cold reader looks up a
-// events.TermKey via Lookup, reads the bitmap record at that slot, and
+// TermKey via Lookup, reads the bitmap record at that slot, and
 // MUST verify a 4-byte fingerprint stored alongside the bitmap
 // before trusting it: an MPHF returns a slot for every input,
 // including keys never added at build time. False positives are
@@ -223,9 +222,9 @@ func DecodeLedgerOffsets(data []byte) (*events.LedgerOffsets, error) {
 //
 // Hash compatibility: streamhash's AddKey/Query do not re-hash the
 // supplied key — they take the first 16 bytes as the routing
-// identity. events.TermKey is already a uniformly distributed 16-byte
-// xxh3-128 value (produced by events.ComputeTermKey via
-// streamhash.PreHashInPlace), so the wrapper passes events.TermKey[:]
+// identity. TermKey is already a uniformly distributed 16-byte
+// xxh3-128 value (produced by ComputeTermKey via
+// streamhash.PreHashInPlace), so the wrapper passes TermKey[:]
 // through. No double-hashing.
 // ──────────────────────────────────────────────────────────────────
 
@@ -246,7 +245,7 @@ type mphf struct {
 	idx *streamhash.Index
 }
 
-// buildMPHF constructs an MPHF over every events.TermKey in bitmaps,
+// buildMPHF constructs an MPHF over every TermKey in bitmaps,
 // writes the serialized form to outputPath, and returns an opened
 // handle ready for immediate Lookup. The freeze path needs slot
 // assignments before closing so it can populate index.pack at the
@@ -254,7 +253,7 @@ type mphf struct {
 //
 // len(bitmaps) supplies streamhash's required total-keys count;
 // the map is iterated once to feed keys to the builder. The bitmap
-// values are not consumed — only the events.TermKey participates in
+// values are not consumed — only the TermKey participates in
 // MPHF construction.
 //
 // Memory usage is bounded by streamhash's internal partition buffers,
@@ -268,7 +267,7 @@ type mphf struct {
 // inputs.
 //
 //nolint:nonamedreturns // named err carries through to the deferred builder.Close
-func buildMPHF(ctx context.Context, bitmaps events.Bitmaps, outputPath string) (m *mphf, err error) {
+func buildMPHF(ctx context.Context, bitmaps Bitmaps, outputPath string) (m *mphf, err error) {
 	total := len(bitmaps)
 
 	tmpDir, terr := os.MkdirTemp("", "eventstore-unsorted-")
@@ -343,7 +342,7 @@ func openMPHF(path string) (*mphf, error) {
 // 4-byte fingerprint stored alongside the bitmap at that slot in
 // index.pack — an MPHF can map an unseen key to a valid build-set
 // slot, and only the fingerprint catches that residual collision.
-func (m *mphf) Lookup(key events.TermKey) (uint32, error) {
+func (m *mphf) Lookup(key TermKey) (uint32, error) {
 	slot, err := m.idx.QueryRank(key[:])
 	if err != nil {
 		if errors.Is(err, streamhash.ErrNotFound) {

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_format_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_format_test.go
@@ -9,16 +9,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 )
 
 // ──────────────────────────────────────────────────────────────────
-// events.LedgerOffsets app-data wire-format tests.
+// LedgerOffsets app-data wire-format tests.
 // ──────────────────────────────────────────────────────────────────
 
 func TestLedgerOffsets_EncodeDecodeRoundTrip(t *testing.T) {
-	o := events.NewLedgerOffsets(50_002)
+	o := NewLedgerOffsets(50_002)
 	require.NoError(t, o.Append(50_002, 3))
 	require.NoError(t, o.Append(50_003, 0)) // empty ledger
 	require.NoError(t, o.Append(50_004, 7))
@@ -46,7 +44,7 @@ func TestLedgerOffsets_EncodeDecodeRoundTrip(t *testing.T) {
 }
 
 func TestLedgerOffsets_EncodeEmpty(t *testing.T) {
-	o := events.NewLedgerOffsets(50_002)
+	o := NewLedgerOffsets(50_002)
 	bytes, err := encodeLedgerOffsets(o)
 	require.NoError(t, err)
 	assert.Len(t, bytes, ledgerOffsetsHeaderLen)
@@ -75,7 +73,7 @@ func TestLedgerOffsets_DecodeRejectsUnknownVersion(t *testing.T) {
 
 func TestLedgerOffsets_DecodeRejectsTruncatedArray(t *testing.T) {
 	// Declare 3 ledgers but only supply 2 entries of payload bytes.
-	o := events.NewLedgerOffsets(50_002)
+	o := NewLedgerOffsets(50_002)
 	require.NoError(t, o.Append(50_002, 1))
 	require.NoError(t, o.Append(50_003, 1))
 	require.NoError(t, o.Append(50_004, 1))
@@ -97,28 +95,28 @@ func TestLedgerOffsets_EncodeNil(t *testing.T) {
 // MPHF wrapper tests.
 // ──────────────────────────────────────────────────────────────────
 
-// keyFor returns the events.TermKey events.ComputeTermKey produces for the i'th
+// keyFor returns the TermKey ComputeTermKey produces for the i'th
 // test value — useful for verifying Lookup against the same value
-// the test loaded into the events.Bitmaps.
-func keyFor(i int) events.TermKey {
-	return events.ComputeTermKey(
+// the test loaded into the Bitmaps.
+func keyFor(i int) TermKey {
+	return ComputeTermKey(
 		fmt.Appendf(nil, "key-%d", i),
-		events.FieldContractID,
+		FieldContractID,
 	)
 }
 
-// buildIndex returns a populated events.Bitmaps of n distinct terms,
+// buildIndex returns a populated Bitmaps of n distinct terms,
 // each with a single event ID. Mirrors how the freeze writer will
 // hand the chunk's term set to buildMPHF at runtime — the writer
-// always has an events.Bitmaps in hand (the chunk's in-memory mirror
+// always has an Bitmaps in hand (the chunk's in-memory mirror
 // or one rebuilt from a RocksDB scan). The returned index is already
 // Close()'d so buildMPHF can iterate via idx.All().
-func buildIndex(t *testing.T, n int) events.Bitmaps {
+func buildIndex(t *testing.T, n int) Bitmaps {
 	t.Helper()
-	idx := events.NewBitmaps()
+	idx := NewBitmaps()
 	for i := range n {
 		idx.AddTo(
-			events.ComputeTermKey(fmt.Appendf(nil, "key-%d", i), events.FieldContractID),
+			ComputeTermKey(fmt.Appendf(nil, "key-%d", i), FieldContractID),
 			uint32(i),
 		)
 	}
@@ -181,9 +179,9 @@ func TestLookup_UnseenKeyBehavior(t *testing.T) {
 		collidedSlot int
 	)
 	for i := range 200 {
-		unseen := events.ComputeTermKey(
+		unseen := ComputeTermKey(
 			fmt.Appendf(nil, "never-added-%d", i),
-			events.FieldTopic0,
+			FieldTopic0,
 		)
 		slot, err := m.Lookup(unseen)
 		switch {
@@ -206,12 +204,12 @@ func TestLookup_UnseenKeyBehavior(t *testing.T) {
 
 func TestBuild_EmptyIndexSucceeds(t *testing.T) {
 	// Zero terms builds a valid empty index rather than erroring.
-	empty := events.NewBitmaps()
+	empty := NewBitmaps()
 	m, err := buildMPHF(context.Background(), empty, filepath.Join(t.TempDir(), "index.hash"))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = m.Close() })
 	assert.True(t, m.isEmpty())
-	_, lerr := m.Lookup(events.ComputeTermKey([]byte("anything"), events.FieldContractID))
+	_, lerr := m.Lookup(ComputeTermKey([]byte("anything"), FieldContractID))
 	assert.ErrorIs(t, lerr, ErrKeyNotFound)
 }
 
@@ -225,7 +223,7 @@ func TestOpen_RoundTripsBuiltFile(t *testing.T) {
 	// Record every (key, slot) the Build handle reports, then close
 	// it and reopen via Open. Slots must match — the file is the
 	// authoritative serialization.
-	expected := make(map[events.TermKey]uint32, n)
+	expected := make(map[TermKey]uint32, n)
 	for i := range n {
 		k := keyFor(i)
 		slot, err := built.Lookup(k)
@@ -249,7 +247,7 @@ func TestBuild_AcceptsManyKeys(t *testing.T) {
 	// A more realistic workload — exercise streamhash beyond toy
 	// sizes so basic build-time issues (chunked partition handling,
 	// etc.) surface in unit tests rather than at PR-2c integration
-	// time. Also exercises the streaming path: with an events.Bitmaps
+	// time. Also exercises the streaming path: with an Bitmaps
 	// holding 10K terms, Build never materializes the keys as a
 	// slice.
 	const n = 10_000

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_index.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_index.go
@@ -5,7 +5,7 @@ package event
 // serialized MPHF) inside a Chunk's cold directory.
 //
 // The events.pack writer half lives in cold_writer.go. Shared format
-// constants, the events.LedgerOffsets app-data wire format, and the
+// constants, the LedgerOffsets app-data wire format, and the
 // MPHF wrapper live in cold_format.go.
 
 import (
@@ -21,7 +21,6 @@ import (
 	"github.com/RoaringBitmap/roaring/v2"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/packfile"
 )
 
@@ -51,7 +50,7 @@ import (
 // catastrophically.
 //
 // Both cold backfill and the live-chunk freeze build a Bitmaps single-threaded by
-// re-deriving terms from raw LCMs (per-event events.TermsForBytes + Bitmaps.AddTo) and
+// re-deriving terms from raw LCMs (per-event TermsForBytes + Bitmaps.AddTo) and
 // hand it directly here.
 //
 // index.hash is the MPHF serialized via buildMPHF.
@@ -60,7 +59,7 @@ import (
 // order. Each record is:
 //
 //	offset  size  field
-//	0       4     fingerprint (first 4 bytes of the events.TermKey hash)
+//	0       4     fingerprint (first 4 bytes of the TermKey hash)
 //	4       N     serialized roaring bitmap (Bitmap.MarshalBinary)
 //
 // The cold reader uses mphf.Lookup(term) → slot to find the record
@@ -83,7 +82,7 @@ import (
 // ctx cancels the MPHF build phase (the expensive part for large
 // chunks); the subsequent index.pack write is a tight in-memory
 // loop that doesn't poll ctx.
-func WriteColdIndex(ctx context.Context, chunkID chunk.ID, bitmaps events.Bitmaps, bucketDir string) (err error) {
+func WriteColdIndex(ctx context.Context, chunkID chunk.ID, bitmaps Bitmaps, bucketDir string) (err error) {
 	indexPackPath := filepath.Join(bucketDir, IndexPackName(chunkID))
 	indexHashPath := filepath.Join(bucketDir, IndexHashName(chunkID))
 

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_index_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_index_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/packfile"
 )
 
@@ -22,18 +21,18 @@ import (
 // composing per-chunk filenames inside the temp bucket directory.
 const indexTestChunkID = chunk.ID(0)
 
-// indexFixture builds a populated events.Bitmaps containing n distinct
+// indexFixture builds a populated Bitmaps containing n distinct
 // contractID terms; each term is mapped to a roaring bitmap of two
 // event IDs derived from i so callers can verify bitmap round-trip
 // integrity term by term. The returned index is already Close()'d
 // so callers can iterate it via WriteColdIndex (which requires a
 // frozen index).
-func indexFixture(t *testing.T, n int) events.Bitmaps {
+func indexFixture(t *testing.T, n int) Bitmaps {
 	t.Helper()
-	idx := events.NewBitmaps()
+	idx := NewBitmaps()
 	for i := range n {
 		v := fmt.Sprintf("term-%d", i)
-		idx.AddTo(events.ComputeTermKey([]byte(v), events.FieldContractID),
+		idx.AddTo(ComputeTermKey([]byte(v), FieldContractID),
 			uint32(i*10), uint32(i*10+1))
 	}
 	return idx
@@ -114,9 +113,9 @@ func TestWriteIndex_RoundTripsBitmapsPerTerm(t *testing.T) {
 	// fingerprint and verify the deserialized bitmap matches the
 	// original.
 	for i := range n {
-		term := events.ComputeTermKey(
+		term := ComputeTermKey(
 			fmt.Appendf(nil, "term-%d", i),
-			events.FieldContractID,
+			FieldContractID,
 		)
 		slot, err := m.Lookup(term)
 		require.NoError(t, err, "lookup term-%d", i)
@@ -157,9 +156,9 @@ func TestWriteIndex_UnseenTermFingerprintMismatches(t *testing.T) {
 	// fingerprint check screens.
 	var collisions, mismatches int
 	for i := range 100 {
-		unseen := events.ComputeTermKey(
+		unseen := ComputeTermKey(
 			fmt.Appendf(nil, "never-seen-%d", i),
-			events.FieldTopic0,
+			FieldTopic0,
 		)
 		slot, err := m.Lookup(unseen)
 		if errors.Is(err, ErrKeyNotFound) {
@@ -205,7 +204,7 @@ func TestWriteIndex_RespectsContextCancellation(t *testing.T) {
 // the ordinary path.
 func TestWriteIndex_ZeroTerms_WritesEmptyIndex(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, events.NewBitmaps(), dir))
+	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, NewBitmaps(), dir))
 
 	// index.hash exists (a real streamhash index built over zero terms).
 	hashInfo, err := os.Stat(filepath.Join(dir, IndexHashName(indexTestChunkID)))
@@ -223,7 +222,7 @@ func TestWriteIndex_ZeroTerms_WritesEmptyIndex(t *testing.T) {
 	m, err := openMPHF(filepath.Join(dir, IndexHashName(indexTestChunkID)))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = m.Close() })
-	_, lerr := m.Lookup(events.ComputeTermKey([]byte("anything"), events.FieldContractID))
+	_, lerr := m.Lookup(ComputeTermKey([]byte("anything"), FieldContractID))
 	assert.ErrorIs(t, lerr, ErrKeyNotFound)
 }
 
@@ -262,9 +261,9 @@ func TestWriteIndex_SlotsAreDense(t *testing.T) {
 
 			seen := make(map[uint32]struct{}, n)
 			for i := range n {
-				term := events.ComputeTermKey(
+				term := ComputeTermKey(
 					fmt.Appendf(nil, "term-%d", i),
-					events.FieldContractID,
+					FieldContractID,
 				)
 				slot, err := m.Lookup(term)
 				require.NoError(t, err)
@@ -295,9 +294,9 @@ func TestWriteIndex_LargeIndex(t *testing.T) {
 
 	// Spot-check a sample of terms.
 	for _, i := range []int{0, 1, 7, n / 2, n - 1} {
-		term := events.ComputeTermKey(
+		term := ComputeTermKey(
 			fmt.Appendf(nil, "term-%d", i),
-			events.FieldContractID,
+			FieldContractID,
 		)
 		slot, err := m.Lookup(term)
 		require.NoError(t, err)
@@ -312,8 +311,8 @@ func TestWriteIndex_RecordEncoding(t *testing.T) {
 	// Future readers (PR-3a) rely on this layout; if it ever changes
 	// silently, this test fails.
 	dir := t.TempDir()
-	idx := events.NewBitmaps()
-	idx.AddTo(events.ComputeTermKey([]byte("only"), events.FieldContractID), 42)
+	idx := NewBitmaps()
+	idx.AddTo(ComputeTermKey([]byte("only"), FieldContractID), 42)
 
 	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, idx, dir))
 
@@ -323,7 +322,7 @@ func TestWriteIndex_RecordEncoding(t *testing.T) {
 	record := records[0]
 	require.Greater(t, len(record), IndexRecordFingerprintLen)
 
-	term := events.ComputeTermKey([]byte("only"), events.FieldContractID)
+	term := ComputeTermKey([]byte("only"), FieldContractID)
 	assert.Equal(t, term[:IndexRecordFingerprintLen], record[:IndexRecordFingerprintLen])
 
 	bm := roaring.New()
@@ -332,7 +331,7 @@ func TestWriteIndex_RecordEncoding(t *testing.T) {
 	assert.True(t, bm.Contains(42))
 
 	// Defensive: the fingerprint occupies bytes 0..3 in little-endian
-	// the way events.TermKey itself encodes — read it back via binary helpers
+	// the way TermKey itself encodes — read it back via binary helpers
 	// just to lock the endianness contract.
 	_ = binary.LittleEndian.Uint32(record[:IndexRecordFingerprintLen])
 }

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_reader.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_reader.go
@@ -3,7 +3,7 @@ package event
 // cold_reader.go is the read side of a frozen Chunk. It opens the
 // three cold artifacts produced by ColdWriter + WriteColdIndex
 // (events.pack, index.pack, index.hash), decodes the embedded
-// events.LedgerOffsets app-data block, and serves the events.Reader
+// LedgerOffsets app-data block, and serves the Reader
 // interface against them.
 //
 // Lifecycle: each ColdReader owns two packfile.Reader instances
@@ -53,13 +53,12 @@ import (
 	"github.com/RoaringBitmap/roaring/v2"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/packfile"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
 
 // ColdReader is the read side of a frozen Chunk. Implements
-// events.Reader.
+// Reader.
 //
 // Open shape: OpenColdReader does no synchronous I/O beyond options
 // validation. packfile.Open starts each file's open + trailer read
@@ -102,7 +101,7 @@ type ColdReader struct {
 // the deferred loader cached behind waitMeta.
 type coldMeta struct {
 	count   uint32
-	offsets *events.LedgerOffsets
+	offsets *LedgerOffsets
 }
 
 // Compile-time guard.
@@ -293,7 +292,7 @@ func (c *ColdReader) EventCount() (uint32, error) {
 // Returns (nil, stores.ErrStoreClosed) after Close. Callers must treat the
 // returned value as read-only — mutations would corrupt every
 // other reader holding the same cached snapshot.
-func (c *ColdReader) Offsets() (*events.LedgerOffsets, error) {
+func (c *ColdReader) Offsets() (*LedgerOffsets, error) {
 	if c.closed.Load() {
 		return nil, stores.ErrStoreClosed
 	}
@@ -311,7 +310,7 @@ func (c *ColdReader) Offsets() (*events.LedgerOffsets, error) {
 // not-found. record is valid only inside ReadItem's callback;
 // UnmarshalBinary copies into roaring's internal state so the
 // returned bitmap outlives the callback safely.
-func verifyAndDeserializeBitmap(record []byte, key events.TermKey, slot uint32) (*roaring.Bitmap, error) {
+func verifyAndDeserializeBitmap(record []byte, key TermKey, slot uint32) (*roaring.Bitmap, error) {
 	if len(record) < IndexRecordFingerprintLen {
 		return nil, fmt.Errorf("events: index.pack record at slot %d truncated (%d bytes)", slot, len(record))
 	}
@@ -346,7 +345,7 @@ func verifyAndDeserializeBitmap(record []byte, key events.TermKey, slot uint32) 
 //     match. Misses (fingerprint mismatch) leave result[i] = nil.
 //
 //nolint:cyclop // the four documented steps above, inline; splitting obscures the pass structure
-func (c *ColdReader) LookupKeys(ctx context.Context, keys []events.TermKey) ([]*roaring.Bitmap, error) {
+func (c *ColdReader) LookupKeys(ctx context.Context, keys []TermKey) ([]*roaring.Bitmap, error) {
 	if c.closed.Load() {
 		return nil, stores.ErrStoreClosed
 	}
@@ -435,7 +434,7 @@ func (c *ColdReader) LookupKeys(ctx context.Context, keys []events.TermKey) ([]*
 // the worker count set via ColdReaderOptions.Concurrency.
 // result[idx] writes from concurrent workers do not race — each
 // idx is unique.
-func (c *ColdReader) FetchEvents(ctx context.Context, eventIDs []uint32) ([]events.Payload, error) {
+func (c *ColdReader) FetchEvents(ctx context.Context, eventIDs []uint32) ([]Payload, error) {
 	if c.closed.Load() {
 		return nil, stores.ErrStoreClosed
 	}
@@ -457,7 +456,7 @@ func (c *ColdReader) FetchEvents(ctx context.Context, eventIDs []uint32) ([]even
 		}
 		positions[i] = int(id)
 	}
-	results := make([]events.Payload, len(eventIDs))
+	results := make([]Payload, len(eventIDs))
 	if err := c.events.ReadItems(ctx, positions, func(idx int, data []byte) error {
 		// packfile.ReadItems passes a borrowed data slice valid only for
 		// the duration of fn (see Reader.ReadItems docstring). FetchEvents
@@ -488,14 +487,14 @@ func (c *ColdReader) FetchEvents(ctx context.Context, eventIDs []uint32) ([]even
 //
 // Yielded Payloads are borrowed: ContractEventBytes aliases the
 // ReadRange buffer and is valid only until the next step — clone to retain.
-func (c *ColdReader) FetchRange(ctx context.Context, start, count uint32) iter.Seq2[events.Payload, error] {
-	return func(yield func(events.Payload, error) bool) {
+func (c *ColdReader) FetchRange(ctx context.Context, start, count uint32) iter.Seq2[Payload, error] {
+	return func(yield func(Payload, error) bool) {
 		if c.closed.Load() {
-			yield(events.Payload{}, stores.ErrStoreClosed)
+			yield(Payload{}, stores.ErrStoreClosed)
 			return
 		}
 		if err := ctx.Err(); err != nil {
-			yield(events.Payload{}, err)
+			yield(Payload{}, err)
 			return
 		}
 		if count == 0 {
@@ -503,31 +502,31 @@ func (c *ColdReader) FetchRange(ctx context.Context, start, count uint32) iter.S
 		}
 		m, err := c.waitMeta()
 		if err != nil {
-			yield(events.Payload{}, err)
+			yield(Payload{}, err)
 			return
 		}
 		if err := validateFetchRange(start, count, m.count, c.chunkID); err != nil {
-			yield(events.Payload{}, err)
+			yield(Payload{}, err)
 			return
 		}
 		// ReadRange yields raw item bytes in position order; we
 		// decode each on the fly.
 		for raw, err := range c.events.ReadRange(int(start), int(count)) {
 			if err != nil {
-				yield(events.Payload{}, fmt.Errorf("events: scan chunk %s: %w", c.chunkID, err))
+				yield(Payload{}, fmt.Errorf("events: scan chunk %s: %w", c.chunkID, err))
 				return
 			}
 			if err := ctx.Err(); err != nil {
-				yield(events.Payload{}, err)
+				yield(Payload{}, err)
 				return
 			}
-			var p events.Payload
+			var p Payload
 			// raw is valid only until the next ReadRange step (see
 			// Reader.ReadRange); Unmarshal aliases it into
 			// ContractEventBytes, so the yielded Payload is borrowed (see
 			// the FetchRange doc). A retaining consumer clones.
 			if err := p.Unmarshal(raw); err != nil {
-				yield(events.Payload{}, fmt.Errorf("events: decode event from chunk %s: %w", c.chunkID, err))
+				yield(Payload{}, fmt.Errorf("events: decode event from chunk %s: %w", c.chunkID, err))
 				return
 			}
 			if !yield(p, nil) {
@@ -543,15 +542,15 @@ func (c *ColdReader) FetchRange(ctx context.Context, start, count uint32) iter.S
 // check short-circuits to stores.ErrStoreClosed without spinning up the cached
 // waitMeta + descending into FetchRange (which would also detect
 // the closed state, just one indirection later).
-func (c *ColdReader) All(ctx context.Context) iter.Seq2[events.Payload, error] {
-	return func(yield func(events.Payload, error) bool) {
+func (c *ColdReader) All(ctx context.Context) iter.Seq2[Payload, error] {
+	return func(yield func(Payload, error) bool) {
 		if c.closed.Load() {
-			yield(events.Payload{}, stores.ErrStoreClosed)
+			yield(Payload{}, stores.ErrStoreClosed)
 			return
 		}
 		m, err := c.waitMeta()
 		if err != nil {
-			yield(events.Payload{}, err)
+			yield(Payload{}, err)
 			return
 		}
 		for p, err := range c.FetchRange(ctx, 0, m.count) {

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_reader_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_reader_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/packfile"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
@@ -20,8 +19,8 @@ import (
 // + index.pack + index.hash) into a fresh directory by:
 //   - writing every payload to events.pack in order,
 //   - feeding the same payload's indexed (contractID + topic0)
-//     fields into a fresh events.Bitmaps (matching what the freezer
-//     would do via events.TermsForBytes + idx.Add),
+//     fields into a fresh Bitmaps (matching what the freezer
+//     would do via TermsForBytes + idx.Add),
 //   - finalizing with WriteColdIndex.
 //
 // Layout:
@@ -38,7 +37,7 @@ import (
 // Returns the directory plus the list of payloads written.
 //
 //nolint:unparam // chunkID kept as a param to mirror production call sites and make per-test override easy
-func buildColdFixture(t *testing.T, chunkID chunk.ID, eventsPerLedger, ledgersPerChunk int) (string, []events.Payload) {
+func buildColdFixture(t *testing.T, chunkID chunk.ID, eventsPerLedger, ledgersPerChunk int) (string, []Payload) {
 	t.Helper()
 	dir := t.TempDir()
 	first := chunkID.FirstLedger()
@@ -47,10 +46,10 @@ func buildColdFixture(t *testing.T, chunkID chunk.ID, eventsPerLedger, ledgersPe
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cw.Close() })
 
-	idx := events.NewBitmaps()
-	offsets := events.NewLedgerOffsets(first)
+	idx := NewBitmaps()
+	offsets := NewLedgerOffsets(first)
 
-	payloads := make([]events.Payload, 0, eventsPerLedger*ledgersPerChunk)
+	payloads := make([]Payload, 0, eventsPerLedger*ledgersPerChunk)
 	eventID := uint32(0)
 	for ledgerOffset := range ledgersPerChunk {
 		ledgerSeq := first + uint32(ledgerOffset)
@@ -64,13 +63,13 @@ func buildColdFixture(t *testing.T, chunkID chunk.ID, eventsPerLedger, ledgersPe
 			require.NoError(t, cw.Append(p))
 
 			// Index the contractID and topic0 fields, matching what
-			// events.TermsForBytes would emit. We keep the (value, field)
-			// pairs in hand so tests can compute the same events.TermKey.
+			// TermsForBytes would emit. We keep the (value, field)
+			// pairs in hand so tests can compute the same TermKey.
 			ev := eventOf(p)
-			idx.AddTo(events.ComputeTermKey(ev.ContractId[:], events.FieldContractID), eventID)
+			idx.AddTo(ComputeTermKey(ev.ContractId[:], FieldContractID), eventID)
 			topicBytes, err := ev.Body.V0.Topics[0].MarshalBinary()
 			require.NoError(t, err)
-			idx.AddTo(events.ComputeTermKey(topicBytes, events.FieldTopic0), eventID)
+			idx.AddTo(ComputeTermKey(topicBytes, FieldTopic0), eventID)
 
 			eventID++
 		}
@@ -82,18 +81,18 @@ func buildColdFixture(t *testing.T, chunkID chunk.ID, eventsPerLedger, ledgersPe
 	return dir, payloads
 }
 
-// contractTermKey computes the events.TermKey ColdReader.LookupKeys expects for
+// contractTermKey computes the TermKey ColdReader.LookupKeys expects for
 // the contractID indexed field of p.
-func contractTermKey(p events.Payload) events.TermKey {
-	return events.ComputeTermKey(eventOf(p).ContractId[:], events.FieldContractID)
+func contractTermKey(p Payload) TermKey {
+	return ComputeTermKey(eventOf(p).ContractId[:], FieldContractID)
 }
 
-// topic0TermKey computes the events.TermKey for topic0 of p.
-func topic0TermKey(t *testing.T, p events.Payload) events.TermKey {
+// topic0TermKey computes the TermKey for topic0 of p.
+func topic0TermKey(t *testing.T, p Payload) TermKey {
 	t.Helper()
 	bytes, err := eventOf(p).Body.V0.Topics[0].MarshalBinary()
 	require.NoError(t, err)
-	return events.ComputeTermKey(bytes, events.FieldTopic0)
+	return ComputeTermKey(bytes, FieldTopic0)
 }
 
 func TestColdReader_OpenRoundTrip(t *testing.T) {
@@ -151,9 +150,9 @@ func TestColdReader_LookupUnseenTermReturnsNil(t *testing.T) {
 	// surface a clean miss: a nil bitmap and no error. We don't care
 	// which path each key takes — only that every outcome is nil.
 	for i := range 100 {
-		key := events.ComputeTermKey(
+		key := ComputeTermKey(
 			fmt.Appendf(nil, "never-added-%d", i),
-			events.FieldTopic1,
+			FieldTopic1,
 		)
 		assert.Nil(t, lookupOne(t, cr, key), "unseen key %d returned a bitmap", i)
 	}
@@ -276,8 +275,8 @@ func TestColdReader_EventlessChunk(t *testing.T) {
 
 	// Term-filtered paths miss cleanly (nil bitmap, no error) instead
 	// of surfacing a filesystem error.
-	someTerm := events.ComputeTermKey([]byte("any"), events.FieldContractID)
-	bms, err := cr.LookupKeys(context.Background(), []events.TermKey{someTerm})
+	someTerm := ComputeTermKey([]byte("any"), FieldContractID)
+	bms, err := cr.LookupKeys(context.Background(), []TermKey{someTerm})
 	require.NoError(t, err)
 	require.Len(t, bms, 1)
 	assert.Nil(t, bms[0])
@@ -316,7 +315,7 @@ func TestColdReader_EmptyIndexOverNonEmptyPackErrors(t *testing.T) {
 	t.Cleanup(func() { _ = cr.Close() })
 
 	// The mismatch must surface as an error, not a clean miss (nil, no error).
-	_, lerr := cr.LookupKeys(context.Background(), []events.TermKey{contractTermKey(payloads[0])})
+	_, lerr := cr.LookupKeys(context.Background(), []TermKey{contractTermKey(payloads[0])})
 	require.Error(t, lerr, "a mispaired empty index must error, not miss silently (nil bitmap)")
 	assert.Contains(t, lerr.Error(), "holds zero terms")
 }
@@ -352,7 +351,7 @@ func TestColdReader_OpenMissingIndexHash(t *testing.T) {
 	t.Cleanup(func() { _ = cr.Close() })
 
 	// First LookupKeys awaits the background MPHF load → missing-file error.
-	_, err = cr.LookupKeys(context.Background(), []events.TermKey{{}})
+	_, err = cr.LookupKeys(context.Background(), []TermKey{{}})
 	assert.Error(t, err, "missing index.hash must surface from the first LookupKeys")
 }
 
@@ -372,7 +371,7 @@ func TestColdReader_PostCloseMethodsError(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, cr.Close())
 
-	_, err = cr.LookupKeys(context.Background(), []events.TermKey{contractTermKey(payloads[0])})
+	_, err = cr.LookupKeys(context.Background(), []TermKey{contractTermKey(payloads[0])})
 	require.ErrorIs(t, err, stores.ErrStoreClosed)
 
 	_, err = cr.FetchEvents(context.Background(), []uint32{0})
@@ -546,9 +545,9 @@ func TestColdReader_LookupKeys(t *testing.T) {
 
 	contractKey := contractTermKey(payloads[0])
 	topicKey := topic0TermKey(t, payloads[0])
-	missing := events.ComputeTermKey([]byte("never-added"), events.FieldTopic1)
+	missing := ComputeTermKey([]byte("never-added"), FieldTopic1)
 
-	keys := []events.TermKey{contractKey, missing, topicKey, missing}
+	keys := []TermKey{contractKey, missing, topicKey, missing}
 	bms, err := cr.LookupKeys(context.Background(), keys)
 	require.NoError(t, err)
 	require.Len(t, bms, len(keys))
@@ -577,13 +576,13 @@ func TestColdReader_LookupKeysClonesAcrossCalls(t *testing.T) {
 	t.Cleanup(func() { _ = cr.Close() })
 
 	key := contractTermKey(payloads[0])
-	first, err := cr.LookupKeys(context.Background(), []events.TermKey{key})
+	first, err := cr.LookupKeys(context.Background(), []TermKey{key})
 	require.NoError(t, err)
 	require.Len(t, first, 1)
 	require.NotNil(t, first[0])
 	first[0].Add(999_999)
 
-	second, err := cr.LookupKeys(context.Background(), []events.TermKey{key})
+	second, err := cr.LookupKeys(context.Background(), []TermKey{key})
 	require.NoError(t, err)
 	require.Len(t, second, 1)
 	require.NotNil(t, second[0])
@@ -719,7 +718,7 @@ func TestColdReader_RejectsWrongFormatIndexPack(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cr.Close() })
 
-	_, err = cr.LookupKeys(context.Background(), []events.TermKey{contractTermKey(payloads[0])})
+	_, err = cr.LookupKeys(context.Background(), []TermKey{contractTermKey(payloads[0])})
 	require.ErrorContains(t, err, "expected format")
 }
 
@@ -740,7 +739,7 @@ func TestColdReader_RejectsMispairedOffsets(t *testing.T) {
 	}
 	// Offsets sum to 2 events; the pack holds 3. ColdWriter.Finish takes
 	// the caller's offsets on trust — the reader-side check is the guard.
-	offsets := events.NewLedgerOffsets(first)
+	offsets := NewLedgerOffsets(first)
 	require.NoError(t, offsets.Append(first, 2))
 	require.NoError(t, cw.Finish(offsets))
 
@@ -767,7 +766,7 @@ func TestColdReader_RejectsMispairedIndexHash(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cr.Close() })
 
-	_, err = cr.LookupKeys(context.Background(), []events.TermKey{contractTermKey(payloadsA[0])})
+	_, err = cr.LookupKeys(context.Background(), []TermKey{contractTermKey(payloadsA[0])})
 	require.ErrorContains(t, err, "index pair mismatch")
 }
 
@@ -786,6 +785,6 @@ func TestColdReader_RejectsNonEmptyIndexOnEventlessChunk(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cr.Close() })
 
-	_, err = cr.LookupKeys(context.Background(), []events.TermKey{contractTermKey(payloads[0])})
+	_, err = cr.LookupKeys(context.Background(), []TermKey{contractTermKey(payloads[0])})
 	require.ErrorContains(t, err, "eventless")
 }

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_writer.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_writer.go
@@ -1,12 +1,12 @@
 package event
 
 // cold_writer.go is the events.pack writer half of the cold-Chunk
-// pipeline. ColdWriter streams a Chunk's events.Payload sequence
+// pipeline. ColdWriter streams a Chunk's Payload sequence
 // into events.pack and embeds the ledger offset array as packfile
 // app data.
 //
 // The index.pack + index.hash half lives in cold_index.go. Shared
-// format constants, the events.LedgerOffsets app-data wire format,
+// format constants, the LedgerOffsets app-data wire format,
 // and the MPHF wrapper live in cold_format.go.
 //
 // ColdWriter is intentionally thin: it owns no closed-state of its
@@ -19,21 +19,20 @@ import (
 	"path/filepath"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/packfile"
 )
 
 // ──────────────────────────────────────────────────────────────────
-// ColdWriter — streams a Chunk's events.Payload sequence into events.pack.
+// ColdWriter — streams a Chunk's Payload sequence into events.pack.
 // ──────────────────────────────────────────────────────────────────
 
-// ColdWriter streams a Chunk's events.Payload sequence into events.pack.
-// events.Payload bytes pass through unchanged — the same canonical wire
+// ColdWriter streams a Chunk's Payload sequence into events.pack.
+// Payload bytes pass through unchanged — the same canonical wire
 // format HotStore stores in events_data. The ledger offset array is
 // serialized as packfile app data so the cold reader can resolve
 // ledger→eventID ranges without a second file.
 //
-// ColdWriter.Finish takes the events.LedgerOffsets externally rather than
+// ColdWriter.Finish takes the LedgerOffsets externally rather than
 // inferring boundaries from the payload stream. This honestly
 // represents the contract: the caller knows ledger boundaries
 // (including any empty ledgers that produce no Append calls) and
@@ -41,7 +40,7 @@ import (
 //
 //   - Freeze: hot.Offsets() already has entries for every ledger
 //     in the Chunk, including empty ones. Hand it to Finish.
-//   - Backfill: maintains a *events.LedgerOffsets incrementally as it
+//   - Backfill: maintains a *LedgerOffsets incrementally as it
 //     processes LCMs. Hand it to Finish.
 //
 // ColdWriter doesn't produce the index files (index.pack +
@@ -112,7 +111,7 @@ func NewColdWriter(chunkID chunk.ID, bucketDir string, opts ColdWriterOptions) (
 // the cold reader reads them back the same way.
 //
 // Returns packfile.ErrWriterClosed if called after Finish or Close.
-func (w *ColdWriter) Append(p events.Payload) error {
+func (w *ColdWriter) Append(p Payload) error {
 	// Marshal into a reusable scratch buffer. AppendItem copies the bytes
 	// into the packfile's record buffer synchronously, so the scratch is
 	// free to reuse on the next Append — no per-event allocation.
@@ -130,7 +129,7 @@ func (w *ColdWriter) Append(p events.Payload) error {
 //
 // Finish must not be called more than once. A second call (or a
 // call after Close) returns packfile.ErrWriterClosed.
-func (w *ColdWriter) Finish(offsets *events.LedgerOffsets) error {
+func (w *ColdWriter) Finish(offsets *LedgerOffsets) error {
 	appData, err := encodeLedgerOffsets(offsets)
 	if err != nil {
 		return fmt.Errorf("events: encode offsets: %w", err)

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_writer_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/cold_writer_test.go
@@ -13,16 +13,15 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/packfile"
 )
 
-// makeColdPayload builds a deterministic events.Payload carrying a single-
+// makeColdPayload builds a deterministic Payload carrying a single-
 // topic ContractEvent so writer round-trips can be inspected against
 // the original by symbol + ledger sequence.
 //
 //nolint:unparam // txIdx kept as a param so future tests can vary it without resurrecting the signature
-func makeColdPayload(ledgerSeq, txIdx uint32, symbol string) events.Payload {
+func makeColdPayload(ledgerSeq, txIdx uint32, symbol string) Payload {
 	var cid xdr.ContractId
 	cid[0] = 0xc0
 	cid[1] = 0x1d
@@ -42,7 +41,7 @@ func makeColdPayload(ledgerSeq, txIdx uint32, symbol string) events.Payload {
 	if err != nil {
 		panic(err) // hardcoded fixture; marshal can't fail
 	}
-	return events.Payload{
+	return Payload{
 		TxHash:             xdr.Hash{0xab},
 		LedgerSequence:     ledgerSeq,
 		TxIdx:              txIdx,
@@ -61,7 +60,7 @@ func TestWriter_AppendThenFinishProducesReadablePackfile(t *testing.T) {
 
 	// Stream 3 payloads across 2 ledgers. Empty third ledger has no
 	// Append call but appears in the offsets cache.
-	payloads := []events.Payload{
+	payloads := []Payload{
 		makeColdPayload(2, 1, "alpha"),
 		makeColdPayload(2, 1, "beta"),
 		makeColdPayload(3, 1, "gamma"),
@@ -70,7 +69,7 @@ func TestWriter_AppendThenFinishProducesReadablePackfile(t *testing.T) {
 		require.NoError(t, w.Append(p))
 	}
 
-	offsets := events.NewLedgerOffsets(chunkID.FirstLedger())
+	offsets := NewLedgerOffsets(chunkID.FirstLedger())
 	require.NoError(t, offsets.Append(2, 2))
 	require.NoError(t, offsets.Append(3, 1))
 	require.NoError(t, offsets.Append(4, 0)) // empty ledger
@@ -85,10 +84,10 @@ func TestWriter_AppendThenFinishProducesReadablePackfile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3, total)
 
-	got := make([]events.Payload, 0, 3)
+	got := make([]Payload, 0, 3)
 	for data, err := range reader.ReadRange(0, total) {
 		require.NoError(t, err)
-		var p events.Payload
+		var p Payload
 		require.NoError(t, p.Unmarshal(data))
 		got = append(got, p)
 	}
@@ -98,7 +97,7 @@ func TestWriter_AppendThenFinishProducesReadablePackfile(t *testing.T) {
 		assert.Equal(t, payloads[i].ContractEventBytes, p.ContractEventBytes, "item %d event bytes", i)
 	}
 
-	// AppData round-trips the events.LedgerOffsets.
+	// AppData round-trips the LedgerOffsets.
 	appData, err := reader.AppData()
 	require.NoError(t, err)
 	decoded, err := DecodeLedgerOffsets(appData)
@@ -123,7 +122,7 @@ func TestWriter_EmptyChunkStillFinalizes(t *testing.T) {
 	w, err := NewColdWriter(chunkID, dir, ColdWriterOptions{})
 	require.NoError(t, err)
 
-	offsets := events.NewLedgerOffsets(chunkID.FirstLedger())
+	offsets := NewLedgerOffsets(chunkID.FirstLedger())
 	require.NoError(t, w.Finish(offsets))
 
 	reader := packfile.Open(
@@ -147,7 +146,7 @@ func TestWriter_AppendAfterFinishErrors(t *testing.T) {
 	w, err := NewColdWriter(chunkID, t.TempDir(), ColdWriterOptions{})
 	require.NoError(t, err)
 
-	offsets := events.NewLedgerOffsets(chunkID.FirstLedger())
+	offsets := NewLedgerOffsets(chunkID.FirstLedger())
 	require.NoError(t, w.Finish(offsets))
 
 	err = w.Append(makeColdPayload(2, 1, "x"))
@@ -213,7 +212,7 @@ func TestWriter_PreservesEventIDOrder(t *testing.T) {
 			fmt.Sprintf("event-%d", i),
 		)))
 	}
-	offsets := events.NewLedgerOffsets(chunkID.FirstLedger())
+	offsets := NewLedgerOffsets(chunkID.FirstLedger())
 	require.NoError(t, offsets.Append(chunkID.FirstLedger(), uint32(n)))
 	require.NoError(t, w.Finish(offsets))
 
@@ -225,7 +224,7 @@ func TestWriter_PreservesEventIDOrder(t *testing.T) {
 
 	var idx int
 	err = reader.ReadItems(context.Background(), rangeIDs(0, n), func(_ int, data []byte) error {
-		var p events.Payload
+		var p Payload
 		if err := p.Unmarshal(data); err != nil {
 			return err
 		}
@@ -263,7 +262,7 @@ func TestEventsPack_TrailerPinsFormatAndRecordSize(t *testing.T) {
 	w, err := NewColdWriter(chunkID, dir, ColdWriterOptions{})
 	require.NoError(t, err)
 	require.NoError(t, w.Append(makeColdPayload(chunkID.FirstLedger(), 1, "x")))
-	offsets := events.NewLedgerOffsets(chunkID.FirstLedger())
+	offsets := NewLedgerOffsets(chunkID.FirstLedger())
 	require.NoError(t, offsets.Append(chunkID.FirstLedger(), 1))
 	require.NoError(t, w.Finish(offsets))
 

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/concurrent_bitmaps.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/concurrent_bitmaps.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"sync"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/concurrent_bitmaps_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/concurrent_bitmaps_test.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"sync"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/concurrent_ledgeroffsets.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/concurrent_ledgeroffsets.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"sync/atomic"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/extract.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/extract.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"fmt"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/extract_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/extract_test.go
@@ -1,4 +1,4 @@
-package events_test
+package event_test
 
 import (
 	"fmt"
@@ -19,17 +19,17 @@ import (
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/host"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv1/sqlitedb"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
 )
 
 const testPassphrase = "Test SDF Network ; September 2015"
 
 // lcmViewToPayloads is the view→payloads convenience the cursor-contract tests
 // need to run from raw LCM bytes: the header reads plus the single
-// ExtractLedgerTxParts walk, fed to PayloadsFromLedgerEvents. Test-only —
+// ExtractLedgerTxParts walk, fed to event.PayloadsFromLedgerEvents. Test-only —
 // production walks once at a higher level (hot HotService.Ingest, cold
-// coldChunk.ingest) and calls PayloadsFromLedgerEvents directly.
-func lcmViewToPayloads(lcmView xdr.LedgerCloseMetaView) ([]events.Payload, error) {
+// coldChunk.ingest) and calls event.PayloadsFromLedgerEvents directly.
+func lcmViewToPayloads(lcmView xdr.LedgerCloseMetaView) ([]event.Payload, error) {
 	seq, err := lcmView.LedgerSequence()
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func lcmViewToPayloads(lcmView xdr.LedgerCloseMetaView) ([]events.Payload, error
 	if err != nil {
 		return nil, err
 	}
-	return events.PayloadsFromLedgerEvents(txParts, seq, closedAt)
+	return event.PayloadsFromLedgerEvents(txParts, seq, closedAt)
 }
 
 // buildContractEvent returns a ContractEvent with a contractID and a

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_store.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/linxGnu/grocksdb"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rocksdb"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
@@ -102,8 +101,8 @@ var ErrLedgerOutOfOrder = errors.New("events: ledger out of order")
 type HotStore struct {
 	chunkStore *rocksdb.Store
 	chunkID    chunk.ID
-	mirror     *events.ConcurrentBitmaps
-	offsets    *events.ConcurrentLedgerOffsets
+	mirror     *ConcurrentBitmaps
+	offsets    *ConcurrentLedgerOffsets
 }
 
 // Compile-time guard: *HotStore satisfies Reader.
@@ -162,7 +161,7 @@ func (h *HotStore) EventCount() (uint32, error) {
 // silently fork it from the live data; the contract is read-only.
 //
 // Returns (nil, stores.ErrStoreClosed) after the caller-owned store is closed.
-func (h *HotStore) Offsets() (*events.LedgerOffsets, error) {
+func (h *HotStore) Offsets() (*LedgerOffsets, error) {
 	if h.chunkStore.IsClosed() {
 		return nil, stores.ErrStoreClosed
 	}
@@ -178,7 +177,7 @@ func (h *HotStore) Offsets() (*events.LedgerOffsets, error) {
 // to batch — but exposing this method satisfies the Reader
 // interface so callers can program against batched lookups
 // uniformly.
-func (h *HotStore) LookupKeys(ctx context.Context, keys []events.TermKey) ([]*roaring.Bitmap, error) {
+func (h *HotStore) LookupKeys(ctx context.Context, keys []TermKey) ([]*roaring.Bitmap, error) {
 	if h.chunkStore.IsClosed() {
 		return nil, stores.ErrStoreClosed
 	}
@@ -219,7 +218,7 @@ func (h *HotStore) LookupKeys(ctx context.Context, keys []events.TermKey) ([]*ro
 // not a normal not-found case.
 //
 // After the caller-owned store is closed, returns stores.ErrStoreClosed.
-func (h *HotStore) FetchEvents(ctx context.Context, eventIDs []uint32) ([]events.Payload, error) {
+func (h *HotStore) FetchEvents(ctx context.Context, eventIDs []uint32) ([]Payload, error) {
 	if h.chunkStore.IsClosed() {
 		return nil, stores.ErrStoreClosed
 	}
@@ -249,7 +248,7 @@ func (h *HotStore) FetchEvents(ctx context.Context, eventIDs []uint32) ([]events
 			len(values), len(eventIDs), h.chunkID)
 	}
 
-	results := make([]events.Payload, len(eventIDs))
+	results := make([]Payload, len(eventIDs))
 	for i, id := range eventIDs {
 		v := values[i]
 		if v == nil {
@@ -287,21 +286,21 @@ func (h *HotStore) FetchEvents(ctx context.Context, eventIDs []uint32) ([]events
 //   - A short scan (fewer DataCF rows than count) yields a wrapped
 //     error after the partial stream — the CF should be dense in
 //     [0, committed count), so a hole indicates corruption.
-func (h *HotStore) FetchRange(ctx context.Context, start, count uint32) iter.Seq2[events.Payload, error] {
-	return func(yield func(events.Payload, error) bool) {
+func (h *HotStore) FetchRange(ctx context.Context, start, count uint32) iter.Seq2[Payload, error] {
+	return func(yield func(Payload, error) bool) {
 		if h.chunkStore.IsClosed() {
-			yield(events.Payload{}, stores.ErrStoreClosed)
+			yield(Payload{}, stores.ErrStoreClosed)
 			return
 		}
 		if err := ctx.Err(); err != nil {
-			yield(events.Payload{}, err)
+			yield(Payload{}, err)
 			return
 		}
 		if count == 0 {
 			return
 		}
 		if err := validateFetchRange(start, count, h.offsets.TotalEvents(), h.chunkID); err != nil {
-			yield(events.Payload{}, err)
+			yield(Payload{}, err)
 			return
 		}
 
@@ -310,20 +309,20 @@ func (h *HotStore) FetchRange(ctx context.Context, start, count uint32) iter.Seq
 		yielded := uint32(0)
 		for entry, err := range h.chunkStore.IterateRange(DataCF, startKey, endKey) {
 			if err != nil {
-				yield(events.Payload{}, fmt.Errorf("events: scan chunk %s: %w", h.chunkID, err))
+				yield(Payload{}, fmt.Errorf("events: scan chunk %s: %w", h.chunkID, err))
 				return
 			}
 			if err := ctx.Err(); err != nil {
-				yield(events.Payload{}, err)
+				yield(Payload{}, err)
 				return
 			}
-			var p events.Payload
+			var p Payload
 			// entry.Value is a zero-copy ref into the IterateRange
 			// iterator buffer, valid only for this step; Unmarshal aliases
 			// it into p.ContractEventBytes, so the yielded Payload is
 			// borrowed (see the FetchRange doc). A retaining consumer clones.
 			if err := p.Unmarshal(entry.Value); err != nil {
-				yield(events.Payload{}, fmt.Errorf("events: decode event from chunk %s: %w",
+				yield(Payload{}, fmt.Errorf("events: decode event from chunk %s: %w",
 					h.chunkID, err))
 				return
 			}
@@ -333,7 +332,7 @@ func (h *HotStore) FetchRange(ctx context.Context, start, count uint32) iter.Seq
 			yielded++
 		}
 		if yielded != count {
-			yield(events.Payload{}, fmt.Errorf(
+			yield(Payload{}, fmt.Errorf(
 				"events: FetchRange short scan for chunk %s: got %d of %d events at [%d, %d)",
 				h.chunkID, yielded, count, start, start+count))
 		}
@@ -353,8 +352,8 @@ func (h *HotStore) FetchRange(ctx context.Context, start, count uint32) iter.Seq
 // consumer's first range step is included in the snapshot.
 //
 // After the caller-owned store is closed, yields (zero Payload, stores.ErrStoreClosed) and stops.
-func (h *HotStore) All(ctx context.Context) iter.Seq2[events.Payload, error] {
-	return func(yield func(events.Payload, error) bool) {
+func (h *HotStore) All(ctx context.Context) iter.Seq2[Payload, error] {
+	return func(yield func(Payload, error) bool) {
 		// FetchRange stops iterating after yielding an error; we
 		// just forward whatever it yields and exit on the same step.
 		for p, err := range h.FetchRange(ctx, 0, h.offsets.TotalEvents()) {
@@ -371,10 +370,10 @@ func (h *HotStore) All(ctx context.Context) iter.Seq2[events.Payload, error] {
 // before any Put; on any error Store.Batch discards the whole WriteBatch, so a
 // rejected ledger never leaves committed rows behind.
 //
-// payloads is produced by events.PayloadsFromLedgerEvents, which emits each ledger's
+// payloads is produced by PayloadsFromLedgerEvents, which emits each ledger's
 // events in ascending getEvents cursor order — write order here IS the cursor
 // contract (event IDs are assigned by arrival position). Terms are derived via
-// events.TermsForBytes on each payload's ContractEventBytes.
+// TermsForBytes on each payload's ContractEventBytes.
 //
 // Sequence validation, before any Put or mirror mutation:
 //
@@ -391,7 +390,7 @@ func (h *HotStore) All(ctx context.Context) iter.Seq2[events.Payload, error] {
 // on-disk state ahead of in-memory state with no clean recovery short of
 // close + reopen.
 func (h *HotStore) IngestLedgerToBatch(
-	b *rocksdb.BatchWriter, ledgerSeq uint32, payloads []events.Payload,
+	b *rocksdb.BatchWriter, ledgerSeq uint32, payloads []Payload,
 ) (func(), error) {
 	// Validate BEFORE any Put. On error Store.Batch discards the whole WriteBatch,
 	// so a mid-loop failure never orphans rows — no separate staging buffer needed.
@@ -408,9 +407,9 @@ func (h *HotStore) IngestLedgerToBatch(
 
 	// Derive term keys per payload up front (a TermsForBytes error rejects the
 	// ledger without any Put) and retain them for the post-commit mirror update.
-	termKeys := make([][]events.TermKey, len(payloads))
+	termKeys := make([][]TermKey, len(payloads))
 	for i := range payloads {
-		keys, err := events.TermsForBytes(payloads[i].ContractEventBytes)
+		keys, err := TermsForBytes(payloads[i].ContractEventBytes)
 		if err != nil {
 			return nil, fmt.Errorf("derive terms for payload %d in ledger %d: %w", i, ledgerSeq, err)
 		}
@@ -448,7 +447,7 @@ func (h *HotStore) IngestLedgerToBatch(
 // index returns the in-memory term mirror. Test-only write hook: no production
 // path reads it. Kept unexported until #772 decides whether the v2 read path
 // hooks into it.
-func (h *HotStore) index() *events.ConcurrentBitmaps { return h.mirror }
+func (h *HotStore) index() *ConcurrentBitmaps { return h.mirror }
 
 // applyLedger updates the mirror + offsets for a ledger whose rows are durable.
 // Infallible by construction (IngestLedgerToBatch validated seq under the
@@ -459,11 +458,11 @@ func (h *HotStore) index() *events.ConcurrentBitmaps { return h.mirror }
 // offsets then reads the mirror must see either the prior state or a consistent
 // later one. Reversing it would let a reader see an offsets count including IDs
 // the mirror hasn't published — FetchEvents would then miss them, silently.
-func (h *HotStore) applyLedger(startID uint32, termKeys [][]events.TermKey) {
+func (h *HotStore) applyLedger(startID uint32, termKeys [][]TermKey) {
 	// Batch by key so each AddTo clones at most once per (key, ledger), not per
 	// (key, event) — turns N COW clones into 1 for popular terms. Cap 64 ≈ a few
 	// × unique-terms per ledger; the map grows past that.
-	perKeyIDs := make(map[events.TermKey][]uint32, 64)
+	perKeyIDs := make(map[TermKey][]uint32, 64)
 	for i, keys := range termKeys {
 		eventID := startID + uint32(i)
 		for _, key := range keys {
@@ -485,19 +484,19 @@ func (h *HotStore) applyLedger(startID uint32, termKeys [][]events.TermKey) {
 // warmup rebuilds the in-memory mirrors for chunkID by prefix-scanning
 // the chunk's two on-disk caches once each:
 //
-//   - events_index  → *events.ConcurrentBitmaps — every
-//     (events.TermKey, eventID) row replayed into a fresh in-memory
+//   - events_index  → *ConcurrentBitmaps — every
+//     (TermKey, eventID) row replayed into a fresh in-memory
 //     bitmap mirror.
-//   - events_offsets → *events.ConcurrentLedgerOffsets — every
+//   - events_offsets → *ConcurrentLedgerOffsets — every
 //     (ledger_seq, per_ledger_count) row replayed into a fresh
 //     offset cache.
 //
-// chunkID seeds events.ConcurrentLedgerOffsets.StartLedger for empty
+// chunkID seeds ConcurrentLedgerOffsets.StartLedger for empty
 // chunks; on-disk rows carry the full ledger sequence themselves.
 // Both mirrors are empty for fresh chunks.
 func warmup(
 	chunkStore *rocksdb.Store, chunkID chunk.ID,
-) (*events.ConcurrentBitmaps, *events.ConcurrentLedgerOffsets, error) {
+) (*ConcurrentBitmaps, *ConcurrentLedgerOffsets, error) {
 	mirror, indexUpperBound, err := warmupIndex(chunkStore)
 	if err != nil {
 		return nil, nil, err
@@ -561,10 +560,10 @@ func verifyChunkConsistency(chunkStore *rocksdb.Store, total uint32, indexUpperB
 }
 
 // warmupIndex scans the events_index CF and replays every
-// (events.TermKey, eventID) row into a fresh events.ConcurrentBitmaps.
+// (TermKey, eventID) row into a fresh ConcurrentBitmaps.
 // Design doc §12 step 3.
 //
-// Implementation: build into a single-threaded events.Bitmaps via
+// Implementation: build into a single-threaded Bitmaps via
 // per-term batching (rocksdb's byte-sorted iteration delivers all
 // rows for term K consecutively, so a small buffer flushes when the
 // term changes), then convert to ConcurrentBitmaps at the end. This
@@ -577,11 +576,11 @@ func verifyChunkConsistency(chunkStore *rocksdb.Store, total uint32, indexUpperB
 // or 0 if the index is empty; uint64 so max+1 can't wrap — see
 // verifyChunkConsistency) for warmup's cross-check against the
 // committed event count.
-func warmupIndex(chunkStore *rocksdb.Store) (*events.ConcurrentBitmaps, uint64, error) {
-	builder := events.NewBitmaps()
+func warmupIndex(chunkStore *rocksdb.Store) (*ConcurrentBitmaps, uint64, error) {
+	builder := NewBitmaps()
 	var (
 		hasPrev         bool
-		prevTerm        events.TermKey
+		prevTerm        TermKey
 		buf             []uint32
 		indexUpperBound uint64 // max indexed event ID + 1; 0 if no rows
 	)
@@ -601,7 +600,7 @@ func warmupIndex(chunkStore *rocksdb.Store) (*events.ConcurrentBitmaps, uint64, 
 			return nil, 0, fmt.Errorf("events: warmup unexpected %s key length %d (want %d)",
 				IndexCF, len(entry.Key), indexKeyLen)
 		}
-		var term events.TermKey
+		var term TermKey
 		copy(term[:], entry.Key[0:16])
 		eventID := binary.BigEndian.Uint32(entry.Key[16:20])
 		if uint64(eventID)+1 > indexUpperBound {
@@ -616,11 +615,11 @@ func warmupIndex(chunkStore *rocksdb.Store) (*events.ConcurrentBitmaps, uint64, 
 	}
 	flush()
 
-	return events.NewConcurrentBitmapsFromBitmaps(builder), indexUpperBound, nil
+	return NewConcurrentBitmapsFromBitmaps(builder), indexUpperBound, nil
 }
 
 // warmupOffsets scans events_offsets and replays every (ledger_seq,
-// event_count) row into a fresh *events.ConcurrentLedgerOffsets. The
+// event_count) row into a fresh *ConcurrentLedgerOffsets. The
 // on-disk shape matches the in-memory Append input directly
 // (per-ledger counts, not cumulative), so no delta arithmetic is
 // needed.
@@ -631,8 +630,8 @@ func warmupIndex(chunkStore *rocksdb.Store) (*events.ConcurrentBitmaps, uint64, 
 // positional Append — a gap or stray row is rejected here rather than
 // silently mis-attributing counts (ConcurrentLedgerOffsets.Append no
 // longer checks the sequence; the trust boundary is here).
-func warmupOffsets(chunkStore *rocksdb.Store, chunkID chunk.ID) (*events.ConcurrentLedgerOffsets, error) {
-	offsets := events.NewConcurrentLedgerOffsets(chunkID.FirstLedger())
+func warmupOffsets(chunkStore *rocksdb.Store, chunkID chunk.ID) (*ConcurrentLedgerOffsets, error) {
+	offsets := NewConcurrentLedgerOffsets(chunkID.FirstLedger())
 
 	for entry, err := range chunkStore.Iterate(OffsetsCF, nil) {
 		if err != nil {
@@ -677,7 +676,7 @@ func encodeDataKey(eventID uint32) []byte {
 	return key[:]
 }
 
-func encodeIndexKey(term events.TermKey, eventID uint32) []byte {
+func encodeIndexKey(term TermKey, eventID uint32) []byte {
 	var key [indexKeyLen]byte
 	copy(key[:16], term[:])
 	binary.BigEndian.PutUint32(key[16:], eventID)

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_store_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_store_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rocksdb"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 )
@@ -87,7 +86,7 @@ func openRawHotChunkForTest(t *testing.T, dir string, chunkID chunk.ID) *rocksdb
 	return raw
 }
 
-func makePayload(symbol string) (events.Payload, []events.TermKey) {
+func makePayload(symbol string) (Payload, []TermKey) {
 	var cid xdr.ContractId
 	cid[0] = 0xab
 	sym := xdr.ScSymbol(symbol)
@@ -106,11 +105,11 @@ func makePayload(symbol string) (events.Payload, []events.TermKey) {
 	if err != nil {
 		panic(err) // hardcoded test fixture; an error here is a test bug
 	}
-	keys, err := events.TermsForBytes(evBytes)
+	keys, err := TermsForBytes(evBytes)
 	if err != nil {
 		panic(err)
 	}
-	p := events.Payload{
+	p := Payload{
 		TxHash:             xdr.Hash{0xde, 0xad},
 		TxIdx:              1,
 		ContractEventBytes: evBytes,
@@ -121,7 +120,7 @@ func makePayload(symbol string) (events.Payload, []events.TermKey) {
 // eventOf decodes a Payload's ContractEventBytes back into the struct for
 // fixtures and assertions. Payloads carry only the raw XDR; a decode
 // failure means a corrupt fixture, so it panics.
-func eventOf(p events.Payload) xdr.ContractEvent {
+func eventOf(p Payload) xdr.ContractEvent {
 	var ev xdr.ContractEvent
 	if err := ev.UnmarshalBinary(p.ContractEventBytes); err != nil {
 		panic(err)
@@ -132,7 +131,7 @@ func eventOf(p events.Payload) xdr.ContractEvent {
 // dataSym returns a Payload's ScVal Data symbol. The event store read path
 // yields Payloads carrying only raw event XDR (ContractEventBytes), so
 // assertions decode it back to a ContractEvent first.
-func dataSym(t *testing.T, p events.Payload) string {
+func dataSym(t *testing.T, p Payload) string {
 	t.Helper()
 	return string(*eventOf(p).Body.V0.Data.Sym)
 }
@@ -151,13 +150,13 @@ func TestHotStore_IngestLedgerWritesAllCFs(t *testing.T) {
 	h := openHotStoreForTest(t, chunkID)
 
 	p, keys := makePayload("transfer")
-	require.NoError(t, ingestLedgerEvents(h.store, 2, []events.Payload{p}))
+	require.NoError(t, ingestLedgerEvents(h.store, 2, []Payload{p}))
 
 	// events_data row exists.
 	got, found, err := h.store.chunkStore.Get(DataCF, encodeDataKey(0))
 	require.NoError(t, err)
 	require.True(t, found)
-	var decoded events.Payload
+	var decoded Payload
 	require.NoError(t, decoded.Unmarshal(got))
 	assert.Equal(t, p.TxHash, decoded.TxHash)
 
@@ -189,10 +188,10 @@ func TestHotStore_EventIDsAreMonotonic(t *testing.T) {
 
 	p1, _ := makePayload("a")
 	p2, _ := makePayload("b")
-	require.NoError(t, ingestLedgerEvents(h.store, first, []events.Payload{p1, p2}))
+	require.NoError(t, ingestLedgerEvents(h.store, first, []Payload{p1, p2}))
 
 	p3, _ := makePayload("c")
-	require.NoError(t, ingestLedgerEvents(h.store, first+1, []events.Payload{p3}))
+	require.NoError(t, ingestLedgerEvents(h.store, first+1, []Payload{p3}))
 
 	for id := range uint32(3) {
 		_, found, err := h.store.chunkStore.Get(DataCF, encodeDataKey(id))
@@ -229,7 +228,7 @@ func TestHotStore_LookupReturnsImmutableSnapshot(t *testing.T) {
 	// Promote to dense mode so we exercise the bm.Load path (sparse
 	// mode allocates a fresh bitmap per Get).
 	for i := range uint32(70) {
-		require.NoError(t, ingestLedgerEvents(h.store, 2+i, []events.Payload{p}))
+		require.NoError(t, ingestLedgerEvents(h.store, 2+i, []Payload{p}))
 	}
 
 	first := lookupOne(t, h.store, keys[0])
@@ -237,7 +236,7 @@ func TestHotStore_LookupReturnsImmutableSnapshot(t *testing.T) {
 
 	// New ingest publishes a new snapshot. The old pointer must
 	// remain unchanged (it's the previous snapshot).
-	require.NoError(t, ingestLedgerEvents(h.store, 72, []events.Payload{p}))
+	require.NoError(t, ingestLedgerEvents(h.store, 72, []Payload{p}))
 
 	assert.Equal(t, cardBefore, first.GetCardinality(),
 		"prior LookupKeys result must be an immutable snapshot — later IngestLedgerEvents must not mutate it")
@@ -253,9 +252,9 @@ func TestHotStore_FetchEventsRoundTrip(t *testing.T) {
 
 	p1, _ := makePayload("a")
 	p2, _ := makePayload("b")
-	require.NoError(t, ingestLedgerEvents(h.store, 2, []events.Payload{p1, p2}))
+	require.NoError(t, ingestLedgerEvents(h.store, 2, []Payload{p1, p2}))
 	p3, _ := makePayload("c")
-	require.NoError(t, ingestLedgerEvents(h.store, 3, []events.Payload{p3}))
+	require.NoError(t, ingestLedgerEvents(h.store, 3, []Payload{p3}))
 
 	fetched, err := h.store.FetchEvents(context.Background(), []uint32{0, 1, 2})
 	require.NoError(t, err)
@@ -269,7 +268,7 @@ func TestHotStore_FetchEventsErrorsOnMissingID(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	h := openHotStoreForTest(t, chunkID)
 	p, _ := makePayload("only")
-	require.NoError(t, ingestLedgerEvents(h.store, 2, []events.Payload{p}))
+	require.NoError(t, ingestLedgerEvents(h.store, 2, []Payload{p}))
 
 	_, err := h.store.FetchEvents(context.Background(), []uint32{99})
 	assert.Error(t, err)
@@ -285,7 +284,7 @@ func TestHotStore_FetchEventsLargeBatch(t *testing.T) {
 	const n = 256
 	h := openHotStoreForTest(t, chunkID)
 
-	payloads := make([]events.Payload, n)
+	payloads := make([]Payload, n)
 	for i := range n {
 		p, _ := makePayload(fmt.Sprintf("evt-%03d", i))
 		payloads[i] = p
@@ -315,7 +314,7 @@ func TestHotStore_FetchEventsHonorsContext(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	h := openHotStoreForTest(t, chunkID)
 	p, _ := makePayload("only")
-	require.NoError(t, ingestLedgerEvents(h.store, 2, []events.Payload{p}))
+	require.NoError(t, ingestLedgerEvents(h.store, 2, []Payload{p}))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -338,7 +337,7 @@ func TestHotStore_FetchEventsRejectsUnsortedInput(t *testing.T) {
 	p2.LedgerSequence = 2
 	p3, _ := makePayload("c")
 	p3.LedgerSequence = 2
-	require.NoError(t, ingestLedgerEvents(h.store, 2, []events.Payload{p1, p2, p3}))
+	require.NoError(t, ingestLedgerEvents(h.store, 2, []Payload{p1, p2, p3}))
 
 	_, err := h.store.FetchEvents(context.Background(), []uint32{2, 0})
 	require.ErrorIs(t, err, ErrUnsortedEventIDs, "out-of-order input must error")
@@ -354,10 +353,10 @@ func TestHotStore_AllStreamsInEventIDOrder(t *testing.T) {
 	p1.LedgerSequence = 2
 	p2, _ := makePayload("b")
 	p2.LedgerSequence = 2
-	require.NoError(t, ingestLedgerEvents(h.store, 2, []events.Payload{p1, p2}))
+	require.NoError(t, ingestLedgerEvents(h.store, 2, []Payload{p1, p2}))
 	p3, _ := makePayload("c")
 	p3.LedgerSequence = 3
-	require.NoError(t, ingestLedgerEvents(h.store, 3, []events.Payload{p3}))
+	require.NoError(t, ingestLedgerEvents(h.store, 3, []Payload{p3}))
 
 	got := make([]string, 0, 3)
 	gotLedgers := make([]uint32, 0, 3)
@@ -397,11 +396,11 @@ func TestHotStore_PostCloseReadsError(t *testing.T) {
 	h := openHotStoreForTest(t, chunkID)
 
 	p, keys := makePayload("seed")
-	require.NoError(t, ingestLedgerEvents(h.store, chunkID.FirstLedger(), []events.Payload{p}))
+	require.NoError(t, ingestLedgerEvents(h.store, chunkID.FirstLedger(), []Payload{p}))
 	require.NoError(t, h.raw.Close())
 
 	// LookupKeys must error rather than silently returning cached bitmaps.
-	bms, err := h.store.LookupKeys(context.Background(), []events.TermKey{keys[0]})
+	bms, err := h.store.LookupKeys(context.Background(), []TermKey{keys[0]})
 	assert.Nil(t, bms)
 	require.ErrorIs(t, err, stores.ErrStoreClosed)
 
@@ -434,13 +433,13 @@ func TestHotStore_IngestLedgerEvents_DuplicateLedgerErrors(t *testing.T) {
 	first := chunkID.FirstLedger()
 
 	p1, _ := makePayload("a")
-	require.NoError(t, ingestLedgerEvents(h.store, first, []events.Payload{p1}))
+	require.NoError(t, ingestLedgerEvents(h.store, first, []Payload{p1}))
 
 	countBefore := mustEventCount(t, h.store)
 
 	// Re-ingesting the same ledger errors (expected is now first+1).
 	p2, _ := makePayload("b")
-	err := ingestLedgerEvents(h.store, first, []events.Payload{p2})
+	err := ingestLedgerEvents(h.store, first, []Payload{p2})
 	require.ErrorIs(t, err, ErrLedgerOutOfOrder, "a re-delivered committed ledger must error, not no-op")
 
 	assert.Equal(t, countBefore, mustEventCount(t, h.store), "event count must not advance on the rejected ingest")
@@ -467,13 +466,13 @@ func TestHotStore_IngestLedgerEvents_RejectsLedgerGap(t *testing.T) {
 	first := chunkID.FirstLedger()
 
 	p1, _ := makePayload("a")
-	require.NoError(t, ingestLedgerEvents(h.store, first, []events.Payload{p1}))
+	require.NoError(t, ingestLedgerEvents(h.store, first, []Payload{p1}))
 
 	countBefore := mustEventCount(t, h.store)
 
 	// Skip first+1; jump directly to first+2.
 	p2, _ := makePayload("c")
-	err := ingestLedgerEvents(h.store, first+2, []events.Payload{p2})
+	err := ingestLedgerEvents(h.store, first+2, []Payload{p2})
 	require.ErrorIs(t, err, ErrLedgerOutOfOrder)
 
 	assert.Equal(t, countBefore, mustEventCount(t, h.store))
@@ -488,11 +487,11 @@ func TestHotStore_IngestLedgerEvents_RejectsOutOfRangeLedger(t *testing.T) {
 	p, _ := makePayload("a")
 
 	// Below range (chunk 0's FirstLedger is FirstLedgerSeq == 2).
-	err := ingestLedgerEvents(h.store, 1, []events.Payload{p})
+	err := ingestLedgerEvents(h.store, 1, []Payload{p})
 	require.ErrorIs(t, err, ErrLedgerOutOfRange, "ledger below chunk range")
 
 	// Above range — well past chunk 0's LastLedger.
-	err = ingestLedgerEvents(h.store, chunkID.LastLedger()+1, []events.Payload{p})
+	err = ingestLedgerEvents(h.store, chunkID.LastLedger()+1, []Payload{p})
 	require.ErrorIs(t, err, ErrLedgerOutOfRange, "ledger above chunk range")
 
 	// State must be unchanged after both rejections.
@@ -514,7 +513,7 @@ func TestHotStore_ReopenRecoversState(t *testing.T) {
 
 	hot1, raw1 := openHotStoreForTestAt(t, dir, chunkID)
 	p1, _ := makePayload("before")
-	require.NoError(t, ingestLedgerEvents(hot1, 2, []events.Payload{p1}))
+	require.NoError(t, ingestLedgerEvents(hot1, 2, []Payload{p1}))
 	require.NoError(t, raw1.Close())
 
 	hot2, _ := openHotStoreForTestAt(t, dir, chunkID)
@@ -522,7 +521,7 @@ func TestHotStore_ReopenRecoversState(t *testing.T) {
 	assert.Equal(t, uint32(1), mustEventCount(t, hot2), "warmup recovered offsets")
 
 	p2, _ := makePayload("after")
-	require.NoError(t, ingestLedgerEvents(hot2, 3, []events.Payload{p2}))
+	require.NoError(t, ingestLedgerEvents(hot2, 3, []Payload{p2}))
 	assert.Equal(t, uint32(2), mustEventCount(t, hot2))
 }
 
@@ -550,7 +549,7 @@ func TestHotStore_ConcurrentIngestAndLookup(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := range uint32(N) {
-			if err := ingestLedgerEvents(h.store, 2+i, []events.Payload{p}); err != nil {
+			if err := ingestLedgerEvents(h.store, 2+i, []Payload{p}); err != nil {
 				t.Errorf("ingest %d: %v", i, err)
 				return
 			}
@@ -574,9 +573,9 @@ func TestHotStore_ConcurrentIngestAndLookup(t *testing.T) {
 // fetchRangePayloads fully drains FetchRange into a slice for tests
 // that want to compare against a known sequence. Shared with
 // cold_reader_test.go via the package.
-func fetchRangePayloads(t *testing.T, r Reader, start, count uint32) ([]events.Payload, error) {
+func fetchRangePayloads(t *testing.T, r Reader, start, count uint32) ([]Payload, error) {
 	t.Helper()
-	var out []events.Payload
+	var out []Payload
 	var firstErr error
 	for p, err := range r.FetchRange(context.Background(), start, count) {
 		if err != nil {
@@ -597,7 +596,7 @@ func fetchRangePayloads(t *testing.T, r Reader, start, count uint32) ([]events.P
 // stops" — the iterator returns immediately after the error yield,
 // so the helper doesn't walk a long sequence in practice. Shared
 // with cold_reader_test.go.
-func firstIterError(seq iter.Seq2[events.Payload, error]) error {
+func firstIterError(seq iter.Seq2[Payload, error]) error {
 	for _, err := range seq {
 		if err != nil {
 			return err
@@ -611,9 +610,9 @@ func firstIterError(seq iter.Seq2[events.Payload, error]) error {
 // hot/cold/query tests that assert on one term at a time. It requires
 // LookupKeys to succeed, so closed/corrupt-path tests must call
 // LookupKeys directly and assert on the error.
-func lookupOne(t *testing.T, r Reader, key events.TermKey) *roaring.Bitmap {
+func lookupOne(t *testing.T, r Reader, key TermKey) *roaring.Bitmap {
 	t.Helper()
-	bms, err := r.LookupKeys(context.Background(), []events.TermKey{key})
+	bms, err := r.LookupKeys(context.Background(), []TermKey{key})
 	require.NoError(t, err)
 	require.Len(t, bms, 1)
 	return bms[0]
@@ -624,7 +623,7 @@ func TestHotStore_FetchRangeMidRange(t *testing.T) {
 	h := openHotStoreForTest(t, chunkID)
 	first := chunkID.FirstLedger()
 
-	payloads := make([]events.Payload, 5)
+	payloads := make([]Payload, 5)
 	for i := range payloads {
 		p, _ := makePayload(fmt.Sprintf("evt-%d", i))
 		payloads[i] = p
@@ -651,7 +650,7 @@ func TestHotStore_FetchRangeOutOfBoundsErrors(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	h := openHotStoreForTest(t, chunkID)
 	p, _ := makePayload("only")
-	require.NoError(t, ingestLedgerEvents(h.store, chunkID.FirstLedger(), []events.Payload{p}))
+	require.NoError(t, ingestLedgerEvents(h.store, chunkID.FirstLedger(), []Payload{p}))
 
 	_, err := fetchRangePayloads(t, h.store, 0, 2) // count > EventCount
 	require.Error(t, err)
@@ -671,7 +670,7 @@ func TestHotStore_AllMatchesFetchRange(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	h := openHotStoreForTest(t, chunkID)
 	first := chunkID.FirstLedger()
-	payloads := make([]events.Payload, 4)
+	payloads := make([]Payload, 4)
 	for i := range payloads {
 		p, _ := makePayload(fmt.Sprintf("e%d", i))
 		payloads[i] = p
@@ -703,7 +702,7 @@ func mustEventCount(t *testing.T, r Reader) uint32 {
 }
 
 // mustOffsets asserts r.Offsets() succeeds and returns the offsets.
-func mustOffsets(t *testing.T, r Reader) *events.LedgerOffsets {
+func mustOffsets(t *testing.T, r Reader) *LedgerOffsets {
 	t.Helper()
 	o, err := r.Offsets()
 	require.NoError(t, err)
@@ -714,7 +713,7 @@ func mustOffsets(t *testing.T, r Reader) *events.LedgerOffsets {
 // ingestLedgerEvents commits one ledger's events through IngestLedgerToBatch in
 // a test-owned batch and runs the post-commit apply hook — the production
 // write shape, reduced to a test seeding call.
-func ingestLedgerEvents(h *HotStore, ledgerSeq uint32, payloads []events.Payload) error {
+func ingestLedgerEvents(h *HotStore, ledgerSeq uint32, payloads []Payload) error {
 	if h.chunkStore.IsClosed() {
 		return stores.ErrStoreClosed
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_warmup_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/hot_warmup_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rocksdb"
 )
 
@@ -24,7 +23,7 @@ func TestWarmup_FreshChunkProducesEmptyMirrorsViaNewWithStore(t *testing.T) {
 
 	// A fresh mirror is empty: probing any term is a clean miss
 	// (nil bitmap, no error).
-	bm, err := h.store.mirror.Get(events.ComputeTermKey([]byte("any"), events.FieldContractID))
+	bm, err := h.store.mirror.Get(ComputeTermKey([]byte("any"), FieldContractID))
 	require.NoError(t, err)
 	assert.Nil(t, bm)
 	assert.Zero(t, h.store.offsets.LedgerCount())
@@ -46,18 +45,18 @@ func TestWarmup_RebuildsMirrorFromIngestedRows(t *testing.T) {
 	hot1, raw1 := openHotStoreForTestAt(t, dir, chunkID)
 	p1, _ := makePayload("alpha")
 	p2, _ := makePayload("beta")
-	require.NoError(t, ingestLedgerEvents(hot1, 2, []events.Payload{p1, p2}))
+	require.NoError(t, ingestLedgerEvents(hot1, 2, []Payload{p1, p2}))
 
 	// Derive the terms each seeded payload contributes (the same
-	// events.TermsForBytes the ingest path indexed by), then snapshot
+	// TermsForBytes the ingest path indexed by), then snapshot
 	// their pre-close cardinalities straight from the live mirror.
-	var seededKeys []events.TermKey
-	for _, p := range []events.Payload{p1, p2} {
-		keys, err := events.TermsForBytes(p.ContractEventBytes)
+	var seededKeys []TermKey
+	for _, p := range []Payload{p1, p2} {
+		keys, err := TermsForBytes(p.ContractEventBytes)
 		require.NoError(t, err)
 		seededKeys = append(seededKeys, keys...)
 	}
-	expected := make(map[events.TermKey]uint64)
+	expected := make(map[TermKey]uint64)
 	for _, k := range seededKeys {
 		bm, err := hot1.mirror.Get(k)
 		require.NoError(t, err)
@@ -69,7 +68,7 @@ func TestWarmup_RebuildsMirrorFromIngestedRows(t *testing.T) {
 	// Reopen — warmup replays events_index into a fresh mirror.
 	hot2, _ := openHotStoreForTestAt(t, dir, chunkID)
 
-	got := make(map[events.TermKey]uint64)
+	got := make(map[TermKey]uint64)
 	for k := range expected {
 		bm, err := hot2.mirror.Get(k)
 		require.NoError(t, err)
@@ -87,12 +86,12 @@ func TestWarmup_RestoresEventIDsForRepeatedTerm(t *testing.T) {
 	p1, _ := makePayload("shared")
 	p2, _ := makePayload("shared")
 	p3, _ := makePayload("shared")
-	require.NoError(t, ingestLedgerEvents(hot1, 2, []events.Payload{p1, p2, p3}))
+	require.NoError(t, ingestLedgerEvents(hot1, 2, []Payload{p1, p2, p3}))
 	require.NoError(t, raw1.Close())
 
 	hot2, _ := openHotStoreForTestAt(t, dir, chunkID)
 
-	contractTermKey := events.ComputeTermKey(eventOf(p1).ContractId[:], events.FieldContractID)
+	contractTermKey := ComputeTermKey(eventOf(p1).ContractId[:], FieldContractID)
 	bm := lookupOne(t, hot2, contractTermKey)
 	require.NotNil(t, bm)
 	assert.Equal(t, uint64(3), bm.GetCardinality())
@@ -108,9 +107,9 @@ func TestWarmup_OffsetsReconstructedAcrossLedgers(t *testing.T) {
 	hot1, raw1 := openHotStoreForTestAt(t, dir, chunkID)
 	p1, _ := makePayload("a")
 	p2, _ := makePayload("b")
-	require.NoError(t, ingestLedgerEvents(hot1, 2, []events.Payload{p1, p2}))
+	require.NoError(t, ingestLedgerEvents(hot1, 2, []Payload{p1, p2}))
 	p3, _ := makePayload("c")
-	require.NoError(t, ingestLedgerEvents(hot1, 3, []events.Payload{p3}))
+	require.NoError(t, ingestLedgerEvents(hot1, 3, []Payload{p3}))
 	require.NoError(t, raw1.Close())
 
 	hot2, _ := openHotStoreForTestAt(t, dir, chunkID)
@@ -148,7 +147,7 @@ func TestWarmup_RejectsDataEventBeyondOffsets(t *testing.T) {
 	hot1, raw1 := openHotStoreForTestAt(t, dir, chunkID)
 	p1, _ := makePayload("a")
 	p2, _ := makePayload("b")
-	require.NoError(t, ingestLedgerEvents(hot1, 2, []events.Payload{p1, p2})) // total = 2
+	require.NoError(t, ingestLedgerEvents(hot1, 2, []Payload{p1, p2})) // total = 2
 	require.NoError(t, raw1.Close())
 
 	// An orphan data row well beyond total (id 7, total = 2): proves the
@@ -170,7 +169,7 @@ func TestWarmup_RejectsOffsetsGap(t *testing.T) {
 	hot1, raw1 := openHotStoreForTestAt(t, dir, chunkID)
 	for _, seq := range []uint32{2, 3, 4} {
 		p, _ := makePayload("x")
-		require.NoError(t, ingestLedgerEvents(hot1, seq, []events.Payload{p}))
+		require.NoError(t, ingestLedgerEvents(hot1, seq, []Payload{p}))
 	}
 	require.NoError(t, raw1.Close())
 
@@ -192,7 +191,7 @@ func TestWarmup_RejectsOffsetsOverflow(t *testing.T) {
 	hot1, raw1 := openHotStoreForTestAt(t, dir, chunkID)
 	for _, seq := range []uint32{2, 3} {
 		p, _ := makePayload("x")
-		require.NoError(t, ingestLedgerEvents(hot1, seq, []events.Payload{p}))
+		require.NoError(t, ingestLedgerEvents(hot1, seq, []Payload{p}))
 	}
 	require.NoError(t, raw1.Close())
 
@@ -231,7 +230,7 @@ func TestWarmup_RejectsMissingTailDataEvent(t *testing.T) {
 	hot1, raw1 := openHotStoreForTestAt(t, dir, chunkID)
 	p1, _ := makePayload("a")
 	p2, _ := makePayload("b")
-	require.NoError(t, ingestLedgerEvents(hot1, 2, []events.Payload{p1, p2})) // total = 2
+	require.NoError(t, ingestLedgerEvents(hot1, 2, []Payload{p1, p2})) // total = 2
 	require.NoError(t, raw1.Close())
 
 	// Drop the last data row (event id total-1 == 1) while offsets still
@@ -251,13 +250,13 @@ func TestWarmup_RejectsIndexBeyondCommitted(t *testing.T) {
 	hot1, raw1 := openHotStoreForTestAt(t, dir, chunkID)
 	p1, _ := makePayload("a")
 	p2, _ := makePayload("b")
-	require.NoError(t, ingestLedgerEvents(hot1, 2, []events.Payload{p1, p2})) // total = 2
+	require.NoError(t, ingestLedgerEvents(hot1, 2, []Payload{p1, p2})) // total = 2
 	require.NoError(t, raw1.Close())
 
 	// An index row at exactly total (id 2): the tightest "beyond
 	// committed" case, pinning the > (not >=) bound — valid ids are 0..1.
 	corruptHotChunk(t, dir, chunkID, func(raw *rocksdb.Store) {
-		var term events.TermKey
+		var term TermKey
 		term[0] = 0x99
 		require.NoError(t, raw.Put(IndexCF, encodeIndexKey(term, 2), nil))
 	})
@@ -272,7 +271,7 @@ func TestWarmup_OffsetsHandleEmptyTrailingLedger(t *testing.T) {
 
 	hot1, raw1 := openHotStoreForTestAt(t, dir, chunkID)
 	p, _ := makePayload("only")
-	require.NoError(t, ingestLedgerEvents(hot1, 2, []events.Payload{p}))
+	require.NoError(t, ingestLedgerEvents(hot1, 2, []Payload{p}))
 	require.NoError(t, ingestLedgerEvents(hot1, 3, nil))
 	require.NoError(t, raw1.Close())
 
@@ -297,11 +296,11 @@ func TestWarmup_RejectsIndexRowAtMaxUint32(t *testing.T) {
 
 	hot1, raw1 := openHotStoreForTestAt(t, dir, chunkID)
 	p1, _ := makePayload("a")
-	require.NoError(t, ingestLedgerEvents(hot1, 2, []events.Payload{p1})) // total = 1
+	require.NoError(t, ingestLedgerEvents(hot1, 2, []Payload{p1})) // total = 1
 	require.NoError(t, raw1.Close())
 
 	corruptHotChunk(t, dir, chunkID, func(raw *rocksdb.Store) {
-		var term events.TermKey
+		var term TermKey
 		term[0] = 0x99
 		require.NoError(t, raw.Put(IndexCF, encodeIndexKey(term, math.MaxUint32), nil))
 	})

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/index.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/index.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"encoding/binary"
@@ -56,6 +56,14 @@ func ComputeTermKey(value []byte, field Field) TermKey {
 // EventTypeTermKey returns the term key for eventType. Every event
 // carries one, so a query for a rare type resolves through the index
 // instead of scanning a chunk to find the few events that have it.
+//
+// The name stutters as event.EventTypeTermKey. It stays that way because
+// every TermKey constructor here is named after the Field it hashes
+// (FieldEventType here, FieldTopicCount -> TopicCountTermKey), and
+// trimming to TypeTermKey drops the domain term: the value is an
+// xdr.ContractEventType, called eventType on the wire.
+//
+//nolint:revive // named after FieldEventType; see the note above
 func EventTypeTermKey(eventType xdr.ContractEventType) TermKey {
 	var value [4]byte
 	binary.BigEndian.PutUint32(value[:], uint32(eventType)) //nolint:gosec // enum keeps its own XDR width

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/index_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/index_test.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"encoding/binary"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/ledgeroffsets.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/ledgeroffsets.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"fmt"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/ledgeroffsets_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/ledgeroffsets_test.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"sync"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/match.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/match.go
@@ -1,6 +1,6 @@
 package event
 
-// query.go is the events-side read surface: Matches turns a
+// match.go is the events-side read surface: Matches turns a
 // {filters, window} spec into a stream of verified matches for one
 // Chunk. It is built on the Reader interface, so it works against
 // HotStore and ColdReader without branching. Filter semantics are on
@@ -23,8 +23,6 @@ import (
 
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 	"github.com/stellar/go-stellar-sdk/xdr"
-
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 )
 
 // Filter is one item in the union of an events query. Within a
@@ -33,7 +31,7 @@ import (
 // zero value are wildcards.
 //
 // Topics[i] constrains topic position i. Positions beyond
-// protocol.MaxTopicCount are not indexed (see events.TermsForBytes).
+// protocol.MaxTopicCount are not indexed (see TermsForBytes).
 type Filter struct {
 	ContractID []byte
 	Topics     [protocol.MaxTopicCount][]byte
@@ -75,14 +73,14 @@ func (f TopicCountFilter) matches(n int) bool {
 // count ValidateFilters admits has a bucket of its own, and an "at
 // least" union is closed by the overflow bucket, so the union never
 // holds an event f does not match.
-func (f TopicCountFilter) termKeys() []events.TermKey {
+func (f TopicCountFilter) termKeys() []TermKey {
 	if f.isWildcard() {
 		return nil
 	}
 	if f.Exact {
-		return []events.TermKey{events.TopicCountTermKey(f.Count)}
+		return []TermKey{TopicCountTermKey(f.Count)}
 	}
-	return events.TopicCountTermKeysAtLeast(f.Count)
+	return TopicCountTermKeysAtLeast(f.Count)
 }
 
 // valueTermKeys returns one term per constrained value field
@@ -91,19 +89,19 @@ func (f TopicCountFilter) termKeys() []events.TermKey {
 // over which values a filter names. The topic-count buckets are not
 // value terms; termGroups adds them separately and the budget does
 // not count them.
-func (f *Filter) valueTermKeys() []events.TermKey {
-	var keys []events.TermKey
+func (f *Filter) valueTermKeys() []TermKey {
+	var keys []TermKey
 	if len(f.ContractID) > 0 {
-		keys = append(keys, events.ComputeTermKey(f.ContractID, events.FieldContractID))
+		keys = append(keys, ComputeTermKey(f.ContractID, FieldContractID))
 	}
 	if f.EventType != nil {
-		keys = append(keys, events.EventTypeTermKey(*f.EventType))
+		keys = append(keys, EventTypeTermKey(*f.EventType))
 	}
 	for tIdx, t := range f.Topics {
 		if len(t) == 0 {
 			continue
 		}
-		keys = append(keys, events.ComputeTermKey(t, topicFieldByPosition[tIdx]))
+		keys = append(keys, ComputeTermKey(t, topicField(tIdx)))
 	}
 	return keys
 }
@@ -111,10 +109,10 @@ func (f *Filter) valueTermKeys() []events.TermKey {
 // termGroups returns the indexed terms this filter constrains, grouped
 // by field: the bitmaps within a group are OR-ed and the groups are
 // AND-ed. Only the topic-count group ever holds more than one term.
-func (f *Filter) termGroups() [][]events.TermKey {
-	var groups [][]events.TermKey
+func (f *Filter) termGroups() [][]TermKey {
+	var groups [][]TermKey
 	for _, key := range f.valueTermKeys() {
-		groups = append(groups, []events.TermKey{key})
+		groups = append(groups, []TermKey{key})
 	}
 	// A constrained topic position already implies an "at least" count at
 	// or below it, since a topic term is only indexed for events carrying
@@ -186,7 +184,7 @@ func (r IDRange) check() error {
 // [firstID, lastID) covering those ledgers' events. Both bounds
 // must lie inside ofs's [StartLedger, EndLedger) range; out-of-range
 // bounds surface a wrapped error from LedgerOffsets.EventIDs.
-func IDRangeForLedgers(ofs *events.LedgerOffsets, startLedger, endLedger uint32) (IDRange, error) {
+func IDRangeForLedgers(ofs *LedgerOffsets, startLedger, endLedger uint32) (IDRange, error) {
 	firstID, _, err := ofs.EventIDs(startLedger)
 	if err != nil {
 		return IDRange{}, fmt.Errorf("events: range start ledger %d: %w", startLedger, err)
@@ -211,20 +209,9 @@ var matchBatchSize = 512
 // stopped; it cannot be recovered from the payload, which carries
 // chain data only.
 type Match struct {
-	events.Payload
+	Payload
 
 	Ordinal uint32
-}
-
-// topicFieldByPosition maps topic position 0..MaxTopicCount-1 to its
-// indexed events.Field. Mirror of the unexported events.topicField.
-//
-//nolint:gochecknoglobals // immutable lookup table; can't use const for array
-var topicFieldByPosition = [protocol.MaxTopicCount]events.Field{
-	events.FieldTopic0,
-	events.FieldTopic1,
-	events.FieldTopic2,
-	events.FieldTopic3,
 }
 
 // termPlan is a filter's termGroups resolved to slots in the batched
@@ -349,7 +336,7 @@ func unionForFilters(
 		return nil, true, nil
 	}
 	filterPlans := make([]termPlan, len(filters))
-	var uniqueKeys []events.TermKey
+	var uniqueKeys []TermKey
 
 	for i := range filters {
 		groups := filters[i].termGroups()
@@ -566,7 +553,7 @@ func ValidateFilters(filters []Filter) error {
 // lookups agree on what a value term is: TermKey over the store's
 // canonical bytes.
 func CountDistinctTerms(filters []Filter) int {
-	unique := make(map[events.TermKey]struct{})
+	unique := make(map[TermKey]struct{})
 	for i := range filters {
 		for _, key := range filters[i].valueTermKeys() {
 			unique[key] = struct{}{}
@@ -601,7 +588,7 @@ func unionSlots(bitmaps []*roaring.Bitmap, slots []int) *roaring.Bitmap {
 
 // indexOfOrAddTerm returns the index of key inside *keys, appending
 // it first if absent.
-func indexOfOrAddTerm(keys *[]events.TermKey, key events.TermKey) int {
+func indexOfOrAddTerm(keys *[]TermKey, key TermKey) int {
 	if i := slices.Index(*keys, key); i >= 0 {
 		return i
 	}
@@ -684,7 +671,7 @@ func streamRange(
 // positionally aligned with payloads (both come from the same
 // candidate batch); survivors carry their ordinal out as
 // Match.Ordinal.
-func postFilter(payloads []events.Payload, ids []uint32, filters []Filter) ([]Match, error) {
+func postFilter(payloads []Payload, ids []uint32, filters []Filter) ([]Match, error) {
 	out := make([]Match, 0, len(payloads))
 	plan := planFilters(filters)
 	for i := range payloads {

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/match_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/match_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 )
 
 // Query and QueryOptions are the engine's historical one-shot surface
@@ -30,8 +29,8 @@ type QueryOptions struct {
 	Range      IDRange
 }
 
-func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) ([]events.Payload, error) {
-	var out []events.Payload
+func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) ([]Payload, error) {
+	var out []Payload
 	for m, err := range Matches(ctx, r, filters, opts.Range, opts.Descending, 0) {
 		if err != nil {
 			return nil, err
@@ -55,7 +54,7 @@ type countingReader struct {
 	totalKeys       int
 }
 
-func (c *countingReader) LookupKeys(ctx context.Context, keys []events.TermKey) ([]*roaring.Bitmap, error) {
+func (c *countingReader) LookupKeys(ctx context.Context, keys []TermKey) ([]*roaring.Bitmap, error) {
 	c.lookupKeysCalls++
 	c.totalKeys += len(keys)
 	return c.Reader.LookupKeys(ctx, keys)
@@ -86,7 +85,7 @@ type queryFixture struct {
 // payloadFor builds a Payload carrying the marshaled ContractEvent XDR
 // in ContractEventBytes — the only shape this branch's Payload supports.
 // dataSym labels the event so tests can match against the layout above.
-func payloadFor(t *testing.T, cid xdr.ContractId, dataSym string, topics ...xdr.ScVal) events.Payload {
+func payloadFor(t *testing.T, cid xdr.ContractId, dataSym string, topics ...xdr.ScVal) Payload {
 	t.Helper()
 	return typedPayloadFor(t, cid, xdr.ContractEventTypeContract, dataSym, topics...)
 }
@@ -96,7 +95,7 @@ func payloadFor(t *testing.T, cid xdr.ContractId, dataSym string, topics ...xdr.
 func typedPayloadFor(
 	t *testing.T, cid xdr.ContractId, eventType xdr.ContractEventType,
 	dataSym string, topics ...xdr.ScVal,
-) events.Payload {
+) Payload {
 	t.Helper()
 	sym := xdr.ScSymbol(dataSym)
 	cidCopy := cid
@@ -113,7 +112,7 @@ func typedPayloadFor(
 	}
 	raw, err := ev.MarshalBinary()
 	require.NoError(t, err)
-	return events.Payload{
+	return Payload{
 		TxHash:             xdr.Hash{0xde, 0xad},
 		ContractEventBytes: raw,
 	}
@@ -141,7 +140,7 @@ func newQueryFixture(t *testing.T) *queryFixture {
 	require.NoError(t, err)
 
 	first := chunkID.FirstLedger()
-	require.NoError(t, ingestLedgerEvents(fx.store, first, []events.Payload{
+	require.NoError(t, ingestLedgerEvents(fx.store, first, []Payload{
 		payloadFor(t, fx.contractA, evtAAB, fx.t0a, fx.t0b),
 		payloadFor(t, fx.contractA, "evt-a-ac", fx.t0a, fx.t0c),
 		payloadFor(t, fx.contractB, "evt-b-ab", fx.t0a, fx.t0b),
@@ -153,7 +152,7 @@ func newQueryFixture(t *testing.T) *queryFixture {
 
 // dataSyms extracts each payload's Data symbol as a string so test
 // assertions can match against the fixture's labels above.
-func dataSyms(t *testing.T, payloads []events.Payload) []string {
+func dataSyms(t *testing.T, payloads []Payload) []string {
 	t.Helper()
 	out := make([]string, len(payloads))
 	for i, p := range payloads {
@@ -295,7 +294,7 @@ func TestQuery_DuplicateTermsAcrossFiltersDedupedInLookup(t *testing.T) {
 func TestQuery_DoesNotMutateMirrorBitmaps(t *testing.T) {
 	fx := newQueryFixture(t)
 	// Snapshot the mirror's bitmap for topic0=alpha before any query.
-	key := events.ComputeTermKey(fx.t0aRaw, events.FieldTopic0)
+	key := ComputeTermKey(fx.t0aRaw, FieldTopic0)
 	before := lookupOne(t, fx.store, key)
 	beforeCard := before.GetCardinality()
 
@@ -381,7 +380,7 @@ func TestQuery_ManyFiltersAtCallerCap(t *testing.T) {
 	// 15 unique contracts; one filter per contract.
 	first := chunkID.FirstLedger()
 	const n = 15
-	payloads := make([]events.Payload, n)
+	payloads := make([]Payload, n)
 	contracts := make([]xdr.ContractId, n)
 	for i := range n {
 		contracts[i][0] = byte(i + 1)
@@ -410,7 +409,7 @@ func newMultiLedgerQueryFixture(t *testing.T) *queryFixture {
 	t.Helper()
 	fx := newQueryFixture(t)
 	first := chunk.ID(0).FirstLedger()
-	require.NoError(t, ingestLedgerEvents(fx.store, first+1, []events.Payload{
+	require.NoError(t, ingestLedgerEvents(fx.store, first+1, []Payload{
 		payloadFor(t, fx.contractA, evtExtra0, fx.t0a),
 		payloadFor(t, fx.contractA, "evt-extra-1", fx.t0a),
 	}))
@@ -571,7 +570,7 @@ func TestQuery_MixedSuccessFilterList(t *testing.T) {
 	require.NoError(t, err)
 	// Sanity check: this term really isn't in the index. LookupKeys
 	// (which Query uses) signals the miss with a nil slot.
-	missingKey := events.ComputeTermKey(missingRaw, events.FieldTopic0)
+	missingKey := ComputeTermKey(missingRaw, FieldTopic0)
 	require.Nil(t, lookupOne(t, fx.store, missingKey),
 		"fixture sanity: 'nonexistent' must not be indexed")
 
@@ -694,7 +693,7 @@ func TestQuery_EmptyLeadingLedgerRangeStaysEmpty(t *testing.T) {
 	//   [first]   → [0, 0)   (empty)
 	//   [first+1] → [0, 5)   (5 events)
 	require.NoError(t, ingestLedgerEvents(h.store, first, nil))
-	require.NoError(t, ingestLedgerEvents(h.store, first+1, []events.Payload{
+	require.NoError(t, ingestLedgerEvents(h.store, first+1, []Payload{
 		makeSimplePayload(t, "evt-0"),
 		makeSimplePayload(t, "evt-1"),
 		makeSimplePayload(t, "evt-2"),
@@ -728,10 +727,10 @@ func TestQuery_EmptyLeadingLedgerRangeStaysEmpty(t *testing.T) {
 	require.Len(t, got, 5, "whole-chunk pin must still see the later-ledger events")
 }
 
-// makeSimplePayload builds an events.Payload with a unique Data symbol
+// makeSimplePayload builds an Payload with a unique Data symbol
 // and a single trivial topic. Used by tests that don't care about the
 // indexed-field layout, only event counts and ordering.
-func makeSimplePayload(t *testing.T, dataSymbol string) events.Payload {
+func makeSimplePayload(t *testing.T, dataSymbol string) Payload {
 	t.Helper()
 	var cid xdr.ContractId
 	cid[0] = 0xab
@@ -749,7 +748,7 @@ func makeSimplePayload(t *testing.T, dataSymbol string) events.Payload {
 	}
 	raw, err := ev.MarshalBinary()
 	require.NoError(t, err)
-	return events.Payload{
+	return Payload{
 		TxHash:             xdr.Hash{0xde, 0xad},
 		ContractEventBytes: raw,
 	}
@@ -797,7 +796,7 @@ func newTypeArityFixture(t *testing.T) *typeArityFixture {
 	fx.alphaRaw, err = alpha.MarshalBinary()
 	require.NoError(t, err)
 
-	require.NoError(t, ingestLedgerEvents(fx.store, chunkID.FirstLedger(), []events.Payload{
+	require.NoError(t, ingestLedgerEvents(fx.store, chunkID.FirstLedger(), []Payload{
 		payloadFor(t, fx.contract, "c-1", alpha),
 		typedPayloadFor(t, fx.contract, xdr.ContractEventTypeSystem, labelS1, alpha),
 		payloadFor(t, fx.contract, "c-2", alpha, beta),
@@ -1198,8 +1197,8 @@ func freezeFixtureToColdReader(t *testing.T, hot *HotStore, chunkID chunk.ID) *C
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cw.Close() })
 
-	idx := events.NewBitmaps()
-	coldOffsets := events.NewLedgerOffsets(chunkID.FirstLedger())
+	idx := NewBitmaps()
+	coldOffsets := NewLedgerOffsets(chunkID.FirstLedger())
 
 	// Read the hot store's offsets snapshot so we know exactly how many
 	// events sit in each ledger. Walking per-ledger via FetchRange lets
@@ -1228,7 +1227,7 @@ func freezeFixtureToColdReader(t *testing.T, hot *HotStore, chunkID chunk.ID) *C
 			require.NoError(t, err)
 			p.ContractEventBytes = bytes.Clone(p.ContractEventBytes)
 			require.NoError(t, cw.Append(p))
-			keys, err := events.TermsForBytes(p.ContractEventBytes)
+			keys, err := TermsForBytes(p.ContractEventBytes)
 			require.NoError(t, err)
 			for _, k := range keys {
 				idx.AddTo(k, eventID)
@@ -1507,12 +1506,12 @@ type fetchCountingReader struct {
 	rangeSizes []int // count per FetchRange call
 }
 
-func (c *fetchCountingReader) FetchEvents(ctx context.Context, ids []uint32) ([]events.Payload, error) {
+func (c *fetchCountingReader) FetchEvents(ctx context.Context, ids []uint32) ([]Payload, error) {
 	c.fetchSizes = append(c.fetchSizes, len(ids))
 	return c.Reader.FetchEvents(ctx, ids)
 }
 
-func (c *fetchCountingReader) FetchRange(ctx context.Context, start, count uint32) iter.Seq2[events.Payload, error] {
+func (c *fetchCountingReader) FetchRange(ctx context.Context, start, count uint32) iter.Seq2[Payload, error] {
 	c.rangeSizes = append(c.rangeSizes, int(count))
 	return c.Reader.FetchRange(ctx, start, count)
 }
@@ -1580,7 +1579,7 @@ func TestMatches_DropsAreInvisible(t *testing.T) {
 	// topic1 == gamma legitimately matches id 1 only. Inject ids 2, 3,
 	// and 4 as false positives, so the candidate set is {1, 2, 3, 4}
 	// and every candidate after the true match drops.
-	gammaKey := events.ComputeTermKey(fx.t0cRaw, events.FieldTopic1)
+	gammaKey := ComputeTermKey(fx.t0cRaw, FieldTopic1)
 	for _, fp := range []uint32{2, 3, 4} {
 		fx.store.index().AddTo(gammaKey, fp)
 	}
@@ -1642,7 +1641,7 @@ func TestMatches_EmptyStreams(t *testing.T) {
 // a no-op.
 func TestMatches_WindowANDLeavesBorrowedBitmapUntouched(t *testing.T) {
 	fx := newQueryFixture(t)
-	key := events.ComputeTermKey(fx.contractA[:], events.FieldContractID)
+	key := ComputeTermKey(fx.contractA[:], FieldContractID)
 	// Promote contract A's term (real matches: ids 0, 1, 4) to dense
 	// mode. The injected ids sit above the chunk's EventCount and every
 	// window below, so they are clipped before any fetch.
@@ -1688,7 +1687,7 @@ func TestQuery_PostFilterRejectsTermHashCollision(t *testing.T) {
 	// gamma's term legitimately matches id=1 only (evt-a-ac with
 	// topic1=gamma). Inject id=4 (evt-a-b: topic0=beta only,
 	// no topic1) into the same bitmap to simulate a collision.
-	gammaKey := events.ComputeTermKey(fx.t0cRaw, events.FieldTopic1)
+	gammaKey := ComputeTermKey(fx.t0cRaw, FieldTopic1)
 	before := lookupOne(t, fx.store, gammaKey)
 	require.True(t, before.Contains(1), "fixture sanity: id=1 indexes topic1=gamma")
 	require.False(t, before.Contains(4), "fixture sanity: id=4 not yet in topic1=gamma bitmap")
@@ -1738,7 +1737,7 @@ func TestPostFilter_OrdinalAlignmentWithLeadingDrop(t *testing.T) {
 
 	// Candidate batch [7, 9]: ordinal 7's bytes do not match the filter
 	// (topic0 = beta), ordinal 9's do: a leading drop.
-	payloads := []events.Payload{
+	payloads := []Payload{
 		payloadFor(t, cid, "drop", betaVal),
 		payloadFor(t, cid, "keep", gammaVal),
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/payload.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/payload.go
@@ -1,4 +1,4 @@
-// Package events defines the canonical binary format for a
+// payload.go defines the canonical binary format for a
 // single event as stored in the full-history pipeline.
 //
 // The same bytes are produced by hot ingest, written into the
@@ -43,7 +43,8 @@
 // records are stored and read back whole, so any slack means the bytes were
 // not written by this layout, and the mismatch fails loudly rather than
 // silently aliasing the wrong event slice.
-package events
+
+package event
 
 import (
 	"encoding/binary"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/payload_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/payload_test.go
@@ -1,4 +1,4 @@
-package events
+package event
 
 import (
 	"encoding/binary"

--- a/cmd/stellar-rpc/internal/rpcv2/stores/event/reader.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/event/reader.go
@@ -1,7 +1,8 @@
-// Package event is the per-chunk event store (hot RocksDB CFs + cold
-// pack/index artifacts). Named in the singular because the plural —
-// events — belongs to rpcv2/events, the extraction/index machinery
-// this store is built on.
+// Package event is everything the daemon knows about a stored event: the
+// canonical binary payload format, the term-index vocabulary and bitmap
+// containers built from it, the extraction that turns a walked ledger into
+// payloads, and the per-chunk stores that hold them (hot RocksDB CFs and
+// cold pack/index artifacts) with the match engine that reads them.
 package event
 
 import (
@@ -13,7 +14,6 @@ import (
 	"github.com/RoaringBitmap/roaring/v2"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 )
 
 // Closed-store lifecycle: HotStore and ColdReader read methods
@@ -55,14 +55,14 @@ var ErrFetchRangeOutOfBounds = errors.New("events: FetchRange out of bounds")
 // ContractEventBytes are safe to retain. FetchRange and All yield borrowed
 // Payloads — ContractEventBytes aliases the reader's iteration buffer and
 // is valid only until the next step; a consumer that retains one past the
-// step must clone its ContractEventBytes. See events.Payload.Unmarshal for
+// step must clone its ContractEventBytes. See Payload.Unmarshal for
 // the alias contract.
 type Reader interface {
 	// ChunkID identifies which Chunk this Reader serves.
 	ChunkID() chunk.ID
 
 	// EventCount is the total number of events in this Chunk.
-	// Equal to the last events.LedgerOffsets cumulative count.
+	// Equal to the last LedgerOffsets cumulative count.
 	// Returns (0, stores.ErrStoreClosed) after Close. On ColdReader, the value
 	// is read lazily from events.pack's trailer on first call.
 	EventCount() (uint32, error)
@@ -88,7 +88,7 @@ type Reader interface {
 	//     other reader holding the cached pointer (cold).
 	//
 	// Returns (nil, stores.ErrStoreClosed) after Close.
-	Offsets() (*events.LedgerOffsets, error)
+	Offsets() (*LedgerOffsets, error)
 
 	// LookupKeys returns bitmaps for each key, aligned positionally
 	// with the input slice (result[i] corresponds to keys[i]).
@@ -113,7 +113,7 @@ type Reader interface {
 	// ctx cancels in-flight I/O on the cold path (MPHF load,
 	// index.pack ReadAt); hot side checks ctx as a fast guard before
 	// touching the in-memory mirror.
-	LookupKeys(ctx context.Context, keys []events.TermKey) ([]*roaring.Bitmap, error)
+	LookupKeys(ctx context.Context, keys []TermKey) ([]*roaring.Bitmap, error)
 
 	// FetchEvents decodes events for the supplied chunk-relative
 	// eventIDs and returns them positionally aligned with the input
@@ -133,7 +133,7 @@ type Reader interface {
 	// resume ordinal is bounds-checked against its ledger's ID range
 	// first), so a miss signals corruption or a writer/reader
 	// mismatch, not a normal not-found case.
-	FetchEvents(ctx context.Context, eventIDs []uint32) ([]events.Payload, error)
+	FetchEvents(ctx context.Context, eventIDs []uint32) ([]Payload, error)
 
 	// FetchRange streams count events starting at chunk-relative
 	// event ID start, in ascending event-ID order. Equivalent to
@@ -148,7 +148,7 @@ type Reader interface {
 	// and may be sparse.
 	//
 	// ctx cancels in-flight I/O on both paths. Yielding
-	// (events.Payload{}, stores.ErrStoreClosed) and stopping is the after-Close
+	// (Payload{}, stores.ErrStoreClosed) and stopping is the after-Close
 	// behavior, mirroring All.
 	//
 	// count == 0 is a no-op regardless of start (both implementations
@@ -156,15 +156,15 @@ type Reader interface {
 	// range escapes [0, EventCount) yields a wrapped
 	// ErrFetchRangeOutOfBounds and stops — callers cap count against
 	// EventCount themselves.
-	FetchRange(ctx context.Context, start, count uint32) iter.Seq2[events.Payload, error]
+	FetchRange(ctx context.Context, start, count uint32) iter.Seq2[Payload, error]
 
 	// All streams every event in this Chunk in chunk-relative
 	// eventID order without intermediate buffering. Equivalent to
 	// FetchRange(ctx, 0, EventCount). (The freeze path does NOT use
 	// this — it re-derives cold artifacts from raw LCMs.)
-	// Each events.Payload carries its LedgerSequence, so consumers can
+	// Each Payload carries its LedgerSequence, so consumers can
 	// track ledger boundaries without separate signaling.
-	All(ctx context.Context) iter.Seq2[events.Payload, error]
+	All(ctx context.Context) iter.Seq2[Payload, error]
 }
 
 // validateSortedEventIDs returns a wrapped ErrUnsortedEventIDs if

--- a/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk/hotchunk.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk/hotchunk.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rocksdb"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
@@ -390,7 +389,7 @@ func (d *DB) IngestLedger(
 	}
 	rep.CloseTime = closedAt
 	// A pre-Soroban ledger yields zero payloads, no error.
-	payloads, err := events.PayloadsFromLedgerEvents(txParts, seq, closedAt)
+	payloads, err := event.PayloadsFromLedgerEvents(txParts, seq, closedAt)
 	if err != nil {
 		rep.Phases[PhaseExtract].Dur = time.Since(extractStart)
 		rep.Failed = PhaseExtract

--- a/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk/hotchunk_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/stores/hotchunk/hotchunk_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/rocksdb"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
@@ -158,7 +157,7 @@ func TestIngestLedger_AllCFsAdvanceTogether(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, first+1, seqB)
 	// events CFs.
-	bms, err := db.Events().LookupKeys(context.Background(), []events.TermKey{termA})
+	bms, err := db.Events().LookupKeys(context.Background(), []event.TermKey{termA})
 	require.NoError(t, err)
 	require.NotNil(t, bms[0])
 	assert.Equal(t, uint64(2), bms[0].GetCardinality(), "both ledgers share the event term")
@@ -198,7 +197,7 @@ func TestIngestLedger_RejectedLedgerPersistsNothingAcrossAnyCF(t *testing.T) {
 	_, gerr = db.Txhash().Get(hash)
 	require.ErrorIs(t, gerr, stores.ErrNotFound)
 	// events CFs — no term indexed, no event committed (clean miss = nil bitmap).
-	bms, lerr := db.Events().LookupKeys(context.Background(), []events.TermKey{term})
+	bms, lerr := db.Events().LookupKeys(context.Background(), []event.TermKey{term})
 	require.NoError(t, lerr)
 	require.Nil(t, bms[0])
 	assert.Equal(t, uint32(0), eventCount(t, db.Events()))
@@ -378,7 +377,7 @@ func TestIngestLedger_WritesEveryHotType(t *testing.T) {
 	seq, err := db.Txhash().Get(hash)
 	require.NoError(t, err)
 	assert.Equal(t, first, seq)
-	bms, err := db.Events().LookupKeys(context.Background(), []events.TermKey{term})
+	bms, err := db.Events().LookupKeys(context.Background(), []event.TermKey{term})
 	require.NoError(t, err)
 	require.NotNil(t, bms[0])
 	assert.Equal(t, uint64(1), bms[0].GetCardinality())
@@ -557,7 +556,7 @@ func TestIngestLedger_ClosedDBFails(t *testing.T) {
 // lcmWithEvent builds a V2 LCM with one transaction carrying one contract event
 // (topic="hotchunk_test"). Returns the wire bytes, the tx hash, and the event's
 // term key.
-func lcmWithEvent(t *testing.T, seq uint32) ([]byte, [32]byte, events.TermKey) {
+func lcmWithEvent(t *testing.T, seq uint32) ([]byte, [32]byte, event.TermKey) {
 	t.Helper()
 	ev := buildContractEvent("hotchunk_test")
 	meta := xdr.TransactionMeta{
@@ -570,7 +569,7 @@ func lcmWithEvent(t *testing.T, seq uint32) ([]byte, [32]byte, events.TermKey) {
 
 	evBytes, err := ev.MarshalBinary()
 	require.NoError(t, err)
-	keys, err := events.TermsForBytes(evBytes)
+	keys, err := event.TermsForBytes(evBytes)
 	require.NoError(t, err)
 	require.NotEmpty(t, keys)
 	return raw, hash, keys[0]


### PR DESCRIPTION
`rpcv2/events` and `rpcv2/stores/event` were two packages, one letter apart. The split separated nothing. Every non-test importer of `rpcv2/events` also imported `stores/event`.

`rpcv2/events` is now part of `rpcv2/stores/event`. One package holds the event formats, indexes, bitmaps, ledger offsets, extraction, and stores. `query.go` is renamed to `match.go`, and `topicFieldByPosition` is removed. No behavior changes.