### PR TITLE
Point integration tests at stellar-core 28.0.1 stable

### DIFF
--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -89,20 +89,20 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '27'
-      core_deb_version: '28.0.0-3494.a9b861321.jammy'
-      core_docker_img: 'stellar/stellar-core:28.0.0-3494.a9b861321.jammy'
+      core_deb_version: '28.0.1-3508.947aad841.jammy'
+      core_docker_img: 'stellar/stellar-core:28.0.1-3508.947aad841.jammy'
 
   integration-p28-pkg:
     name: Integration tests (P28)
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '28'
-      # Protocol 28 GA core release. Its src/rust/soroban/p28 submodule is
-      # rs-soroban-env v28.0.0 (ba37ea5f) — the same release soroban-env-host-curr
-      # pins from crates.io, keeping simulation cost models identical to
-      # apply-time metering.
-      core_deb_version: '28.0.0-3494.a9b861321.jammy'
-      core_docker_img: 'stellar/stellar-core:28.0.0-3494.a9b861321.jammy'
+      # Protocol 28 stable core release (28.0.1). Its src/rust/soroban/p28
+      # submodule is unchanged from 28.0.0: rs-soroban-env v28.0.0 (ba37ea5f)
+      # — the same release soroban-env-host-curr pins from crates.io, keeping
+      # simulation cost models identical to apply-time metering.
+      core_deb_version: '28.0.1-3508.947aad841.jammy'
+      core_docker_img: 'stellar/stellar-core:28.0.1-3508.947aad841.jammy'
 
   # integration-p25-src:
   #   name: Integration tests (p25, core from source)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+## [v28.0.1](https://github.com/stellar/stellar-rpc/compare/v28.0.0...v28.0.1)
+
 ### Fixed
+* Integration tests and docker images now use the stellar-core 28.0.1 stable release (`28.0.1-3508.947aad841`).
 * Bumped dependencies to latest versions, including `grpc`, `go-jose` and `opentelemetry` ([#958](https://github.com/stellar/stellar-rpc/pull/958)).
 
 ## [v28.0.0](https://github.com/stellar/stellar-rpc/compare/v27.1.1...v28.0.0)


### PR DESCRIPTION
Prep for the v28.0.1 patch release. No code changes.

- Both the P27 and P28 integration jobs now use the stellar-core 28.0.1 stable release (`28.0.1-3508.947aad841.jammy`, deb package and docker image). Verified present in the `jammy` stable/unstable apt channels and on Docker Hub.
- The core patch does not change the bundled p28 soroban host (still rs-soroban-env v28.0.0, ba37ea5f), so simulation cost models remain identical to apply-time metering.
- CHANGELOG entry for v28.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)