### PR TITLE
jsonrpc: own the response envelope — one marshal, one write; the jhttp bridge retires

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,25 @@ linters:
           deny:
             - pkg: github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv1
               desc: the rpcv2 tree and the v2 binary must not import the rpcv1 tree
+        # internal/jsonrpc is the ONLY assembler of the serving stack. It owns the
+        # sync.WaitGroup that wire.Handler.Shutdown joins and that the method
+        # table's duration limiters count into; a second assembler that passes
+        # a different group, or nil, compiles and serves correctly and produces
+        # a Shutdown that reports success while handlers run into a closing
+        # store. Blind spot, stated rather than sold past: this cannot see a
+        # second assembler INSIDE package jsonrpc, where admin.go already lives.
+        jsonrpc-assembly:
+          files:
+            - "**/cmd/stellar-rpc/internal/**"
+            - "**/cmd/stellar-rpc/rpcv1/**"
+            - "**/cmd/stellar-rpc/rpcv2/**"
+            - "!**/cmd/stellar-rpc/internal/jsonrpc/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/jsonrpc/wire
+              desc: only internal/jsonrpc may build the framing; it owns the liveHandlers group Shutdown joins
+            - pkg: github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/network
+              desc: only internal/jsonrpc may wrap handlers in the limiters; they must count into that same group
     cyclop:
       max-complexity: 15
     dogsled:

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -56,10 +56,9 @@ type Handler struct {
 }
 
 // Shutdown cancels the context every method handler runs on and waits for the
-// ones still running, or for ctx to end. Call it after the HTTP server has
-// stopped accepting and BEFORE closing the stores the handlers read: handler
-// contexts are server-scoped, so nothing else ends a request that outlived the
-// HTTP deadline. Idempotent.
+// ones still running, or for ctx to end. Handler contexts are server-scoped,
+// so nothing else ends a request that outlived the HTTP deadline: call this
+// after the server stops accepting and BEFORE closing the stores it reads.
 func (h Handler) Shutdown(ctx context.Context) error { return h.framing.Shutdown(ctx) }
 
 // HandlerSpec describes one JSON-RPC method: its handler plus the per-method
@@ -136,16 +135,11 @@ func decorateHandlers(daemon host.Daemon, logger *log.Entry, m handler.Map) hand
 	return decorated
 }
 
-// maxLoggedRequestID bounds the client-controlled text that reaches the log.
-// jrpc2.Request.ID() is the raw JSON id token the client sent; under the jhttp
-// bridge it was the bridge's own virtualized counter instead, so this field
-// used to be a couple of bytes and is now anything up to the 512KB body cap,
-// once per request at INFO. Every sane id fits (a quoted UUID is 38 bytes).
-//
-// This bounds what is WRITTEN, not what is copied: jrpc2.Request.ID() is
-// string(r.id) and has already copied the whole token by the time it returns.
-// jrpc2 exposes no length or zero-copy accessor, so the copy stays; the log
-// volume, which is the part that reaches a disk, does not.
+// maxLoggedRequestID bounds the client-controlled text that reaches the log:
+// jrpc2.Request.ID() is the raw id token the client sent, so this field is
+// anything up to the 512KB body cap, once per request at INFO. A quoted UUID
+// is 38 bytes. It bounds what is WRITTEN, not what is copied — ID() has
+// already copied the token, and jrpc2 exposes no length accessor.
 const maxLoggedRequestID = 64
 
 func loggedRequestID(req *jrpc2.Request) string {

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 	"unicode"
 
@@ -210,7 +209,7 @@ func toSnakeCase(s string) string {
 // dispatches and cannot see them. Swap the two and the slot is released when
 // the wrapper returns, bounding nothing.
 func wrapWithLimiters(
-	spec HandlerSpec, daemon host.Daemon, logger *log.Entry, liveHandlers *sync.WaitGroup,
+	spec HandlerSpec, daemon host.Daemon, logger *log.Entry, liveHandlers *network.LiveHandlers,
 ) jrpc2.Handler {
 	longName := toSnakeCase(spec.MethodName)
 	queueLimiterGaugeName := longName + "_inflight_requests"
@@ -262,7 +261,7 @@ func NewHandler(params Params) Handler {
 	// The duration limiter answers at its timeout and leaves its handler
 	// running, so the framing's bound loses sight of it. Both ends of that
 	// share this group: the limiters count into it, Handler.Shutdown joins it.
-	liveHandlers := new(sync.WaitGroup)
+	liveHandlers := new(network.LiveHandlers)
 	handlersMap := handler.Map{}
 	for _, spec := range params.Specs {
 		handlersMap[spec.MethodName] = wrapWithLimiters(spec, params.Daemon, params.Logger, liveHandlers)

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -189,7 +190,9 @@ func toSnakeCase(s string) string {
 
 // wrapWithLimiters applies the per-method backlog-queue and request-duration
 // limiters (and their metrics) around a single method handler.
-func wrapWithLimiters(spec HandlerSpec, daemon host.Daemon, logger *log.Entry) jrpc2.Handler {
+func wrapWithLimiters(
+	spec HandlerSpec, daemon host.Daemon, logger *log.Entry, detached *sync.WaitGroup,
+) jrpc2.Handler {
 	longName := toSnakeCase(spec.MethodName)
 	queueLimiterGaugeName := longName + "_inflight_requests"
 	queueLimiterGaugeHelp := "Number of concurrenty in-flight " + spec.MethodName + " requests"
@@ -230,15 +233,20 @@ func wrapWithLimiters(spec HandlerSpec, daemon host.Daemon, logger *log.Entry) j
 		spec.RequestDurationLimit,
 		requestDurationWarnCounter,
 		requestDurationLimitCounter,
-		logger)
+		logger,
+		detached)
 	return durationLimiter.Handle
 }
 
 // NewHandler constructs a Handler instance from the given method specs
 func NewHandler(params Params) Handler {
+	// The duration limiter answers at its timeout and leaves its handler
+	// running, so the framing's bound loses sight of it. Both ends of that
+	// share this group: the limiters count into it, Handler.Shutdown joins it.
+	detached := new(sync.WaitGroup)
 	handlersMap := handler.Map{}
 	for _, spec := range params.Specs {
-		handlersMap[spec.MethodName] = wrapWithLimiters(spec, params.Daemon, params.Logger)
+		handlersMap[spec.MethodName] = wrapWithLimiters(spec, params.Daemon, params.Logger, detached)
 	}
 	// The framing at the bottom of the chain. Both mounts use the same one:
 	// internal/jsonrpc/wire, which parses with jrpc2.ParseRequests and then
@@ -250,7 +258,7 @@ func NewHandler(params Params) Handler {
 	framing := wire.NewHandler(decorateHandlers(
 		params.Daemon,
 		params.Logger,
-		handlersMap))
+		handlersMap), detached)
 
 	// globalQueueRequestBacklogLimiter is a metric for measuring the total concurrent inflight requests
 	globalQueueRequestBacklogLimiter := prometheus.NewGauge(prometheus.GaugeOpts{

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
-	"github.com/creachadair/jrpc2/jhttp"
 	"github.com/go-chi/chi/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
@@ -26,6 +25,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/support/log"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/host"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/jsonrpc/wire"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/network"
 )
 
@@ -48,20 +48,15 @@ const (
 	warningThresholdDenominator = 3
 )
 
-// Handler is the HTTP handler which serves the Soroban JSON RPC responses
+// Handler is the HTTP handler which serves the Soroban JSON RPC responses.
+//
+// It owns no background goroutine and no connection, so there is nothing to
+// close: the framing under it (internal/jsonrpc/wire) runs entirely on the
+// calling request's goroutine. The jhttp bridge that used to sit there did own
+// a jrpc2 server goroutine and an in-process client, which is why this type
+// once had a Close method.
 type Handler struct {
 	http.Handler
-
-	bridge jhttp.Bridge
-	logger *log.Entry
-}
-
-// Close closes all the resources held by the Handler instances.
-// After Close is called the Handler instance will stop accepting JSON RPC requests.
-func (h Handler) Close() {
-	if err := h.bridge.Close(); err != nil {
-		h.logger.WithError(err).Warn("could not close bridge")
-	}
 }
 
 // HandlerSpec describes one JSON-RPC method: its handler plus the per-method
@@ -224,24 +219,21 @@ func wrapWithLimiters(spec HandlerSpec, daemon host.Daemon, logger *log.Entry) j
 
 // NewHandler constructs a Handler instance from the given method specs
 func NewHandler(params Params) Handler {
-	bridgeOptions := jhttp.BridgeOptions{
-		Server: &jrpc2.ServerOptions{
-			Logger: func(text string) { params.Logger.Debug(text) },
-			// Disable built-in rpc.* methods (e.g. rpc.serverInfo) that
-			// bypass the handler allowlist and request limiters.
-			DisableBuiltin: true,
-		},
-	}
-
 	handlersMap := handler.Map{}
 	for _, spec := range params.Specs {
 		handlersMap[spec.MethodName] = wrapWithLimiters(spec, params.Daemon, params.Logger)
 	}
-	bridge := jhttp.NewBridge(decorateHandlers(
+	// The framing at the bottom of the chain. Both mounts use the same one:
+	// internal/jsonrpc/wire, which parses with jrpc2.ParseRequests and then
+	// writes its own envelope. Everything assembled around it below — cors, the
+	// 512KB body cap, the request-duration limiter and its buffered response
+	// writer, the global backlog limiter — is unchanged and stays in this
+	// order. The duration limiter is the slow-client decoupler and must remain
+	// OUTSIDE the framing, never beside or under it.
+	framing := wire.NewHandler(decorateHandlers(
 		params.Daemon,
 		params.Logger,
-		handlersMap),
-		&bridgeOptions)
+		handlersMap))
 
 	// globalQueueRequestBacklogLimiter is a metric for measuring the total concurrent inflight requests
 	globalQueueRequestBacklogLimiter := prometheus.NewGauge(prometheus.GaugeOpts{
@@ -249,8 +241,8 @@ func NewHandler(params Params) Handler {
 		Help: "Number of concurrenty in-flight http requests",
 	})
 
-	queueLimitedBridge := network.MakeHTTPBacklogQueueLimiter(
-		bridge,
+	queueLimitedFraming := network.MakeHTTPBacklogQueueLimiter(
+		framing,
 		globalQueueRequestBacklogLimiter,
 		uint64(params.GlobalQueueLimit),
 		params.Logger)
@@ -268,7 +260,7 @@ func NewHandler(params Params) Handler {
 		Help:      "The metric measures the count of requests that surpassed the limit threshold for execution time",
 	})
 	handler := network.MakeHTTPRequestDurationLimiter(
-		queueLimitedBridge,
+		queueLimitedFraming,
 		params.GlobalDurationWarning,
 		params.GlobalDurationLimit,
 		globalQueueRequestExecutionDurationWarningCounter,
@@ -284,9 +276,5 @@ func NewHandler(params Params) Handler {
 		AllowedMethods:         []string{"GET", "PUT", "POST", "PATCH", "DELETE", "HEAD", "OPTIONS"},
 	})
 
-	return Handler{
-		bridge:  bridge,
-		logger:  params.Logger,
-		Handler: corsMiddleware.Handler(handler),
-	}
+	return Handler{Handler: corsMiddleware.Handler(handler)}
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -49,15 +49,18 @@ const (
 )
 
 // Handler is the HTTP handler which serves the Soroban JSON RPC responses.
-//
-// It owns no background goroutine and no connection, so there is nothing to
-// close: the framing under it (internal/jsonrpc/wire) runs entirely on the
-// calling request's goroutine. The jhttp bridge that used to sit there did own
-// a jrpc2 server goroutine and an in-process client, which is why this type
-// once had a Close method.
 type Handler struct {
 	http.Handler
+
+	framing *wire.Handler
 }
+
+// Shutdown cancels the context every method handler runs on and waits for the
+// ones still running, or for ctx to end. Call it after the HTTP server has
+// stopped accepting and BEFORE closing the stores the handlers read: handler
+// contexts are server-scoped, so nothing else ends a request that outlived the
+// HTTP deadline. Idempotent.
+func (h Handler) Shutdown(ctx context.Context) error { return h.framing.Shutdown(ctx) }
 
 // HandlerSpec describes one JSON-RPC method: its handler plus the per-method
 // request limits applied around it.
@@ -296,5 +299,5 @@ func NewHandler(params Params) Handler {
 		AllowedMethods:         []string{"GET", "PUT", "POST", "PATCH", "DELETE", "HEAD", "OPTIONS"},
 	})
 
-	return Handler{Handler: corsMiddleware.Handler(handler)}
+	return Handler{Handler: corsMiddleware.Handler(handler), framing: framing}
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -37,7 +37,7 @@ const (
 	LedgerKeyDecodeMaxMemory   = 16 * 1024   // 16 KB
 	TransactionDecodeMaxMemory = 1024 * 1024 // 1 MB
 
-	// metric label/subsystem names shared across the assembly below
+	// Metric label and subsystem names, shared across the assembly below.
 	subsystemNetwork = "network"
 	labelStatus      = "status"
 
@@ -55,10 +55,11 @@ type Handler struct {
 	framing *wire.Handler
 }
 
-// Shutdown cancels the context every method handler runs on and waits for the
-// ones still running, or for ctx to end. Handler contexts are server-scoped,
-// so nothing else ends a request that outlived the HTTP deadline: call this
-// after the server stops accepting and BEFORE closing the stores it reads.
+// Shutdown cancels the context every method handler runs on, then waits for
+// the ones still running or for ctx to end. Handler contexts are
+// server-scoped, so nothing else ends a handler that outlived its HTTP
+// deadline. Call it after the server stops accepting and before closing the
+// stores it reads.
 func (h Handler) Shutdown(ctx context.Context) error { return h.framing.Shutdown(ctx) }
 
 // HandlerSpec describes one JSON-RPC method: its handler plus the per-method
@@ -82,17 +83,10 @@ type Params struct {
 	GlobalDurationLimit   time.Duration
 }
 
-// decorateHandlers wraps every method with request logging and the duration
-// summary. Each daemon builds its handler once, so creating and registering
-// the collector here happens once per registry.
-// registerOrReuse registers c and returns it, or returns the collector already
-// registered under the same name. Each daemon builds its handler once today,
-// but a second build on the same registry (a reload, a re-bind) must keep
-// counting on the existing series rather than panic on a duplicate.
-//
-// EVERY collector this package builds must go through here. Six families were
-// constructed and never registered between #804 and this commit, so the
-// per-method and global limiter signals did not exist on /metrics at all.
+// registerOrReuse registers c, or returns the collector already registered
+// under the same name so a rebuild keeps counting on the existing series.
+// Every collector this package builds goes through here; one that does not is
+// incremented on every request and never appears on /metrics.
 func registerOrReuse[T prometheus.Collector](registry *prometheus.Registry, c T) T {
 	rerr := registry.Register(c)
 	if rerr == nil {
@@ -109,6 +103,9 @@ func registerOrReuse[T prometheus.Collector](registry *prometheus.Registry, c T)
 	return existing
 }
 
+// decorateHandlers wraps every method with request logging and the duration
+// summary. Each daemon builds its handler once, so the collector is created
+// and registered once per registry.
 func decorateHandlers(daemon host.Daemon, logger *log.Entry, m handler.Map) handler.Map {
 	requestMetric := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace:  daemon.MetricsNamespace(),
@@ -146,11 +143,10 @@ func decorateHandlers(daemon host.Daemon, logger *log.Entry, m handler.Map) hand
 	return decorated
 }
 
-// maxLoggedRequestID bounds the client-controlled text that reaches the log:
-// jrpc2.Request.ID() is the raw id token the client sent, so this field is
-// anything up to the 512KB body cap, once per request at INFO. A quoted UUID
-// is 38 bytes. It bounds what is WRITTEN, not what is copied — ID() has
-// already copied the token, and jrpc2 exposes no length accessor.
+// maxLoggedRequestID caps the client-controlled text reaching the log.
+// jrpc2.Request.ID() is the raw id token, up to the body cap, written once per
+// request at INFO; a quoted UUID is 38 bytes. It caps what is written, not
+// what is copied: ID() has already copied the token and exposes no length.
 const maxLoggedRequestID = 64
 
 func loggedRequestID(req *jrpc2.Request) string {
@@ -199,15 +195,11 @@ func toSnakeCase(s string) string {
 }
 
 // wrapWithLimiters applies the per-method backlog-queue and request-duration
-// limiters (and their metrics) around a single method handler.
-//
-// LOAD-BEARING nesting: the backlog limiter wraps spec.Handler and the
-// duration limiter wraps queueLimiter.Handle, so the backlog slot is held
-// ACROSS the real call — including after the duration limiter has answered its
-// timeout and walked away from it. That is the only thing bounding live
-// handler bodies (QueueLimit per method); the wire semaphore counts
-// dispatches and cannot see them. Swap the two and the slot is released when
-// the wrapper returns, bounding nothing.
+// limiters, and their metrics, around one method handler. The nesting order is
+// load-bearing: the backlog limiter wraps the handler and the duration limiter
+// wraps that, so the backlog slot is held across the real call and bounds live
+// handler bodies at QueueLimit. Swapped, it releases on return and bounds
+// nothing.
 func wrapWithLimiters(
 	spec HandlerSpec, daemon host.Daemon, logger *log.Entry, liveHandlers *network.LiveHandlers,
 ) jrpc2.Handler {
@@ -243,7 +235,7 @@ func wrapWithLimiters(
 		Name: durationLimitCounterName,
 		Help: durationLimitCounterHelp,
 	})
-	// set the warning threshold to be one third of the limit.
+	// The warning threshold is one third of the limit.
 	requestDurationWarn := spec.RequestDurationLimit / warningThresholdDenominator
 	durationLimiter := network.MakeJrpcRequestDurationLimiter(
 		queueLimiter.Handle,
@@ -256,23 +248,20 @@ func wrapWithLimiters(
 	return durationLimiter.Handle
 }
 
-// NewHandler constructs a Handler instance from the given method specs
+// NewHandler constructs a Handler from the given method specs.
 func NewHandler(params Params) Handler {
-	// The duration limiter answers at its timeout and leaves its handler
-	// running, so the framing's bound loses sight of it. Both ends of that
-	// share this group: the limiters count into it, Handler.Shutdown joins it.
+	// A duration limiter answering at its timeout leaves its handler running,
+	// out of the framing's sight. The limiters count into this group and
+	// Handler.Shutdown waits on it.
 	liveHandlers := new(network.LiveHandlers)
 	handlersMap := handler.Map{}
 	for _, spec := range params.Specs {
 		handlersMap[spec.MethodName] = wrapWithLimiters(spec, params.Daemon, params.Logger, liveHandlers)
 	}
-	// The framing at the bottom of the chain. Both mounts use the same one:
-	// internal/jsonrpc/wire, which parses with jrpc2.ParseRequests and then
-	// writes its own envelope. Everything assembled around it below — cors, the
-	// 512KB body cap, the request-duration limiter and its buffered response
-	// writer, the global backlog limiter — is unchanged and stays in this
-	// order. The duration limiter is the slow-client decoupler and must remain
-	// OUTSIDE the framing, never beside or under it.
+	// The framing at the bottom of the chain, shared by both mounts. What is
+	// assembled around it below stays in this order: cors, the body cap, the
+	// request-duration limiter with its buffered writer, the global backlog
+	// limiter. The duration limiter must stay outside the framing.
 	framing := wire.NewHandler(decorateHandlers(
 		params.Daemon,
 		params.Logger,

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -86,6 +86,30 @@ type Params struct {
 // decorateHandlers wraps every method with request logging and the duration
 // summary. Each daemon builds its handler once, so creating and registering
 // the collector here happens once per registry.
+// registerOrReuse registers c and returns it, or returns the collector already
+// registered under the same name. Each daemon builds its handler once today,
+// but a second build on the same registry (a reload, a re-bind) must keep
+// counting on the existing series rather than panic on a duplicate.
+//
+// EVERY collector this package builds must go through here. Six families were
+// constructed and never registered between #804 and this commit, so the
+// per-method and global limiter signals did not exist on /metrics at all.
+func registerOrReuse[T prometheus.Collector](registry *prometheus.Registry, c T) T {
+	rerr := registry.Register(c)
+	if rerr == nil {
+		return c
+	}
+	are := prometheus.AlreadyRegisteredError{}
+	if !errors.As(rerr, &are) {
+		panic(rerr)
+	}
+	existing, ok := are.ExistingCollector.(T)
+	if !ok {
+		panic(rerr)
+	}
+	return existing
+}
+
 func decorateHandlers(daemon host.Daemon, logger *log.Entry, m handler.Map) handler.Map {
 	requestMetric := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace:  daemon.MetricsNamespace(),
@@ -94,20 +118,7 @@ func decorateHandlers(daemon host.Daemon, logger *log.Entry, m handler.Map) hand
 		Help:       "JSON RPC request duration",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, []string{"endpoint", labelStatus})
-	// Register-or-reuse: each daemon builds its handler once today, but a
-	// second build on the same registry (a future reload or re-bind) must keep
-	// counting on the existing series, not panic on duplicate registration.
-	if rerr := daemon.MetricsRegistry().Register(requestMetric); rerr != nil {
-		are := prometheus.AlreadyRegisteredError{}
-		if !errors.As(rerr, &are) {
-			panic(rerr)
-		}
-		existing, ok := are.ExistingCollector.(*prometheus.SummaryVec)
-		if !ok {
-			panic(rerr)
-		}
-		requestMetric = existing
-	}
+	requestMetric = registerOrReuse(daemon.MetricsRegistry(), requestMetric)
 	decorated := handler.Map{}
 	for endpoint, h := range m {
 		decorated[endpoint] = handler.New(func(ctx context.Context, r *jrpc2.Request) (any, error) {
@@ -204,7 +215,7 @@ func wrapWithLimiters(
 	})
 	queueLimiter := network.MakeJrpcBacklogQueueLimiter(
 		spec.Handler,
-		queueLimiterGauge,
+		registerOrReuse(daemon.MetricsRegistry(), queueLimiterGauge),
 		uint64(spec.QueueLimit),
 		logger)
 
@@ -231,8 +242,8 @@ func wrapWithLimiters(
 		queueLimiter.Handle,
 		requestDurationWarn,
 		spec.RequestDurationLimit,
-		requestDurationWarnCounter,
-		requestDurationLimitCounter,
+		registerOrReuse(daemon.MetricsRegistry(), requestDurationWarnCounter),
+		registerOrReuse(daemon.MetricsRegistry(), requestDurationLimitCounter),
 		logger,
 		detached)
 	return durationLimiter.Handle
@@ -268,7 +279,7 @@ func NewHandler(params Params) Handler {
 
 	queueLimitedFraming := network.MakeHTTPBacklogQueueLimiter(
 		framing,
-		globalQueueRequestBacklogLimiter,
+		registerOrReuse(params.Daemon.MetricsRegistry(), globalQueueRequestBacklogLimiter),
 		uint64(params.GlobalQueueLimit),
 		params.Logger)
 
@@ -288,8 +299,8 @@ func NewHandler(params Params) Handler {
 		queueLimitedFraming,
 		params.GlobalDurationWarning,
 		params.GlobalDurationLimit,
-		globalQueueRequestExecutionDurationWarningCounter,
-		globalQueueRequestExecutionDurationLimitCounter,
+		registerOrReuse(params.Daemon.MetricsRegistry(), globalQueueRequestExecutionDurationWarningCounter),
+		registerOrReuse(params.Daemon.MetricsRegistry(), globalQueueRequestExecutionDurationLimitCounter),
 		params.Logger)
 
 	handler = http.MaxBytesHandler(handler, maxHTTPRequestSize)

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -141,10 +141,11 @@ func decorateHandlers(daemon host.Daemon, logger *log.Entry, m handler.Map) hand
 const maxLoggedRequestID = 64
 
 func loggedRequestID(req *jrpc2.Request) string {
-	if id := req.ID(); len(id) <= maxLoggedRequestID {
+	id := req.ID()
+	if len(id) <= maxLoggedRequestID {
 		return id
 	}
-	return req.ID()[:maxLoggedRequestID] + "…(truncated)"
+	return id[:maxLoggedRequestID] + "…(truncated)"
 }
 
 func logRequest(logger *log.Entry, reqID string, req *jrpc2.Request) {

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -201,8 +201,16 @@ func toSnakeCase(s string) string {
 
 // wrapWithLimiters applies the per-method backlog-queue and request-duration
 // limiters (and their metrics) around a single method handler.
+//
+// LOAD-BEARING nesting: the backlog limiter wraps spec.Handler and the
+// duration limiter wraps queueLimiter.Handle, so the backlog slot is held
+// ACROSS the real call — including after the duration limiter has answered its
+// timeout and walked away from it. That is the only thing bounding live
+// handler bodies (QueueLimit per method); the wire semaphore counts
+// dispatches and cannot see them. Swap the two and the slot is released when
+// the wrapper returns, bounding nothing.
 func wrapWithLimiters(
-	spec HandlerSpec, daemon host.Daemon, logger *log.Entry, detached *sync.WaitGroup,
+	spec HandlerSpec, daemon host.Daemon, logger *log.Entry, liveHandlers *sync.WaitGroup,
 ) jrpc2.Handler {
 	longName := toSnakeCase(spec.MethodName)
 	queueLimiterGaugeName := longName + "_inflight_requests"
@@ -245,7 +253,7 @@ func wrapWithLimiters(
 		registerOrReuse(daemon.MetricsRegistry(), requestDurationWarnCounter),
 		registerOrReuse(daemon.MetricsRegistry(), requestDurationLimitCounter),
 		logger,
-		detached)
+		liveHandlers)
 	return durationLimiter.Handle
 }
 
@@ -254,10 +262,10 @@ func NewHandler(params Params) Handler {
 	// The duration limiter answers at its timeout and leaves its handler
 	// running, so the framing's bound loses sight of it. Both ends of that
 	// share this group: the limiters count into it, Handler.Shutdown joins it.
-	detached := new(sync.WaitGroup)
+	liveHandlers := new(sync.WaitGroup)
 	handlersMap := handler.Map{}
 	for _, spec := range params.Specs {
-		handlersMap[spec.MethodName] = wrapWithLimiters(spec, params.Daemon, params.Logger, detached)
+		handlersMap[spec.MethodName] = wrapWithLimiters(spec, params.Daemon, params.Logger, liveHandlers)
 	}
 	// The framing at the bottom of the chain. Both mounts use the same one:
 	// internal/jsonrpc/wire, which parses with jrpc2.ParseRequests and then
@@ -269,7 +277,7 @@ func NewHandler(params Params) Handler {
 	framing := wire.NewHandler(decorateHandlers(
 		params.Daemon,
 		params.Logger,
-		handlersMap), detached)
+		handlersMap), liveHandlers)
 
 	// globalQueueRequestBacklogLimiter is a metric for measuring the total concurrent inflight requests
 	globalQueueRequestBacklogLimiter := prometheus.NewGauge(prometheus.GaugeOpts{

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -133,11 +133,25 @@ func decorateHandlers(daemon host.Daemon, logger *log.Entry, m handler.Map) hand
 	return decorated
 }
 
+// maxLoggedRequestID bounds the client-controlled text that reaches the log.
+// jrpc2.Request.ID() is the raw JSON id token the client sent; under the jhttp
+// bridge it was the bridge's own virtualized counter instead, so this field
+// used to be a couple of bytes and is now anything up to the 512KB body cap,
+// once per request at INFO. Every sane id fits (a quoted UUID is 38 bytes).
+const maxLoggedRequestID = 64
+
+func loggedRequestID(req *jrpc2.Request) string {
+	if id := req.ID(); len(id) <= maxLoggedRequestID {
+		return id
+	}
+	return req.ID()[:maxLoggedRequestID] + "…(truncated)"
+}
+
 func logRequest(logger *log.Entry, reqID string, req *jrpc2.Request) {
 	logger = logger.WithFields(log.F{
 		"subsys":   "jsonrpc",
 		"req":      reqID,
-		"json_req": req.ID(),
+		"json_req": loggedRequestID(req),
 		"method":   req.Method(),
 	})
 	logger.Info("starting JSONRPC request")

--- a/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/jsonrpc.go
@@ -138,6 +138,11 @@ func decorateHandlers(daemon host.Daemon, logger *log.Entry, m handler.Map) hand
 // bridge it was the bridge's own virtualized counter instead, so this field
 // used to be a couple of bytes and is now anything up to the 512KB body cap,
 // once per request at INFO. Every sane id fits (a quoted UUID is 38 bytes).
+//
+// This bounds what is WRITTEN, not what is copied: jrpc2.Request.ID() is
+// string(r.id) and has already copied the whole token by the time it returns.
+// jrpc2 exposes no length or zero-copy accessor, so the copy stays; the log
+// volume, which is the part that reaches a disk, does not.
 const maxLoggedRequestID = 64
 
 func loggedRequestID(req *jrpc2.Request) string {

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -122,7 +122,8 @@ func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
 	})
 }
 
-// A client that hangs up mid-call does not cancel the work.
+// A client's disconnect does not cancel a handler; the method budget does.
+// This mount gives the method no budget, so nothing cancels it at all.
 func TestMount_HandlerContextIsNotTheRequestContext(t *testing.T) {
 	type outcome struct {
 		deadline bool

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -572,3 +572,56 @@ func TestMount_LimiterMetricsAreRegistered(t *testing.T) {
 		})
 	})
 }
+
+// DELTA (c), scoped. A notification's work has finished when its 204 lands —
+// unless its method budget expired first, in which case the limiter answered
+// and walked away, and the 204 precedes the side effects. Not joined here on
+// purpose: see invoke. The child stays tracked, so Shutdown still covers it.
+func TestMount_ANotificationOverItsBudgetIsAnsweredAtBudget(t *testing.T) {
+	const budget = 200 * time.Millisecond
+	release := make(chan struct{})
+	defer close(release)
+	var slowFinished, quickFinished atomic.Bool
+
+	url, handler := newMountedHandlerAndHandle(t, time.Minute, []HandlerSpec{{
+		MethodName: "slowNote",
+		Handler: func(context.Context, *jrpc2.Request) (any, error) {
+			<-release
+			slowFinished.Store(true)
+			return "late", nil
+		},
+		QueueLimit:           10,
+		RequestDurationLimit: budget,
+	}, {
+		MethodName: "quickNote",
+		Handler: func(context.Context, *jrpc2.Request) (any, error) {
+			quickFinished.Store(true)
+			return "ok", nil
+		},
+		QueueLimit:           10,
+		RequestDurationLimit: time.Minute,
+	}})
+
+	// The original property, still true within budget.
+	status, _ := postMounted(t, url, `{"jsonrpc":"2.0","method":"quickNote"}`)
+	require.Equal(t, http.StatusNoContent, status)
+	assert.True(t, quickFinished.Load(), "a within-budget notification must run before its 204")
+
+	// Over budget: answered at the budget, not at completion.
+	start := time.Now()
+	status, body := postMounted(t, url, `[{"jsonrpc":"2.0","method":"slowNote"}]`)
+	answered := time.Since(start)
+
+	require.Equal(t, http.StatusNoContent, status)
+	assert.Empty(t, body)
+	t.Logf("204 after %v against a %v budget", answered, budget)
+	assert.GreaterOrEqual(t, answered, budget, "the 204 did not wait for the budget: the handler never ran")
+	assert.Less(t, answered, 4*budget, "the 204 waited for the handler instead of the budget")
+	assert.False(t, slowFinished.Load(), "the handler finished on its own; this pins nothing")
+
+	// Abandoned, but still counted: the drain sees it even though the 204 did not.
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+	assert.Error(t, handler.Shutdown(ctx),
+		"an abandoned notification is not tracked by liveHandlers")
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -378,4 +379,59 @@ func TestMount_ShutdownEndsWhatTheDeadlineDidNot(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("Shutdown did not end a handler the deadline had abandoned")
 	}
+}
+
+// A handler that ignores cancellation and outruns its per-method budget is
+// answered -32001 and ABANDONED: the duration limiter returns without joining
+// it, so its wire permit is back long before Shutdown starts. Draining the
+// bound alone would prove nothing about it.
+func TestMount_ShutdownJoinsATimedOutHandler(t *testing.T) {
+	const budget = 200 * time.Millisecond
+
+	// stuckMount answers one request, whose handler then parks on release.
+	stuckMount := func(t *testing.T, release <-chan struct{}, done *atomic.Bool) Handler {
+		t.Helper()
+		url, handler := newMountedHandlerAndHandle(t, time.Minute, []HandlerSpec{{
+			MethodName: "stuck",
+			Handler: func(context.Context, *jrpc2.Request) (any, error) {
+				<-release
+				done.Store(true)
+				return "late", nil
+			},
+			QueueLimit:           10,
+			RequestDurationLimit: budget,
+		}})
+		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":1,"method":"stuck"}`)
+		require.Equal(t, http.StatusOK, status)
+		require.Contains(t, body, "-32001", "the method budget did not fire")
+		return handler
+	}
+
+	t.Run("reports the straggler when the drain budget runs out", func(t *testing.T) {
+		release := make(chan struct{})
+		defer close(release)
+		var done atomic.Bool
+		handler := stuckMount(t, release, &done)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+		defer cancel()
+		err := handler.Shutdown(ctx)
+
+		require.Error(t, err, "the drain claimed success while an abandoned handler was still running")
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.False(t, done.Load())
+	})
+
+	t.Run("returns only once the straggler has finished", func(t *testing.T) {
+		release := make(chan struct{})
+		var done atomic.Bool
+		handler := stuckMount(t, release, &done)
+
+		time.AfterFunc(2*budget, func() { close(release) })
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		require.NoError(t, handler.Shutdown(ctx))
+		assert.True(t, done.Load(), "Shutdown returned before the abandoned handler finished")
+	})
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -435,3 +435,75 @@ func TestMount_ShutdownJoinsATimedOutHandler(t *testing.T) {
 		assert.True(t, done.Load(), "Shutdown returned before the abandoned handler finished")
 	})
 }
+
+// The wiring invariant both daemons now hold: connections dead BEFORE the
+// drain. DELTA (g) gates an element's start on the request's context, so a
+// live connection mid-batch keeps authorizing starts and the drain chases a
+// moving target. Closing the connections kills those contexts first.
+func TestMount_ClosedConnectionsStopTheDispatchBeforeTheDrain(t *testing.T) {
+	weight := runtime.GOMAXPROCS(0)
+	elements := 4 * weight
+	entered := make(chan struct{}, elements)
+	release := make(chan struct{})
+	var started atomic.Int64
+
+	handler := NewHandler(Params{
+		Daemon: host.MakeNoOpDaemon(), Logger: mountLogger(), GlobalQueueLimit: 100,
+		GlobalDurationWarning: time.Minute, GlobalDurationLimit: time.Minute,
+		Specs: []HandlerSpec{{
+			MethodName: "hold",
+			Handler: func(context.Context, *jrpc2.Request) (any, error) {
+				started.Add(1)
+				entered <- struct{}{}
+				<-release
+				return "done", nil
+			},
+			QueueLimit:           1000,
+			RequestDurationLimit: time.Minute,
+		}},
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	body := make([]string, elements)
+	for i := range body {
+		body[i] = fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"hold"}`, i+1)
+	}
+	go func() {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL,
+			strings.NewReader("["+strings.Join(body, ",")+"]"))
+		if err != nil {
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if res, derr := http.DefaultClient.Do(req); derr == nil {
+			_, _ = io.Copy(io.Discard, res.Body)
+			res.Body.Close()
+		}
+	}()
+
+	// Bound saturated: the dispatch loop is parked in Acquire with most of the
+	// batch still queued behind it.
+	for range weight {
+		select {
+		case <-entered:
+		case <-time.After(10 * time.Second):
+			close(release)
+			t.Fatal("the batch never saturated the bound")
+		}
+	}
+
+	srv.CloseClientConnections() // the request contexts die with them
+	time.Sleep(250 * time.Millisecond)
+	atClose := started.Load()
+	close(release)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, handler.Shutdown(ctx), "the drain did not converge after the connections closed")
+
+	t.Logf("started %d of %d elements at a bound of %d", started.Load(), elements, weight)
+	assert.Equal(t, atClose, started.Load(), "elements started after the connections were closed")
+	assert.LessOrEqual(t, atClose, int64(weight+1),
+		"the dispatch kept going past the bound while its connection was dead")
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -230,8 +230,8 @@ func TestMount_ABatchOfSlowCallsFitsTheOneHTTPDeadline(t *testing.T) {
 		perCall     = 400 * time.Millisecond
 		elements    = 4
 	)
-	if runtime.NumCPU() < elements {
-		t.Skip("needs at least one permit per batch element")
+	if runtime.GOMAXPROCS(0) < elements {
+		t.Skip("needs at least one permit per batch element; the wire bound is GOMAXPROCS")
 	}
 
 	url := newMountedHandler(t, globalLimit, []HandlerSpec{{
@@ -266,4 +266,66 @@ func TestMount_ABatchOfSlowCallsFitsTheOneHTTPDeadline(t *testing.T) {
 	require.Equal(t, http.StatusOK, status,
 		"a batch of %d %v calls did not fit a %v budget: the elements ran serially", elements, perCall, globalLimit)
 	assert.Equal(t, want.String(), got)
+}
+
+// The panic path, pinned at the mount, because which layer catches a handler
+// panic decides what the client sees and there are two candidate layers in the
+// chain.
+//
+// jrpc2 recovered nothing: under the bridge a panic from a method with no
+// duration budget unwound on a goroutine the jrpc2.Server owned and took the
+// PROCESS with it. Here the chain's own recover answers 500 and the mount
+// keeps serving — and a batch element's panic has to be relayed to the serving
+// goroutine to get that, since nothing above a worker recovers.
+func TestMount_HandlerPanics(t *testing.T) {
+	boom := func(context.Context, *jrpc2.Request) (any, error) { panic("handler exploded") }
+	url := newMountedHandler(t, time.Minute, []HandlerSpec{{
+		MethodName:           "boomBudgeted",
+		Handler:              boom,
+		QueueLimit:           10,
+		RequestDurationLimit: time.Minute,
+	}, {
+		MethodName: "boomUnbudgeted",
+		Handler:    boom,
+		QueueLimit: 10,
+		// The only configuration in which a panic reaches the framing at all.
+		// No method either daemon registers is built this way.
+		RequestDurationLimit: network.RequestDurationLimiterNoLimit,
+	}, {
+		MethodName:           "fast",
+		Handler:              func(context.Context, *jrpc2.Request) (any, error) { return map[string]int{"n": 7}, nil },
+		QueueLimit:           10,
+		RequestDurationLimit: time.Minute,
+	}})
+
+	stillServing := func(t *testing.T, id string) {
+		t.Helper()
+		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":`+id+`,"method":"fast"}`)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, `{"jsonrpc":"2.0","id":`+id+`,"result":{"n":7}}`, body)
+	}
+
+	t.Run("a method with a duration budget answers -32003; the panic never reaches the framing", func(t *testing.T) {
+		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":1,"method":"boomBudgeted"}`)
+		assert.Equal(t, http.StatusOK, status)
+		//nolint:testifylint // byte-exact wire pin; JSONEq would ignore key order and escaping
+		assert.Equal(t, `{"jsonrpc":"2.0","id":1,"error":{"code":-32003,`+
+			`"message":"[-32003] request failed to process due to internal issue"}}`, body)
+		stillServing(t, "2")
+	})
+
+	t.Run("a method with no budget fails the request with 500 and no body", func(t *testing.T) {
+		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":3,"method":"boomUnbudgeted"}`)
+		assert.Equal(t, http.StatusInternalServerError, status)
+		assert.Empty(t, body, "the limiter's 500 discards the response buffer rather than writing a partial one")
+		stillServing(t, "4")
+	})
+
+	t.Run("a panicking batch element fails its batch, not the process", func(t *testing.T) {
+		status, body := postMounted(t, url,
+			`[{"jsonrpc":"2.0","id":5,"method":"fast"},{"jsonrpc":"2.0","id":6,"method":"boomUnbudgeted"}]`)
+		assert.Equal(t, http.StatusInternalServerError, status)
+		assert.Empty(t, body)
+		stillServing(t, "7")
+	})
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/network"
 )
 
-// The framing is only correct WHERE IT IS MOUNTED: inside the shared chain.
-// NewHandler builds one, so these cover both daemons.
+// The framing is only correct mounted inside the shared chain; NewHandler
+// builds one, so these cover both daemons.
 
 func mountLogger() *log.Entry {
 	l := log.New()
@@ -122,8 +122,8 @@ func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
 	})
 }
 
-// A client's disconnect does not cancel a handler; the method budget does.
-// This mount gives the method no budget, so nothing cancels it at all.
+// A client's disconnect does not cancel a handler; this mount gives the method
+// no budget, so nothing cancels it at all.
 func TestMount_HandlerContextIsNotTheRequestContext(t *testing.T) {
 	type outcome struct {
 		deadline bool
@@ -139,8 +139,7 @@ func TestMount_HandlerContextIsNotTheRequestContext(t *testing.T) {
 			return "ok", nil
 		},
 		QueueLimit: 10,
-		// No per-method budget, so nothing between Background and the handler
-		// adds a deadline of its own.
+		// No per-method budget, so nothing adds a deadline.
 		RequestDurationLimit: network.RequestDurationLimiterNoLimit,
 	}})
 
@@ -342,8 +341,7 @@ func TestMount_AStartedElementSurvivesTheDeadline(t *testing.T) {
 	}
 }
 
-// The deadline answers the client and leaves the handler running; only
-// Shutdown ends it.
+// The deadline leaves the handler running; only Shutdown ends it.
 func TestMount_ShutdownEndsWhatTheDeadlineDidNot(t *testing.T) {
 	const limit = 300 * time.Millisecond
 	entered := make(chan struct{}, 1)
@@ -383,10 +381,8 @@ func TestMount_ShutdownEndsWhatTheDeadlineDidNot(t *testing.T) {
 	}
 }
 
-// A handler that ignores cancellation and outruns its per-method budget is
-// answered -32001 and ABANDONED: the duration limiter returns without joining
-// it, so its wire permit is back long before Shutdown starts. Draining the
-// bound alone would prove nothing about it.
+// An over-budget handler that ignores cancellation is abandoned with its
+// permit returned, so draining the bound alone proves nothing about it.
 func TestMount_ShutdownJoinsATimedOutHandler(t *testing.T) {
 	const budget = 200 * time.Millisecond
 
@@ -438,10 +434,8 @@ func TestMount_ShutdownJoinsATimedOutHandler(t *testing.T) {
 	})
 }
 
-// The wiring invariant both daemons now hold: connections dead BEFORE the
-// drain. DELTA (g) gates an element's start on the request's context, so a
-// live connection mid-batch keeps authorizing starts and the drain chases a
-// moving target. Closing the connections kills those contexts first.
+// Connections dead before the drain: a live one keeps authorizing element
+// starts, so the drain chases a moving target.
 func TestMount_ClosedConnectionsStopTheDispatchBeforeTheDrain(t *testing.T) {
 	weight := runtime.GOMAXPROCS(0)
 	elements := 4 * weight
@@ -484,8 +478,7 @@ func TestMount_ClosedConnectionsStopTheDispatchBeforeTheDrain(t *testing.T) {
 		}
 	}()
 
-	// Bound saturated: the dispatch loop is parked in Acquire with most of the
-	// batch still queued behind it.
+	// Bound saturated: the loop is parked in Acquire, most of the batch to go.
 	for range weight {
 		select {
 		case <-entered:
@@ -510,9 +503,8 @@ func TestMount_ClosedConnectionsStopTheDispatchBeforeTheDrain(t *testing.T) {
 		"the dispatch kept going past the bound while its connection was dead")
 }
 
-// stableRegistryDaemon is MakeNoOpDaemon with a registry that does not change
-// between calls. NoOpDaemon hands out a fresh one per call so tests can
-// register repeatedly, which also makes registration unobservable.
+// stableRegistryDaemon is MakeNoOpDaemon with a registry that survives between
+// calls; NoOpDaemon hands out a fresh one, which hides registration.
 type stableRegistryDaemon struct {
 	*host.NoOpDaemon
 
@@ -521,11 +513,8 @@ type stableRegistryDaemon struct {
 
 func (d stableRegistryDaemon) MetricsRegistry() *prometheus.Registry { return d.registry }
 
-// Six metric families were built and never registered between #804 (2023) and
-// the commit that added this test, so the per-method and global limiter
-// signals did not exist on /metrics at all — including
-// <method>_inflight_requests, which is the count of live handler bodies and
-// the operator's only view of the population the drain waits for.
+// Six limiter metric families were built and never registered, so they were
+// incremented on every request and never reached /metrics.
 func TestMount_LimiterMetricsAreRegistered(t *testing.T) {
 	daemon := stableRegistryDaemon{host.MakeNoOpDaemon(), prometheus.NewRegistry()}
 	NewHandler(Params{
@@ -573,10 +562,8 @@ func TestMount_LimiterMetricsAreRegistered(t *testing.T) {
 	})
 }
 
-// DELTA (c), scoped. A notification's work has finished when its 204 lands —
-// unless its method budget expired first, in which case the limiter answered
-// and walked away, and the 204 precedes the side effects. Not joined here on
-// purpose: see invoke. The child stays tracked, so Shutdown still covers it.
+// Delta (c) scoped: an over-budget notification's 204 precedes its side
+// effects, and the abandoned child stays tracked for Shutdown.
 func TestMount_ANotificationOverItsBudgetIsAnsweredAtBudget(t *testing.T) {
 	const budget = 200 * time.Millisecond
 	release := make(chan struct{})

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -75,8 +75,12 @@ func postMounted(t *testing.T, url, body string) (int, string) {
 //nolint:testifylint // byte-exact wire pins; JSONEq would ignore key order and escaping
 func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
 	const limit = 500 * time.Millisecond
+	// The slow handler holds a wire permit for as long as it runs, and the
+	// bound is GOMAXPROCS — one, on a single-CPU runner. So it is released and
+	// joined at the end of its own subtest rather than at cleanup; leaving it
+	// parked would 504 every subtest after it.
 	blocked := make(chan struct{})
-	t.Cleanup(func() { close(blocked) })
+	slowReturned := make(chan struct{}, 1)
 
 	url := newMountedHandler(t, limit, []HandlerSpec{{
 		MethodName: "fast",
@@ -88,6 +92,7 @@ func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
 	}, {
 		MethodName: "slow",
 		Handler: func(ctx context.Context, _ *jrpc2.Request) (any, error) {
+			defer func() { slowReturned <- struct{}{} }()
 			select {
 			case <-blocked:
 			case <-ctx.Done():
@@ -112,6 +117,16 @@ func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
 		assert.Equal(t, http.StatusGatewayTimeout, status)
 		assert.Empty(t, body, "the duration limiter answers before the framing writes anything")
 		assert.Less(t, time.Since(start), 30*time.Second)
+
+		// The 504 answered the client; the handler goroutine is still live and
+		// still holds its permit. Release it and wait, so the bound is whole
+		// again for the subtests below.
+		close(blocked)
+		select {
+		case <-slowReturned:
+		case <-time.After(10 * time.Second):
+			t.Fatal("the slow handler never returned after its channel was closed")
+		}
 	})
 
 	t.Run("the mount keeps serving after a timed-out request", func(t *testing.T) {

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -23,9 +23,8 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/network"
 )
 
-// The framing is only correct WHERE IT IS MOUNTED: inside the shared chain
-// (cors -> 512KB cap -> duration limiter and its buffered writer -> backlog
-// limiter -> framing). NewHandler builds one, so these cover both daemons.
+// The framing is only correct WHERE IT IS MOUNTED: inside the shared chain.
+// NewHandler builds one, so these cover both daemons.
 
 func mountLogger() *log.Entry {
 	l := log.New()
@@ -88,8 +87,7 @@ func fastSpec() HandlerSpec {
 
 //nolint:testifylint // byte-exact wire pins; JSONEq would ignore key order and escaping
 func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
-	// No parking handler: it would hold the only permit on a single-CPU
-	// runner. The 504 path has its own mount below.
+	// No parking handler: it would hold the only permit on one CPU.
 	url := newMountedHandler(t, time.Minute, []HandlerSpec{fastSpec()})
 
 	t.Run("a normal call gets its framed body, id escaped as the bridge escaped it", func(t *testing.T) {
@@ -122,8 +120,7 @@ func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
 	})
 }
 
-// Handlers see a server-scoped context, so a client that hangs up mid-call
-// does not cancel the work — sendTransaction included.
+// A client that hangs up mid-call does not cancel the work.
 func TestMount_HandlerContextIsNotTheRequestContext(t *testing.T) {
 	type outcome struct {
 		deadline bool
@@ -154,8 +151,7 @@ func TestMount_HandlerContextIsNotTheRequestContext(t *testing.T) {
 	assert.NoError(t, got.err)
 }
 
-// A frame the mount produces must be what a JSON-RPC client parses: the belt
-// to the byte-pins' braces.
+// A frame the mount produces must be what a JSON-RPC client parses.
 func TestMount_FramesParseAsJSONRPC(t *testing.T) {
 	url := newMountedHandler(t, time.Minute, []HandlerSpec{{
 		MethodName:           "fast",
@@ -180,8 +176,7 @@ func TestMount_FramesParseAsJSONRPC(t *testing.T) {
 	assert.Nil(t, frame.Error)
 }
 
-// The slow-client decoupler, on a mount of its own: a parked handler holds its
-// permit, and that bound is one on a single-CPU runner.
+// The slow-client decoupler, on its own mount: a parked handler holds a permit.
 //
 //nolint:testifylint // byte-exact wire pins; JSONEq would ignore key order and escaping
 func TestMount_ASlowCallGets504AndTheMountRecovers(t *testing.T) {
@@ -200,8 +195,7 @@ func TestMount_ASlowCallGets504AndTheMountRecovers(t *testing.T) {
 			return eventually, nil
 		},
 		QueueLimit: 10,
-		// Longer than the global limit, so the HTTP-level limiter is the one
-		// that answers and the 504 path is the one under test.
+		// Longer than the global limit, so the HTTP limiter answers.
 		RequestDurationLimit: time.Minute,
 	}})
 
@@ -211,8 +205,7 @@ func TestMount_ASlowCallGets504AndTheMountRecovers(t *testing.T) {
 	assert.Empty(t, body, "the duration limiter answers before the framing writes anything")
 	assert.Less(t, time.Since(start), 30*time.Second)
 
-	// The client has its 504 and the handler still holds its permit — the
-	// documented shape (DELTA (g)) — so serving resumes once it finishes.
+	// The handler still holds its permit (DELTA (g)), so join it first.
 	close(blocked)
 	select {
 	case <-returned:
@@ -225,8 +218,7 @@ func TestMount_ASlowCallGets504AndTheMountRecovers(t *testing.T) {
 	assert.Equal(t, `{"jsonrpc":"2.0","id":2,"result":{"n":7}}`, body)
 }
 
-// The mount enforces ONE deadline for the whole request, so a serial batch
-// sums its elements against it. Calls that each fit must fit together.
+// ONE deadline for the whole request: calls that each fit must fit together.
 func TestMount_ABatchOfSlowCallsFitsTheOneHTTPDeadline(t *testing.T) {
 	const (
 		globalLimit = time.Second
@@ -262,8 +254,7 @@ func TestMount_ABatchOfSlowCallsFitsTheOneHTTPDeadline(t *testing.T) {
 	assert.Equal(t, "["+strings.Join(want, ",")+"]", got)
 }
 
-// Which layer catches a handler panic decides what the client sees. A batch
-// element's panic must be relayed to the serving goroutine to reach either.
+// Which layer catches a handler panic decides what the client sees.
 func TestMount_HandlerPanics(t *testing.T) {
 	boom := func(context.Context, *jrpc2.Request) (any, error) { panic("handler exploded") }
 	url := newMountedHandler(t, time.Minute, []HandlerSpec{{
@@ -275,8 +266,7 @@ func TestMount_HandlerPanics(t *testing.T) {
 		MethodName: "boomUnbudgeted",
 		Handler:    boom,
 		QueueLimit: 10,
-		// The only configuration in which a panic reaches the framing. No
-		// method either daemon registers is built this way.
+		// The only configuration in which a panic reaches the framing.
 		RequestDurationLimit: network.RequestDurationLimiterNoLimit,
 	}, {
 		MethodName:           "fast",
@@ -317,8 +307,7 @@ func TestMount_HandlerPanics(t *testing.T) {
 	})
 }
 
-// DELTA (g), the half that does not stop: the deadline ends the DISPATCH, not
-// the work, which is what sendTransaction depends on.
+// DELTA (g): the deadline ends the DISPATCH, not the work.
 func TestMount_AStartedElementSurvivesTheDeadline(t *testing.T) {
 	const limit = 300 * time.Millisecond
 	finished := make(chan error, 1)
@@ -350,8 +339,8 @@ func TestMount_AStartedElementSurvivesTheDeadline(t *testing.T) {
 	}
 }
 
-// The two halves of the handler lifetime: the HTTP deadline answers the client
-// and leaves the handler running, and only Shutdown ends it.
+// The deadline answers the client and leaves the handler running; only
+// Shutdown ends it.
 func TestMount_ShutdownEndsWhatTheDeadlineDidNot(t *testing.T) {
 	const limit = 300 * time.Millisecond
 	entered := make(chan struct{}, 1)

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -1,0 +1,204 @@
+package jsonrpc
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/host"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/network"
+)
+
+// The framing is only correct if it is correct WHERE IT IS MOUNTED: inside the
+// shared chain (cors -> 512KB cap -> request-duration limiter and its buffered
+// response writer -> global backlog limiter -> framing), not on its own. The
+// duration limiter is the slow-client decoupler — it answers at the deadline
+// and returns while the handler goroutine is still live, which is only safe
+// because the framing wrote into a buffer and not the socket. These tests drive
+// the assembled mount over real HTTP and pin both halves of that: a slow
+// handler still gets 504, a normal one still gets its body.
+//
+// NewHandler builds one mount, so these cover both daemons: v1 and v2 differ
+// only in which HandlerSpecs they hand it.
+
+func mountLogger() *log.Entry {
+	l := log.New()
+	l.SetLevel(logrus.PanicLevel)
+	return l
+}
+
+// newMountedHandler assembles the production chain over specs and serves it
+// over real HTTP.
+func newMountedHandler(t *testing.T, globalLimit time.Duration, specs []HandlerSpec) string {
+	t.Helper()
+	handler := NewHandler(Params{
+		Daemon:                host.MakeNoOpDaemon(),
+		Logger:                mountLogger(),
+		Specs:                 specs,
+		GlobalQueueLimit:      100,
+		GlobalDurationWarning: globalLimit / 2,
+		GlobalDurationLimit:   globalLimit,
+	})
+	srv := httptest.NewServer(handler)
+	// No handler teardown: the mount owns no goroutine and no connection.
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func postMounted(t *testing.T, url, body string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	raw, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	return res.StatusCode, string(raw)
+}
+
+//nolint:testifylint // byte-exact wire pins; JSONEq would ignore key order and escaping
+func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
+	const limit = 500 * time.Millisecond
+	blocked := make(chan struct{})
+	t.Cleanup(func() { close(blocked) })
+
+	url := newMountedHandler(t, limit, []HandlerSpec{{
+		MethodName: "fast",
+		Handler: func(context.Context, *jrpc2.Request) (any, error) {
+			return map[string]int{"n": 7}, nil
+		},
+		QueueLimit:           10,
+		RequestDurationLimit: time.Minute,
+	}, {
+		MethodName: "slow",
+		Handler: func(ctx context.Context, _ *jrpc2.Request) (any, error) {
+			select {
+			case <-blocked:
+			case <-ctx.Done():
+			}
+			return "eventually", nil
+		},
+		QueueLimit: 10,
+		// Longer than the global limit, so the HTTP-level limiter is the one
+		// that answers and the 504 path is the one under test.
+		RequestDurationLimit: time.Minute,
+	}})
+
+	t.Run("a normal call gets its framed body, id escaped as the bridge escaped it", func(t *testing.T) {
+		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":"a<b","method":"fast"}`)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, `{"jsonrpc":"2.0","id":"a\u003cb","result":{"n":7}}`, body)
+	})
+
+	t.Run("a slow call still gets the 504 path with no body", func(t *testing.T) {
+		start := time.Now()
+		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":1,"method":"slow"}`)
+		assert.Equal(t, http.StatusGatewayTimeout, status)
+		assert.Empty(t, body, "the duration limiter answers before the framing writes anything")
+		assert.Less(t, time.Since(start), 30*time.Second)
+	})
+
+	t.Run("the mount keeps serving after a timed-out request", func(t *testing.T) {
+		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":2,"method":"fast"}`)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, `{"jsonrpc":"2.0","id":2,"result":{"n":7}}`, body)
+	})
+
+	t.Run("an unknown method is method-not-found, not a 500", func(t *testing.T) {
+		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":3,"method":"nope"}`)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t,
+			`{"jsonrpc":"2.0","id":3,"error":{"code":-32601,"message":"method not found","data":"nope"}}`, body)
+	})
+
+	t.Run("a batch answers in input order through the whole chain", func(t *testing.T) {
+		status, body := postMounted(t, url,
+			`[{"jsonrpc":"2.0","id":1,"method":"fast"},{"jsonrpc":"1.0","id":2,"method":"fast"}]`)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, `[{"jsonrpc":"2.0","id":1,"result":{"n":7}},`+
+			`{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"invalid version marker"}}]`, body)
+	})
+
+	t.Run("a body over the 512KB cap is rejected by the shared MaxBytesHandler", func(t *testing.T) {
+		padding := strings.Repeat("x", maxHTTPRequestSize+1)
+		status, body := postMounted(t, url,
+			`{"jsonrpc":"2.0","id":1,"method":"fast","params":{"pad":"`+padding+`"}}`)
+		assert.Equal(t, http.StatusInternalServerError, status)
+		assert.Contains(t, body, "request body too large")
+	})
+}
+
+// Handlers see a context derived from context.Background, exactly as jrpc2's
+// ServerOptions.NewContext default gave them: a client that hangs up mid-call
+// does not cancel the work. Deriving from the http.Request's context would
+// change that for every method including sendTransaction, and is deliberately
+// not part of this change.
+func TestMount_HandlerContextIsNotTheRequestContext(t *testing.T) {
+	type outcome struct {
+		deadline bool
+		err      error
+	}
+	seen := make(chan outcome, 1)
+
+	url := newMountedHandler(t, time.Minute, []HandlerSpec{{
+		MethodName: "inspect",
+		Handler: func(ctx context.Context, _ *jrpc2.Request) (any, error) {
+			_, hasDeadline := ctx.Deadline()
+			seen <- outcome{deadline: hasDeadline, err: ctx.Err()}
+			return "ok", nil
+		},
+		QueueLimit: 10,
+		// No per-method budget, so nothing between Background and the handler
+		// adds a deadline of its own.
+		RequestDurationLimit: network.RequestDurationLimiterNoLimit,
+	}})
+
+	status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":1,"method":"inspect"}`)
+	require.Equal(t, http.StatusOK, status)
+	//nolint:testifylint // byte-exact wire pin; JSONEq would ignore key order and escaping
+	require.Equal(t, `{"jsonrpc":"2.0","id":1,"result":"ok"}`, body)
+
+	got := <-seen
+	assert.False(t, got.deadline, "the handler context must not carry the HTTP request's deadline")
+	assert.NoError(t, got.err)
+}
+
+// A frame the mount produces must be exactly what a JSON-RPC client parses, not
+// merely something that looks like it. This is the belt to the byte-pins' braces.
+func TestMount_FramesParseAsJSONRPC(t *testing.T) {
+	url := newMountedHandler(t, time.Minute, []HandlerSpec{{
+		MethodName:           "fast",
+		Handler:              func(context.Context, *jrpc2.Request) (any, error) { return []int{1, 2, 3}, nil },
+		QueueLimit:           10,
+		RequestDurationLimit: time.Minute,
+	}})
+
+	status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":"x","method":"fast"}`)
+	require.Equal(t, http.StatusOK, status)
+
+	var frame struct {
+		Version string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  []int           `json:"result"`
+		Error   *jrpc2.Error    `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &frame))
+	assert.Equal(t, "2.0", frame.Version)
+	assert.JSONEq(t, `"x"`, string(frame.ID))
+	assert.Equal(t, []int{1, 2, 3}, frame.Result)
+	assert.Nil(t, frame.Error)
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -3,9 +3,11 @@ package jsonrpc
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -201,4 +203,52 @@ func TestMount_FramesParseAsJSONRPC(t *testing.T) {
 	assert.JSONEq(t, `"x"`, string(frame.ID))
 	assert.Equal(t, []int{1, 2, 3}, frame.Result)
 	assert.Nil(t, frame.Error)
+}
+
+// The regression that made batch dispatch concurrent, at the altitude where it
+// bites: the mount enforces ONE deadline for the whole HTTP request, so a
+// serial batch sums its elements' latencies against it. Four calls that each
+// fit comfortably inside the budget must still fit inside it together.
+func TestMount_ABatchOfSlowCallsFitsTheOneHTTPDeadline(t *testing.T) {
+	const (
+		globalLimit = time.Second
+		perCall     = 400 * time.Millisecond
+		elements    = 4
+	)
+	if runtime.NumCPU() < elements {
+		t.Skip("needs at least one permit per batch element")
+	}
+
+	url := newMountedHandler(t, globalLimit, []HandlerSpec{{
+		MethodName: "slow",
+		Handler: func(context.Context, *jrpc2.Request) (any, error) {
+			time.Sleep(perCall)
+			return "done", nil
+		},
+		QueueLimit:           10,
+		RequestDurationLimit: time.Minute,
+	}})
+
+	var body strings.Builder
+	var want strings.Builder
+	body.WriteByte('[')
+	want.WriteByte('[')
+	for i := 1; i <= elements; i++ {
+		if i > 1 {
+			body.WriteByte(',')
+			want.WriteByte(',')
+		}
+		fmt.Fprintf(&body, `{"jsonrpc":"2.0","id":%d,"method":"slow"}`, i)
+		fmt.Fprintf(&want, `{"jsonrpc":"2.0","id":%d,"result":"done"}`, i)
+	}
+	body.WriteByte(']')
+	want.WriteByte(']')
+
+	status, got := postMounted(t, url, body.String())
+
+	// Serial dispatch needs elements*perCall, which is past globalLimit, and
+	// the duration limiter answers 504 with an empty body.
+	require.Equal(t, http.StatusOK, status,
+		"a batch of %d %v calls did not fit a %v budget: the elements ran serially", elements, perCall, globalLimit)
+	assert.Equal(t, want.String(), got)
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -23,17 +23,9 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/network"
 )
 
-// The framing is only correct if it is correct WHERE IT IS MOUNTED: inside the
-// shared chain (cors -> 512KB cap -> request-duration limiter and its buffered
-// response writer -> global backlog limiter -> framing), not on its own. The
-// duration limiter is the slow-client decoupler — it answers at the deadline
-// and returns while the handler goroutine is still live, which is only safe
-// because the framing wrote into a buffer and not the socket. These tests drive
-// the assembled mount over real HTTP and pin both halves of that: a slow
-// handler still gets 504, a normal one still gets its body.
-//
-// NewHandler builds one mount, so these cover both daemons: v1 and v2 differ
-// only in which HandlerSpecs they hand it.
+// The framing is only correct WHERE IT IS MOUNTED: inside the shared chain
+// (cors -> 512KB cap -> duration limiter and its buffered writer -> backlog
+// limiter -> framing). NewHandler builds one, so these cover both daemons.
 
 func mountLogger() *log.Entry {
 	l := log.New()
@@ -41,16 +33,14 @@ func mountLogger() *log.Entry {
 	return l
 }
 
-// newMountedHandler assembles the production chain over specs and serves it
-// over real HTTP.
+// newMountedHandler assembles the production chain and serves it over HTTP.
 func newMountedHandler(t *testing.T, globalLimit time.Duration, specs []HandlerSpec) string {
 	t.Helper()
 	url, _ := newMountedHandlerAndHandle(t, globalLimit, specs)
 	return url
 }
 
-// newMountedHandlerAndHandle also returns the mount, for the tests that drive
-// its lifetime rather than its requests.
+// newMountedHandlerAndHandle also returns the mount, for lifetime tests.
 func newMountedHandlerAndHandle(
 	t *testing.T, globalLimit time.Duration, specs []HandlerSpec,
 ) (string, Handler) {
@@ -84,7 +74,7 @@ func postMounted(t *testing.T, url, body string) (int, string) {
 // eventually is what the parking handlers below return once released.
 const eventually = "eventually"
 
-// fastSpec answers immediately, and is every mount below's ordinary method.
+// fastSpec is every mount below's ordinary method.
 func fastSpec() HandlerSpec {
 	return HandlerSpec{
 		MethodName: "fast",
@@ -98,9 +88,8 @@ func fastSpec() HandlerSpec {
 
 //nolint:testifylint // byte-exact wire pins; JSONEq would ignore key order and escaping
 func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
-	// No parking handler here: one would hold a wire permit for as long as it
-	// parks, and the bound is GOMAXPROCS — one, on a single-CPU runner — so
-	// every subtest after it would 504. The 504 path has its own mount below.
+	// No parking handler: it would hold the only permit on a single-CPU
+	// runner. The 504 path has its own mount below.
 	url := newMountedHandler(t, time.Minute, []HandlerSpec{fastSpec()})
 
 	t.Run("a normal call gets its framed body, id escaped as the bridge escaped it", func(t *testing.T) {
@@ -133,11 +122,8 @@ func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
 	})
 }
 
-// Handlers see a context derived from context.Background, exactly as jrpc2's
-// ServerOptions.NewContext default gave them: a client that hangs up mid-call
-// does not cancel the work. Deriving from the http.Request's context would
-// change that for every method including sendTransaction, and is deliberately
-// not part of this change.
+// Handlers see a server-scoped context, so a client that hangs up mid-call
+// does not cancel the work — sendTransaction included.
 func TestMount_HandlerContextIsNotTheRequestContext(t *testing.T) {
 	type outcome struct {
 		deadline bool
@@ -168,8 +154,8 @@ func TestMount_HandlerContextIsNotTheRequestContext(t *testing.T) {
 	assert.NoError(t, got.err)
 }
 
-// A frame the mount produces must be exactly what a JSON-RPC client parses, not
-// merely something that looks like it. This is the belt to the byte-pins' braces.
+// A frame the mount produces must be what a JSON-RPC client parses: the belt
+// to the byte-pins' braces.
 func TestMount_FramesParseAsJSONRPC(t *testing.T) {
 	url := newMountedHandler(t, time.Minute, []HandlerSpec{{
 		MethodName:           "fast",
@@ -194,12 +180,8 @@ func TestMount_FramesParseAsJSONRPC(t *testing.T) {
 	assert.Nil(t, frame.Error)
 }
 
-// The slow-client decoupler, on a mount of its own. A parked handler holds its
-// wire permit until it returns, and that bound is GOMAXPROCS — one on a
-// single-CPU runner — so this cannot share a mount with tests that need a
-// permit of their own. Releasing and joining the handler is the second half of
-// the test, not bookkeeping: "the mount survives a 504" is only meaningful once
-// the abandoned handler has finished.
+// The slow-client decoupler, on a mount of its own: a parked handler holds its
+// permit, and that bound is one on a single-CPU runner.
 //
 //nolint:testifylint // byte-exact wire pins; JSONEq would ignore key order and escaping
 func TestMount_ASlowCallGets504AndTheMountRecovers(t *testing.T) {
@@ -229,9 +211,8 @@ func TestMount_ASlowCallGets504AndTheMountRecovers(t *testing.T) {
 	assert.Empty(t, body, "the duration limiter answers before the framing writes anything")
 	assert.Less(t, time.Since(start), 30*time.Second)
 
-	// The client has its 504; the handler goroutine is still live and still
-	// holds its permit. That is the documented shape (DELTA (g)), so the mount
-	// is only expected to serve again once it has actually finished.
+	// The client has its 504 and the handler still holds its permit — the
+	// documented shape (DELTA (g)) — so serving resumes once it finishes.
 	close(blocked)
 	select {
 	case <-returned:
@@ -244,10 +225,8 @@ func TestMount_ASlowCallGets504AndTheMountRecovers(t *testing.T) {
 	assert.Equal(t, `{"jsonrpc":"2.0","id":2,"result":{"n":7}}`, body)
 }
 
-// The regression that made batch dispatch concurrent, at the altitude where it
-// bites: the mount enforces ONE deadline for the whole HTTP request, so a
-// serial batch sums its elements' latencies against it. Four calls that each
-// fit comfortably inside the budget must still fit inside it together.
+// The mount enforces ONE deadline for the whole request, so a serial batch
+// sums its elements against it. Calls that each fit must fit together.
 func TestMount_ABatchOfSlowCallsFitsTheOneHTTPDeadline(t *testing.T) {
 	const (
 		globalLimit = time.Second
@@ -277,22 +256,14 @@ func TestMount_ABatchOfSlowCallsFitsTheOneHTTPDeadline(t *testing.T) {
 
 	status, got := postMounted(t, url, "["+strings.Join(body, ",")+"]")
 
-	// Serial dispatch needs elements*perCall, which is past globalLimit, and
-	// the duration limiter answers 504 with an empty body.
+	// Serial dispatch needs elements*perCall, past globalLimit.
 	require.Equal(t, http.StatusOK, status,
 		"a batch of %d %v calls did not fit a %v budget: the elements ran serially", elements, perCall, globalLimit)
 	assert.Equal(t, "["+strings.Join(want, ",")+"]", got)
 }
 
-// The panic path, pinned at the mount, because which layer catches a handler
-// panic decides what the client sees and there are two candidate layers in the
-// chain.
-//
-// jrpc2 recovered nothing: under the bridge a panic from a method with no
-// duration budget unwound on a goroutine the jrpc2.Server owned and took the
-// PROCESS with it. Here the chain's own recover answers 500 and the mount
-// keeps serving — and a batch element's panic has to be relayed to the serving
-// goroutine to get that, since nothing above a worker recovers.
+// Which layer catches a handler panic decides what the client sees. A batch
+// element's panic must be relayed to the serving goroutine to reach either.
 func TestMount_HandlerPanics(t *testing.T) {
 	boom := func(context.Context, *jrpc2.Request) (any, error) { panic("handler exploded") }
 	url := newMountedHandler(t, time.Minute, []HandlerSpec{{
@@ -304,8 +275,8 @@ func TestMount_HandlerPanics(t *testing.T) {
 		MethodName: "boomUnbudgeted",
 		Handler:    boom,
 		QueueLimit: 10,
-		// The only configuration in which a panic reaches the framing at all.
-		// No method either daemon registers is built this way.
+		// The only configuration in which a panic reaches the framing. No
+		// method either daemon registers is built this way.
 		RequestDurationLimit: network.RequestDurationLimiterNoLimit,
 	}, {
 		MethodName:           "fast",
@@ -347,10 +318,7 @@ func TestMount_HandlerPanics(t *testing.T) {
 }
 
 // DELTA (g), the half that does not stop: the deadline ends the DISPATCH, not
-// the work. A handler that had already started keeps running on its
-// context.Background-derived context, with no deadline of the HTTP request's —
-// the guarantee sendTransaction depends on. The half that does stop is
-// TestWire_ADeadRequestStopsStartingElements.
+// the work, which is what sendTransaction depends on.
 func TestMount_AStartedElementSurvivesTheDeadline(t *testing.T) {
 	const limit = 300 * time.Millisecond
 	finished := make(chan error, 1)
@@ -382,10 +350,8 @@ func TestMount_AStartedElementSurvivesTheDeadline(t *testing.T) {
 	}
 }
 
-// The two halves of the handler lifetime, at the mount. The HTTP deadline
-// answers the client and leaves the handler running (that is DELTA (g), and
-// what sendTransaction depends on); only Shutdown ends it. Between the two,
-// nothing did — which is what let a straggler outlive the stores it reads.
+// The two halves of the handler lifetime: the HTTP deadline answers the client
+// and leaves the handler running, and only Shutdown ends it.
 func TestMount_ShutdownEndsWhatTheDeadlineDidNot(t *testing.T) {
 	const limit = 300 * time.Millisecond
 	entered := make(chan struct{}, 1)

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -333,3 +333,39 @@ func TestMount_HandlerPanics(t *testing.T) {
 		stillServing(t, "7")
 	})
 }
+
+// DELTA (g), the half that does not stop: the deadline ends the DISPATCH, not
+// the work. A handler that had already started keeps running on its
+// context.Background-derived context, with no deadline of the HTTP request's —
+// the guarantee sendTransaction depends on. The half that does stop is
+// TestWire_ADeadRequestStopsStartingElements.
+func TestMount_AStartedElementSurvivesTheDeadline(t *testing.T) {
+	const limit = 300 * time.Millisecond
+	finished := make(chan error, 1)
+
+	url := newMountedHandler(t, limit, []HandlerSpec{{
+		MethodName: "slow",
+		Handler: func(ctx context.Context, _ *jrpc2.Request) (any, error) {
+			time.Sleep(3 * limit) // well past the HTTP deadline
+			finished <- ctx.Err()
+			return "eventually", nil
+		},
+		QueueLimit:           10,
+		RequestDurationLimit: time.Minute,
+	}})
+
+	start := time.Now()
+	status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":1,"method":"slow"}`)
+	answered := time.Since(start)
+
+	require.Equal(t, http.StatusGatewayTimeout, status)
+	assert.Empty(t, body)
+	assert.Less(t, answered, 3*limit, "the 504 waited for the handler instead of abandoning it")
+
+	select {
+	case err := <-finished:
+		assert.NoError(t, err, "the HTTP deadline reached a handler that had already started")
+	case <-time.After(10 * time.Second):
+		t.Fatal("a started handler never finished: the run-to-completion guarantee is gone")
+	}
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -244,28 +244,20 @@ func TestMount_ABatchOfSlowCallsFitsTheOneHTTPDeadline(t *testing.T) {
 		RequestDurationLimit: time.Minute,
 	}})
 
-	var body strings.Builder
-	var want strings.Builder
-	body.WriteByte('[')
-	want.WriteByte('[')
-	for i := 1; i <= elements; i++ {
-		if i > 1 {
-			body.WriteByte(',')
-			want.WriteByte(',')
-		}
-		fmt.Fprintf(&body, `{"jsonrpc":"2.0","id":%d,"method":"slow"}`, i)
-		fmt.Fprintf(&want, `{"jsonrpc":"2.0","id":%d,"result":"done"}`, i)
+	body := make([]string, elements)
+	want := make([]string, elements)
+	for i := range elements {
+		body[i] = fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"slow"}`, i+1)
+		want[i] = fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"result":"done"}`, i+1)
 	}
-	body.WriteByte(']')
-	want.WriteByte(']')
 
-	status, got := postMounted(t, url, body.String())
+	status, got := postMounted(t, url, "["+strings.Join(body, ",")+"]")
 
 	// Serial dispatch needs elements*perCall, which is past globalLimit, and
 	// the duration limiter answers 504 with an empty body.
 	require.Equal(t, http.StatusOK, status,
 		"a batch of %d %v calls did not fit a %v budget: the elements ran serially", elements, perCall, globalLimit)
-	assert.Equal(t, want.String(), got)
+	assert.Equal(t, "["+strings.Join(want, ",")+"]", got)
 }
 
 // The panic path, pinned at the mount, because which layer catches a handler

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -45,6 +45,16 @@ func mountLogger() *log.Entry {
 // over real HTTP.
 func newMountedHandler(t *testing.T, globalLimit time.Duration, specs []HandlerSpec) string {
 	t.Helper()
+	url, _ := newMountedHandlerAndHandle(t, globalLimit, specs)
+	return url
+}
+
+// newMountedHandlerAndHandle also returns the mount, for the tests that drive
+// its lifetime rather than its requests.
+func newMountedHandlerAndHandle(
+	t *testing.T, globalLimit time.Duration, specs []HandlerSpec,
+) (string, Handler) {
+	t.Helper()
 	handler := NewHandler(Params{
 		Daemon:                host.MakeNoOpDaemon(),
 		Logger:                mountLogger(),
@@ -54,9 +64,8 @@ func newMountedHandler(t *testing.T, globalLimit time.Duration, specs []HandlerS
 		GlobalDurationLimit:   globalLimit,
 	})
 	srv := httptest.NewServer(handler)
-	// No handler teardown: the mount owns no goroutine and no connection.
 	t.Cleanup(srv.Close)
-	return srv.URL
+	return srv.URL, handler
 }
 
 func postMounted(t *testing.T, url, body string) (int, string) {
@@ -71,6 +80,9 @@ func postMounted(t *testing.T, url, body string) (int, string) {
 	require.NoError(t, err)
 	return res.StatusCode, string(raw)
 }
+
+// eventually is what the parking handlers below return once released.
+const eventually = "eventually"
 
 // fastSpec answers immediately, and is every mount below's ordinary method.
 func fastSpec() HandlerSpec {
@@ -203,7 +215,7 @@ func TestMount_ASlowCallGets504AndTheMountRecovers(t *testing.T) {
 			case <-blocked:
 			case <-ctx.Done():
 			}
-			return "eventually", nil
+			return eventually, nil
 		},
 		QueueLimit: 10,
 		// Longer than the global limit, so the HTTP-level limiter is the one
@@ -348,7 +360,7 @@ func TestMount_AStartedElementSurvivesTheDeadline(t *testing.T) {
 		Handler: func(ctx context.Context, _ *jrpc2.Request) (any, error) {
 			time.Sleep(3 * limit) // well past the HTTP deadline
 			finished <- ctx.Err()
-			return "eventually", nil
+			return eventually, nil
 		},
 		QueueLimit:           10,
 		RequestDurationLimit: time.Minute,
@@ -367,5 +379,48 @@ func TestMount_AStartedElementSurvivesTheDeadline(t *testing.T) {
 		assert.NoError(t, err, "the HTTP deadline reached a handler that had already started")
 	case <-time.After(10 * time.Second):
 		t.Fatal("a started handler never finished: the run-to-completion guarantee is gone")
+	}
+}
+
+// The two halves of the handler lifetime, at the mount. The HTTP deadline
+// answers the client and leaves the handler running (that is DELTA (g), and
+// what sendTransaction depends on); only Shutdown ends it. Between the two,
+// nothing did — which is what let a straggler outlive the stores it reads.
+func TestMount_ShutdownEndsWhatTheDeadlineDidNot(t *testing.T) {
+	const limit = 300 * time.Millisecond
+	entered := make(chan struct{}, 1)
+	observed := make(chan error, 1)
+
+	url, handler := newMountedHandlerAndHandle(t, limit, []HandlerSpec{{
+		MethodName: "watch",
+		Handler: func(ctx context.Context, _ *jrpc2.Request) (any, error) {
+			entered <- struct{}{}
+			<-ctx.Done()
+			observed <- ctx.Err()
+			return eventually, nil
+		},
+		QueueLimit:           10,
+		RequestDurationLimit: time.Minute,
+	}})
+
+	status, _ := postMounted(t, url, `{"jsonrpc":"2.0","id":1,"method":"watch"}`)
+	require.Equal(t, http.StatusGatewayTimeout, status)
+	<-entered
+
+	select {
+	case err := <-observed:
+		t.Fatalf("the HTTP deadline canceled the handler context (%v); it must outlive its request", err)
+	case <-time.After(2 * limit):
+	}
+
+	// Bounded, so a regression fails here instead of hanging the package.
+	drainCtx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, handler.Shutdown(drainCtx))
+	select {
+	case err := <-observed:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Shutdown did not end a handler the deadline had abandoned")
 	}
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -72,67 +72,29 @@ func postMounted(t *testing.T, url, body string) (int, string) {
 	return res.StatusCode, string(raw)
 }
 
-//nolint:testifylint // byte-exact wire pins; JSONEq would ignore key order and escaping
-func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
-	const limit = 500 * time.Millisecond
-	// The slow handler holds a wire permit for as long as it runs, and the
-	// bound is GOMAXPROCS — one, on a single-CPU runner. So it is released and
-	// joined at the end of its own subtest rather than at cleanup; leaving it
-	// parked would 504 every subtest after it.
-	blocked := make(chan struct{})
-	slowReturned := make(chan struct{}, 1)
-
-	url := newMountedHandler(t, limit, []HandlerSpec{{
+// fastSpec answers immediately, and is every mount below's ordinary method.
+func fastSpec() HandlerSpec {
+	return HandlerSpec{
 		MethodName: "fast",
 		Handler: func(context.Context, *jrpc2.Request) (any, error) {
 			return map[string]int{"n": 7}, nil
 		},
 		QueueLimit:           10,
 		RequestDurationLimit: time.Minute,
-	}, {
-		MethodName: "slow",
-		Handler: func(ctx context.Context, _ *jrpc2.Request) (any, error) {
-			defer func() { slowReturned <- struct{}{} }()
-			select {
-			case <-blocked:
-			case <-ctx.Done():
-			}
-			return "eventually", nil
-		},
-		QueueLimit: 10,
-		// Longer than the global limit, so the HTTP-level limiter is the one
-		// that answers and the 504 path is the one under test.
-		RequestDurationLimit: time.Minute,
-	}})
+	}
+}
+
+//nolint:testifylint // byte-exact wire pins; JSONEq would ignore key order and escaping
+func TestMount_ServesThroughTheRealMiddlewareChain(t *testing.T) {
+	// No parking handler here: one would hold a wire permit for as long as it
+	// parks, and the bound is GOMAXPROCS — one, on a single-CPU runner — so
+	// every subtest after it would 504. The 504 path has its own mount below.
+	url := newMountedHandler(t, time.Minute, []HandlerSpec{fastSpec()})
 
 	t.Run("a normal call gets its framed body, id escaped as the bridge escaped it", func(t *testing.T) {
 		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":"a<b","method":"fast"}`)
 		assert.Equal(t, http.StatusOK, status)
 		assert.Equal(t, `{"jsonrpc":"2.0","id":"a\u003cb","result":{"n":7}}`, body)
-	})
-
-	t.Run("a slow call still gets the 504 path with no body", func(t *testing.T) {
-		start := time.Now()
-		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":1,"method":"slow"}`)
-		assert.Equal(t, http.StatusGatewayTimeout, status)
-		assert.Empty(t, body, "the duration limiter answers before the framing writes anything")
-		assert.Less(t, time.Since(start), 30*time.Second)
-
-		// The 504 answered the client; the handler goroutine is still live and
-		// still holds its permit. Release it and wait, so the bound is whole
-		// again for the subtests below.
-		close(blocked)
-		select {
-		case <-slowReturned:
-		case <-time.After(10 * time.Second):
-			t.Fatal("the slow handler never returned after its channel was closed")
-		}
-	})
-
-	t.Run("the mount keeps serving after a timed-out request", func(t *testing.T) {
-		status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":2,"method":"fast"}`)
-		assert.Equal(t, http.StatusOK, status)
-		assert.Equal(t, `{"jsonrpc":"2.0","id":2,"result":{"n":7}}`, body)
 	})
 
 	t.Run("an unknown method is method-not-found, not a 500", func(t *testing.T) {
@@ -218,6 +180,56 @@ func TestMount_FramesParseAsJSONRPC(t *testing.T) {
 	assert.JSONEq(t, `"x"`, string(frame.ID))
 	assert.Equal(t, []int{1, 2, 3}, frame.Result)
 	assert.Nil(t, frame.Error)
+}
+
+// The slow-client decoupler, on a mount of its own. A parked handler holds its
+// wire permit until it returns, and that bound is GOMAXPROCS — one on a
+// single-CPU runner — so this cannot share a mount with tests that need a
+// permit of their own. Releasing and joining the handler is the second half of
+// the test, not bookkeeping: "the mount survives a 504" is only meaningful once
+// the abandoned handler has finished.
+//
+//nolint:testifylint // byte-exact wire pins; JSONEq would ignore key order and escaping
+func TestMount_ASlowCallGets504AndTheMountRecovers(t *testing.T) {
+	const limit = 500 * time.Millisecond
+	blocked := make(chan struct{})
+	returned := make(chan struct{}, 1)
+
+	url := newMountedHandler(t, limit, []HandlerSpec{fastSpec(), {
+		MethodName: "slow",
+		Handler: func(ctx context.Context, _ *jrpc2.Request) (any, error) {
+			defer func() { returned <- struct{}{} }()
+			select {
+			case <-blocked:
+			case <-ctx.Done():
+			}
+			return "eventually", nil
+		},
+		QueueLimit: 10,
+		// Longer than the global limit, so the HTTP-level limiter is the one
+		// that answers and the 504 path is the one under test.
+		RequestDurationLimit: time.Minute,
+	}})
+
+	start := time.Now()
+	status, body := postMounted(t, url, `{"jsonrpc":"2.0","id":1,"method":"slow"}`)
+	assert.Equal(t, http.StatusGatewayTimeout, status)
+	assert.Empty(t, body, "the duration limiter answers before the framing writes anything")
+	assert.Less(t, time.Since(start), 30*time.Second)
+
+	// The client has its 504; the handler goroutine is still live and still
+	// holds its permit. That is the documented shape (DELTA (g)), so the mount
+	// is only expected to serve again once it has actually finished.
+	close(blocked)
+	select {
+	case <-returned:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the slow handler never returned after its channel was closed")
+	}
+
+	status, body = postMounted(t, url, `{"jsonrpc":"2.0","id":2,"method":"fast"}`)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, `{"jsonrpc":"2.0","id":2,"result":{"n":7}}`, body)
 }
 
 // The regression that made batch dispatch concurrent, at the altitude where it

--- a/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/mount_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/creachadair/jrpc2"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -506,4 +507,67 @@ func TestMount_ClosedConnectionsStopTheDispatchBeforeTheDrain(t *testing.T) {
 	assert.Equal(t, atClose, started.Load(), "elements started after the connections were closed")
 	assert.LessOrEqual(t, atClose, int64(weight+1),
 		"the dispatch kept going past the bound while its connection was dead")
+}
+
+// stableRegistryDaemon is MakeNoOpDaemon with a registry that does not change
+// between calls. NoOpDaemon hands out a fresh one per call so tests can
+// register repeatedly, which also makes registration unobservable.
+type stableRegistryDaemon struct {
+	*host.NoOpDaemon
+
+	registry *prometheus.Registry
+}
+
+func (d stableRegistryDaemon) MetricsRegistry() *prometheus.Registry { return d.registry }
+
+// Six metric families were built and never registered between #804 (2023) and
+// the commit that added this test, so the per-method and global limiter
+// signals did not exist on /metrics at all — including
+// <method>_inflight_requests, which is the count of live handler bodies and
+// the operator's only view of the population the drain waits for.
+func TestMount_LimiterMetricsAreRegistered(t *testing.T) {
+	daemon := stableRegistryDaemon{host.MakeNoOpDaemon(), prometheus.NewRegistry()}
+	NewHandler(Params{
+		Daemon: daemon, Logger: mountLogger(), GlobalQueueLimit: 100,
+		GlobalDurationWarning: time.Second, GlobalDurationLimit: time.Minute,
+		Specs: []HandlerSpec{{
+			MethodName:           "getHealth",
+			Handler:              func(context.Context, *jrpc2.Request) (any, error) { return "ok", nil },
+			QueueLimit:           10,
+			RequestDurationLimit: time.Minute,
+		}},
+	})
+
+	families, err := daemon.registry.Gather()
+	require.NoError(t, err)
+	got := make(map[string]bool, len(families))
+	for _, f := range families {
+		got[f.GetName()] = true
+	}
+
+	ns := host.PrometheusNamespace + "_" + subsystemNetwork + "_"
+	for _, name := range []string{
+		ns + "get_health_inflight_requests",
+		ns + "get_health_execution_threshold_warning",
+		ns + "get_health_execution_threshold_limit",
+		ns + "global_inflight_requests",
+		ns + "global_request_execution_duration_threshold_warning",
+		ns + "global_request_execution_duration_threshold_limit",
+	} {
+		assert.True(t, got[name], "%s was built but never registered", name)
+	}
+
+	// Registering twice must reuse rather than panic: the mount is rebuildable.
+	assert.NotPanics(t, func() {
+		NewHandler(Params{
+			Daemon: daemon, Logger: mountLogger(), GlobalQueueLimit: 100,
+			GlobalDurationWarning: time.Second, GlobalDurationLimit: time.Minute,
+			Specs: []HandlerSpec{{
+				MethodName:           "getHealth",
+				Handler:              func(context.Context, *jrpc2.Request) (any, error) { return "ok", nil },
+				QueueLimit:           10,
+				RequestDurationLimit: time.Minute,
+			}},
+		})
+	})
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -23,6 +23,21 @@
 // []json.RawMessage), and a batch worker's permit taken before its goroutine
 // is started (never inside it).
 //
+// # The deltas
+//
+// Seven places answer differently from the bridge. Each is argued where it is
+// implemented; they are indexed here so the set is countable, because a
+// lettered list whose letters are scattered is exactly the kind of thing that
+// silently loses one.
+//
+//	(a) a malformed body is a -32700 frame over 200, not 500 + plaintext
+//	(b) an empty batch `[]` is a -32600 frame, not a 204
+//	(c) notifications have finished when their 204 is written
+//	(d) an empty-method notification is answered rather than 204'd
+//	(e) batch frames come back in input order
+//	(f) params reach handlers verbatim rather than re-marshaled
+//	(g) OPEN: the serving goroutine does not unwind at the HTTP deadline
+//
 // # What the jrpc2.Server took with it
 //
 // Handlers run on a context derived from context.Background, which is what
@@ -138,7 +153,8 @@ type Handler struct {
 	// number of fat results being marshaled at once: 64 x 17MB rather than
 	// 2 x 17MB is the difference between a bound and a decoration. The repo
 	// already takes GOMAXPROCS as its parallelism convention — see
-	// rpcv2/backfill.DefaultWorkers.
+	// rpcv2/backfill.DefaultWorkers. It is read once, here, which is enough:
+	// the quota that matters is in effect before the daemon binds a port.
 	//
 	// It is ONE semaphore for the whole handler, and a batch's elements take
 	// their permits from it individually, just as jrpc2's Server.invoke did.
@@ -287,7 +303,12 @@ func (h *Handler) dispatchAll(reqs []*jrpc2.ParsedRequest) [][]byte {
 
 	if len(reqs) == 1 {
 		// A single-element body — every non-batch request, including the fat
-		// ones this package exists for — never leaves this goroutine.
+		// ones this package exists for — never leaves this goroutine. The
+		// saving is a goroutine and a WaitGroup, which is noise beside a 17MB
+		// marshal; what this branch really buys is that a single request's
+		// panic reaches the limiter's recover with its OWN stack rather than
+		// wrapped in a relayedPanic. Deleting it as premature optimization
+		// would quietly change that.
 		frames[0] = h.dispatchOne(reqs[0])
 	} else {
 		h.dispatchBatch(reqs, frames)
@@ -331,8 +352,10 @@ func (h *Handler) dispatchBatch(reqs []*jrpc2.ParsedRequest, frames [][]byte) {
 		// would take the whole process down; the same handler bug on a single
 		// request unwinds into httpRequestDurationLimiter's recover, which
 		// answers 500 and logs the stack. Re-raising it here, after every
-		// sibling has finished, keeps a batch element's panic failing exactly
-		// the request it already failed and nothing else. (No parity is lost:
+		// sibling has finished, keeps a batch element's panic inside the HTTP
+		// request it belongs to instead of the process — the batch's other
+		// frames go down with it, which is what the serial dispatch this
+		// replaced did too. (No parity is lost:
 		// jrpc2 ran batch elements on goroutines it did not recover either, so
 		// under the bridge this bug class was a crash.) In this mount it is a
 		// safety net and not a live path: every method both daemons register

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -16,10 +16,12 @@
 // envelope: one json.Marshal of the handler's result, one hand-appended
 // envelope around it, one Write.
 //
-// Two rules in here are load-bearing and are commented at their site, because
-// each has a plausible-looking "improvement" that silently reverses this
-// package's reason to exist: json.Marshal + Write (never json.NewEncoder), and
-// hand-appended batch frames (never json.Marshal of a []json.RawMessage).
+// Three rules in here are load-bearing and are commented at their site,
+// because each has a plausible-looking "improvement" that silently reverses
+// this package's reason to exist: json.Marshal + Write (never
+// json.NewEncoder), hand-appended batch frames (never json.Marshal of a
+// []json.RawMessage), and a batch worker's permit taken before its goroutine
+// is started (never inside it).
 package wire
 
 import (
@@ -30,7 +32,11 @@ import (
 	"mime"
 	"net/http"
 	"runtime"
+	"runtime/debug"
+	"slices"
 	"strconv"
+	"sync"
+	"sync/atomic"
 
 	"github.com/creachadair/jrpc2"
 	"golang.org/x/sync/semaphore"
@@ -91,6 +97,11 @@ type Handler struct {
 	// socket write stays outside the bound and a slow reader cannot hold a
 	// permit. jrpc2 defaults ServerOptions.Concurrency to runtime.NumCPU();
 	// this reproduces that number rather than inventing one.
+	//
+	// It is ONE semaphore for the whole handler, and a batch's elements take
+	// their permits from it individually, just as jrpc2's Server.invoke did.
+	// A batch therefore borrows from the process-wide budget instead of
+	// multiplying it — see dispatchAll.
 	sem *semaphore.Weighted
 }
 
@@ -165,38 +176,146 @@ func (h *Handler) serve(w http.ResponseWriter, body []byte) {
 	// Batch-ness is a property of the body, carried on every element.
 	isBatch := reqs[0].Batch
 
-	// DELTA (f): frames come back in input order. The bridge emits every
-	// statically-invalid element first and the valid ones after, so any mixed
-	// batch is reordered against the request. Spec-legal, but client-visible
-	// and needless.
-	frames := make([][]byte, 0, len(reqs))
-	for _, pr := range reqs {
-		if frame := h.dispatch(pr); frame != nil {
-			frames = append(frames, frame)
-		}
-	}
-
+	frames := h.dispatchAll(reqs)
 	if len(frames) == 0 {
 		// Every element was a notification. DELTA (c): they have all run to
-		// completion by the time this 204 is written, because dispatch is
-		// synchronous. The bridge fires notifications at its in-process client
-		// and 204s immediately, so today a notification is free to the caller
-		// and its work races the response.
+		// completion by the time this 204 is written, because dispatchAll
+		// returns only after every handler it started has returned. The bridge
+		// fires notifications at its in-process client and 204s immediately,
+		// so today a notification is free to the caller and its work races the
+		// response.
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	writeFrames(w, isBatch, frames)
 }
 
-// dispatch answers one parsed request, returning its response frame or nil if
-// the request gets no response.
+// dispatchAll answers every element of one parsed body and returns the frames
+// in INPUT order (DELTA (f)), with the elements that get no response — the
+// notifications — compacted out. It returns only once every handler it started
+// has returned, which is what lets serve's 204 mean "the notifications have
+// run" rather than "the notifications have been queued".
+//
+// A batch's elements run CONCURRENTLY, as jrpc2's dispatchLocked ran them.
+// Dispatching them serially would sum their latencies under the ONE HTTP
+// deadline the mount enforces (httpRequestDurationLimiter, 25s by default), so
+// a batch of individually-fine calls would 504 where each call on its own
+// succeeds, and would hold its global backlog slot for the sum rather than the
+// max.
+//
+// The concurrency is the process-wide semaphore's, not a second budget: a batch
+// borrows permits from the same bound a single request takes one from, so N
+// elements cannot buy N times the handler parallelism. It also cannot buy N
+// goroutines. The permit is acquired HERE, on the serving goroutine, and
+// released by the worker; that ordering is the third load-bearing rule in this
+// file. Acquire inside the worker instead and every element gets a goroutine
+// parked on Acquire — and the body cap bounds elements only by their minimum
+// size, so a 512KB body of `[5,5,5,...]` is ~260,000 of them. Acquiring first
+// makes the in-flight worker count runtime.NumCPU(), whatever the batch's
+// length; the batch's length still bounds the frames, which is where the
+// (pre-existing, bridge-identical) response amplification lives.
+func (h *Handler) dispatchAll(reqs []*jrpc2.ParsedRequest) [][]byte {
+	// One slot per element, filled by index, so the response order is the
+	// request order and does not depend on completion order. A nil slot is an
+	// element that gets no response.
+	frames := make([][]byte, len(reqs))
+
+	if len(reqs) == 1 {
+		// A single-element body — every non-batch request, including the fat
+		// ones this package exists for — never leaves this goroutine.
+		frames[0] = h.dispatchOne(reqs[0])
+	} else {
+		h.dispatchBatch(reqs, frames)
+	}
+	return slices.DeleteFunc(frames, func(f []byte) bool { return f == nil })
+}
+
+// dispatchBatch runs the elements of a multi-element body, writing each one's
+// frame into its own slot of frames. See dispatchAll for why the permit is
+// taken on this goroutine rather than in the worker.
+func (h *Handler) dispatchBatch(reqs []*jrpc2.ParsedRequest, frames [][]byte) {
+	var wg sync.WaitGroup
+	var raised atomic.Pointer[relayedPanic]
+
+	for i, pr := range reqs {
+		method, frame := h.route(pr)
+		if method == nil {
+			// Answered without running anything: a parse or shape error, an
+			// empty method, an unknown method, or a silent notification. No
+			// permit and no goroutine are spent on it.
+			frames[i] = frame
+			continue
+		}
+		if denied := h.acquirePermit(pr); denied != nil {
+			frames[i] = denied
+			continue
+		}
+		wg.Go(func() {
+			// Released once the frame is built and strictly before the caller
+			// writes a byte, exactly as dispatchOne releases it — and released
+			// on a panicking handler too, because it is deferred.
+			defer h.sem.Release(1)
+			defer catchPanic(&raised)
+			frames[i] = h.invoke(pr, method)
+		})
+	}
+	wg.Wait()
+
+	if p := raised.Load(); p != nil {
+		// A panic on a worker goroutine has nothing above it to recover, so it
+		// would take the whole process down; the same handler bug on a single
+		// request unwinds into httpRequestDurationLimiter's recover, which
+		// answers 500 and logs the stack. Re-raising it here, after every
+		// sibling has finished, keeps a batch element's panic failing exactly
+		// the request it already failed and nothing else. (No parity is lost:
+		// jrpc2 ran batch elements on goroutines it did not recover either, so
+		// under the bridge this bug class was a crash.)
+		panic(p)
+	}
+}
+
+// dispatchOne answers one request on the calling goroutine, holding a permit
+// across the handler and the marshal and releasing it before it returns the
+// finished frame — so the caller writes with no permit held, and a panicking
+// handler still releases on the way out.
+func (h *Handler) dispatchOne(pr *jrpc2.ParsedRequest) []byte {
+	method, frame := h.route(pr)
+	if method == nil {
+		return frame
+	}
+	if denied := h.acquirePermit(pr); denied != nil {
+		return denied
+	}
+	defer h.sem.Release(1)
+	return h.invoke(pr, method)
+}
+
+// acquirePermit takes one permit from the shared bound, returning nil. It
+// returns the frame that answers pr instead if the permit cannot be taken,
+// which is unreachable today: Background is never canceled and Acquire only
+// fails on a canceled context. Answered rather than dropped so that a future
+// change of context cannot turn this into a silent 200 with no body.
+func (h *Handler) acquirePermit(pr *jrpc2.ParsedRequest) []byte {
+	if err := h.sem.Acquire(context.Background(), 1); err != nil {
+		return errorFrame(pr.ID, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
+	}
+	return nil
+}
+
+// route decides how one parsed request is answered, WITHOUT running anything:
+// it returns the handler to invoke, or a nil handler and the finished frame —
+// which is itself nil for a request that gets no response at all.
 //
 // Order is load-bearing and is not jrpc2's stated order, because jrpc2's
 // composite behavior is not its stated order either:
 //
 //  1. Parse and shape errors answer with a frame even for a notification —
 //     that is what the bridge does today (it filters invalid elements before
-//     it ever looks at notification-ness) and what the spec requires.
+//     it ever looks at notification-ness) and what the spec requires. jrpc2's
+//     own responses() reports a notification's error only when its code is
+//     ParseError or InvalidRequest; every error ParseRequests can attach to an
+//     element carries one of those two codes, so reporting them all is the
+//     same set, not a wider one.
 //  2. An empty method name is the same class of request-level protocol error,
 //     so it answers with a frame too. DELTA (e): today an empty-method
 //     NOTIFICATION returns 204, and only by accident — jrpc2's server does
@@ -210,39 +329,34 @@ func (h *Handler) serve(w http.ResponseWriter, body []byte) {
 // ToRequest builds the id with fixID(json.RawMessage(p.ID)) from a string, so
 // for an absent id it yields an empty-but-non-nil RawMessage and
 // IsNotification (which tests id == nil) cannot be trusted.
-func (h *Handler) dispatch(pr *jrpc2.ParsedRequest) []byte {
+func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, []byte) {
 	if pr.Error != nil {
-		return errorFrame(pr.ID, pr.Error)
+		return nil, errorFrame(pr.ID, pr.Error)
 	}
 	if pr.Method == "" {
-		return errorFrame(pr.ID, errEmptyMethod)
+		return nil, errorFrame(pr.ID, errEmptyMethod)
 	}
-
-	notification := pr.ID == ""
-
-	method, ok := h.methods[pr.Method]
-	if !ok {
-		if notification {
-			return nil
-		}
-		// jrpc2's own errNoSuchMethod frame, byte for byte: code -32601,
-		// message "method not found", data the method name. Resolving it here
-		// means no jrpc2.Server ever sees the request, which is also why the
-		// library's unknown-method in-flight-map leak is unreachable from this
-		// serving path. No handler is invoked and no metric is labeled, so an
-		// attacker-chosen method name cannot grow the per-method summary's
-		// cardinality either.
-		return errorFrame(pr.ID, (&jrpc2.Error{
-			Code:    jrpc2.MethodNotFound,
-			Message: jrpc2.MethodNotFound.String(),
-		}).WithData(pr.Method))
+	if method, ok := h.methods[pr.Method]; ok {
+		return method, nil
 	}
-
-	return h.invoke(pr, method, notification)
+	if pr.ID == "" {
+		return nil, nil // an unknown method on a notification is silent
+	}
+	// jrpc2's own errNoSuchMethod frame, byte for byte: code -32601, message
+	// "method not found", data the method name. Resolving it here means no
+	// jrpc2.Server ever sees the request, which is also why the library's
+	// unknown-method in-flight-map leak is unreachable from this serving path.
+	// No handler is invoked and no metric is labeled, so an attacker-chosen
+	// method name cannot grow the per-method summary's cardinality either.
+	return nil, errorFrame(pr.ID, (&jrpc2.Error{
+		Code:    jrpc2.MethodNotFound,
+		Message: jrpc2.MethodNotFound.String(),
+	}).WithData(pr.Method))
 }
 
-// invoke runs one handler and builds its frame under the concurrency bound.
-func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler, notification bool) []byte {
+// invoke runs one handler and builds its frame. The caller holds the permit
+// for the whole call and releases it before any byte is written.
+func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
 	// context.Background, never the http.Request's context, and never a
 	// timeout of our own: this reproduces jrpc2's ServerOptions.NewContext
 	// default byte for byte. Handlers keep today's hangup semantics (a client
@@ -252,18 +366,8 @@ func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler, notifica
 	// is a separate, deliberate decision that has not been taken.
 	ctx := context.Background()
 
-	if err := h.sem.Acquire(ctx, 1); err != nil {
-		// Unreachable: Background is never canceled and Acquire only fails on
-		// a canceled context. Answered rather than dropped so a future ctx
-		// change cannot turn this into a silent 200 with no body.
-		return errorFrame(pr.ID, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
-	}
-	// Deferred, so the permit is released when this function returns the
-	// finished frame — i.e. strictly before the caller writes any byte.
-	defer h.sem.Release(1)
-
 	result, err := method(ctx, pr.ToRequest())
-	if notification {
+	if pr.ID == "" {
 		// "The Server MUST NOT reply to a Notification, including those that
 		// are within a batch request." The work is done; the answer is not
 		// sent. Errors are dropped exactly as jrpc2's invoke drops them.
@@ -288,6 +392,30 @@ func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler, notifica
 		return errorFrame(pr.ID, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
 	}
 	return resultFrame(pr.ID, bits)
+}
+
+// relayedPanic is a handler panic caught on a batch worker so the serving
+// goroutine can re-raise it. It carries the stack the handler actually
+// panicked on, because the recover that ends up logging it runs on a different
+// goroutine and debug.Stack() there would show only the relay.
+type relayedPanic struct {
+	value any
+	stack []byte
+}
+
+// String is what httpRequestDurationLimiter's "%v" of the recovered value
+// prints, so the original panic and its stack land in the log.
+func (p *relayedPanic) String() string {
+	return fmt.Sprintf("%v (panicked on a batch worker goroutine)\n%s", p.value, p.stack)
+}
+
+// catchPanic must be deferred directly, so that its recover is the worker's.
+// The first panic wins; later ones are dropped, exactly as only one panic can
+// be re-raised.
+func catchPanic(raised *atomic.Pointer[relayedPanic]) {
+	if v := recover(); v != nil {
+		raised.CompareAndSwap(nil, &relayedPanic{value: v, stack: debug.Stack()})
+	}
 }
 
 // handlerError maps a handler's error onto the wire error object, reproducing

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -313,6 +313,13 @@ func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte)
 //     There is no answer to give it and nobody to give one to: the 504 is
 //     already on the wire. serve writes nothing at all rather than assembling
 //     a response out of the survivors.
+//   - An element that needs no handler at all — a parse or shape error, an
+//     empty method, an unknown method — never reaches the permit, so the loop
+//     probes the request's Done channel per element as well. Without that,
+//     the one body that is ALL such elements (`[5,5,5,...]`, ~260,000 of them
+//     inside the 512KB cap) would keep building its 22MB of answers after the
+//     deadline. The permit covers the slow batches; this covers the cheap
+//     enormous one.
 //
 // So a canceled CALL element yields no frame, not an error frame. Building
 // one would allocate up to 22MB of answers for a batch whose reader is gone,
@@ -346,20 +353,31 @@ func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest
 	var wg sync.WaitGroup
 	var raised atomic.Pointer[relayedPanic]
 
+	// Read once: this loop asks per element, and ctx.Err() takes a lock every
+	// time where a closed-channel probe takes none.
+	dead := ctx.Done()
+
 	for i, pr := range reqs {
+		if isClosed(dead) {
+			// DELTA (g), the half the permit does not cover: an element that
+			// answers without a handler — a parse or shape error, an empty
+			// method, an unknown method — never reaches acquirePermit, so
+			// without this check a batch of nothing but those would keep
+			// building frames after the request was dead. That is the
+			// adversarial shape: `[5,5,5,...]` fits ~260,000 elements into the
+			// 512KB cap and 22MB of answers into a response nobody will read.
+			break
+		}
 		method, frame := h.route(pr)
 		if method == nil {
-			// Answered without running anything: a parse or shape error, an
-			// empty method, an unknown method, or a silent notification. No
-			// permit and no goroutine are spent on it.
+			// Answered without running anything. No permit and no goroutine
+			// are spent on it.
 			frames[i] = frame
 			continue
 		}
 		if !h.acquirePermit(ctx) {
-			// DELTA (g): the request is dead, so this element and every one
-			// after it stays unstarted and unanswered. Breaking rather than
-			// continuing is the point — routing the rest would build frames
-			// for a reader that is already gone.
+			// The request died while this element waited for the bound. Same
+			// answer as above: stop, and leave the rest unstarted.
 			break
 		}
 		//nolint:contextcheck // invoke's context is Background by design; see invoke
@@ -421,6 +439,16 @@ func (h *Handler) dispatchOne(ctx context.Context, pr *jrpc2.ParsedRequest) []by
 // it belongs to is over".
 func (h *Handler) acquirePermit(ctx context.Context) bool {
 	return h.sem.Acquire(ctx, 1) == nil
+}
+
+// isClosed reports whether c is closed, without blocking.
+func isClosed(c <-chan struct{}) bool {
+	select {
+	case <-c:
+		return true
+	default:
+		return false
+	}
 }
 
 // route decides how one parsed request is answered, WITHOUT running anything:

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -310,9 +310,9 @@ func (h *Handler) dispatchOne(pr *jrpc2.ParsedRequest) []byte {
 	return h.invoke(pr, method)
 }
 
-// acquirePermit takes one permit from the shared bound, returning nil. It
-// returns the frame that answers pr instead if the permit cannot be taken,
-// which is unreachable today: Background is never canceled and Acquire only
+// acquirePermit takes one permit from the shared bound and returns nil. If the
+// permit cannot be taken it returns the error frame that answers pr instead —
+// unreachable today, because Background is never canceled and Acquire only
 // fails on a canceled context. Answered rather than dropped so that a future
 // change of context cannot turn this into a silent 200 with no body.
 func (h *Handler) acquirePermit(pr *jrpc2.ParsedRequest) []byte {
@@ -613,7 +613,8 @@ func writeFrames(w http.ResponseWriter, isBatch bool, frames [][]byte) {
 		// dispatcher already built: no second copy of a 17MB body.
 		body = frames[0]
 	} else {
-		size := 2
+		// '[' + ']' is 2, and n frames carry n-1 commas: 1 + sum(len+1).
+		size := 1
 		for _, f := range frames {
 			size += len(f) + 1
 		}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -77,8 +77,11 @@ type Handler struct {
 	// per-method budget gets its permit back while its handler runs on, by
 	// design (network.RPCRequestDurationLimiter, and the graceMargin that
 	// exists for that gap), so goroutines executing handler code can exceed
-	// this by the number of timed-out requests. Shutdown joins them; nothing
-	// bounds them.
+	// this by the number of timed-out requests. Shutdown joins them, and what
+	// BOUNDS them is the per-method backlog limiter nested inside the duration
+	// limiter (jsonrpc.wrapWithLimiters), whose slot is held across the real
+	// call: QueueLimit per method, ~10,700 aggregate at v2 defaults. Far too
+	// loose to be an operative memory bound, and invisible from here.
 	sem *semaphore.Weighted
 
 	// weight is sem's size; Weighted does not expose it and Shutdown drains by
@@ -92,32 +95,33 @@ type Handler struct {
 	root     context.Context
 	stopRoot context.CancelFunc
 
-	// detached is the handler goroutines the per-method duration limiter
-	// abandoned at its own timeout. They have already given their permits
-	// back, so the bound cannot see them and Shutdown joins them separately.
-	detached *sync.WaitGroup
+	// liveHandlers is every handler execution under a budgeted method, not
+	// just the abandoned ones (see network.RPCRequestDurationLimiter). An
+	// abandoned one has given its permit back, so the bound cannot see it and
+	// Shutdown joins the group separately.
+	liveHandlers *sync.WaitGroup
 
 	drainOnce sync.Once
 	drainErr  error
 }
 
 // NewHandler returns the handler over methods, read-only from here on.
-// detached is the group the method table's duration limiters count their
+// liveHandlers is the group the method table's duration limiters count their
 // abandoned handler goroutines into; nil means nothing registers any.
-func NewHandler(methods map[string]jrpc2.Handler, detached *sync.WaitGroup) *Handler {
+func NewHandler(methods map[string]jrpc2.Handler, liveHandlers *sync.WaitGroup) *Handler {
 	weight := int64(runtime.GOMAXPROCS(0))
 	//nolint:gosec // G118: stopRoot is the handler's, called by Shutdown
 	root, stopRoot := context.WithCancel(context.Background())
-	if detached == nil {
-		detached = new(sync.WaitGroup)
+	if liveHandlers == nil {
+		liveHandlers = new(sync.WaitGroup)
 	}
 	return &Handler{
-		methods:  methods,
-		sem:      semaphore.NewWeighted(weight),
-		weight:   weight,
-		root:     root,
-		stopRoot: stopRoot,
-		detached: detached,
+		methods:      methods,
+		sem:          semaphore.NewWeighted(weight),
+		weight:       weight,
+		root:         root,
+		stopRoot:     stopRoot,
+		liveHandlers: liveHandlers,
 	}
 }
 
@@ -126,6 +130,14 @@ func NewHandler(methods map[string]jrpc2.Handler, detached *sync.WaitGroup) *Han
 // the whole bound, which IS "no dispatch is in flight" since every invocation
 // holds a permit, and then joins the handlers a per-method duration limiter
 // abandoned at its timeout, which gave their permits back long ago.
+//
+// THREE premises, none of them local. The caller closes its connections FIRST
+// — DELTA (g) gates an element's start on the REQUEST's context, so a live
+// connection keeps authorizing starts and the drain chases a moving target.
+// The method table's limiters count into the same group this handler was
+// built with. And the full-weight Acquire converges against an in-flight batch
+// only because x/sync queues a full-weight waiter ahead of the Acquire(1)s
+// behind it.
 //
 // The permits are never returned. An error means a straggler is still touching
 // what the caller is about to close. Idempotent; call it after the HTTP server
@@ -138,17 +150,17 @@ func (h *Handler) Shutdown(ctx context.Context) error {
 			return
 		}
 		// Only now: every permit is held, so no wrapper is running and none
-		// can start another detached handler behind the Wait.
-		if err := joinDetached(ctx, h.detached); err != nil {
+		// can launch another child behind the Wait.
+		if err := joinLiveHandlers(ctx, h.liveHandlers); err != nil {
 			h.drainErr = fmt.Errorf("wire: joining timed-out handlers: %w", err)
 		}
 	})
 	return h.drainErr
 }
 
-// joinDetached waits for wg, or for ctx to end. The waiter outlives this call
+// joinLiveHandlers waits for wg, or for ctx to end. The waiter outlives this call
 // when ctx wins; it ends when the stragglers do.
-func joinDetached(ctx context.Context, wg *sync.WaitGroup) error {
+func joinLiveHandlers(ctx context.Context, wg *sync.WaitGroup) error {
 	done := make(chan struct{})
 	go func() { wg.Wait(); close(done) }()
 	select {

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -1,19 +1,10 @@
-// Package wire frames JSON-RPC 2.0 over HTTP. Both mounts use it; it is the
-// only framing this repo serves.
+// Package wire frames JSON-RPC 2.0 over HTTP; both mounts use it.
 //
-// It replaced jrpc2's jhttp.Bridge, a loopback that marshaled every response
-// four times over. jrpc2 remains the parser and the vocabulary; this package
-// owns the envelope: one json.Marshal, one hand-appended envelope, one Write.
-//
-// Three rules here are LOAD-BEARING, each with a plausible-looking
-// "improvement" that silently reverses this package's reason to exist:
-// json.Marshal + Write (never json.NewEncoder), hand-appended batch frames
-// (never json.Marshal of a []json.RawMessage), and a batch worker's permit
-// taken before its goroutine is started (never inside it).
+// Three rules are LOAD-BEARING: json.Marshal + Write (never json.NewEncoder),
+// hand-appended batch frames (never json.Marshal of a []json.RawMessage), and
+// a batch worker's permit taken before its goroutine starts (never inside it).
 //
 // # The deltas
-//
-// Seven places answer differently from the bridge, argued at their sites:
 //
 //	(a) a malformed body is a -32700 frame over 200, not 500 + plaintext
 //	(b) an empty batch `[]` is a -32600 frame, not a 204
@@ -23,17 +14,11 @@
 //	(f) params reach handlers verbatim rather than re-marshaled
 //	(g) dispatch stops at the HTTP deadline; started elements still finish
 //
-// # Three jrpc2 accessors a handler must not use
-//
-// Handlers run on a SERVER-scoped context: derived from context.Background, so
-// no request cancels it, and canceled by Handler.Shutdown. It carries none of
-// the values jrpc2's Server.invoke attached, and none is fabricated back —
-// jrpc2.InboundRequest(ctx) returns nil, jrpc2.ServerFromContext(ctx) panics,
-// and (*jrpc2.Request).IsNotification() is false for EVERY request. The last
-// is the dangerous one because it fails quietly: it tests id == nil, and
-// ToRequest builds an empty-but-non-nil id for an absent one. Notification-ness
-// is ParsedRequest.ID == "". Take the request from the handler's second
-// argument. TestNoJRPC2ContextValueCallersInProductionCode fails on a caller.
+// Handlers run on a SERVER-scoped context, Background-derived and canceled only
+// by Handler.Shutdown. Three jrpc2 accessors are therefore unusable, and a
+// guard test pins that: InboundRequest returns nil, ServerFromContext panics,
+// and IsNotification is false for EVERY request — that one QUIETLY, so
+// notification-ness is ParsedRequest.ID == "".
 package wire
 
 import (
@@ -67,46 +52,34 @@ const (
 	nullID = "null"
 )
 
-// Transcriptions of jrpc2's unexported error vocabulary (jrpc2/error.go). The
-// cost is permanent: a `go get -u` moves the library's strings and leaves
-// these frozen. The byte-exact tests are what notice.
+// Transcribed from jrpc2's unexported vocabulary; byte-exact tests notice drift.
 var (
 	errEmptyMethod         = &jrpc2.Error{Code: jrpc2.InvalidRequest, Message: "empty method name"}
 	errEmptyBatch          = &jrpc2.Error{Code: jrpc2.InvalidRequest, Message: "empty request batch"}
 	errInvalidRequestValue = &jrpc2.Error{Code: jrpc2.ParseError, Message: "invalid request value"}
 )
 
-// Handler serves JSON-RPC 2.0 over HTTP for one method table.
-//
-// Mounted INSIDE the shared middleware chain jsonrpc.NewHandler builds:
-// cors -> MaxBytesHandler -> httpRequestDurationLimiter -> BacklogHTTPQLimiter
-// -> Handler. The duration limiter is the slow-client decoupler — it answers a
-// timed-out client with 504 while the handler is still live, safe only because
-// nothing has reached the socket, and flushes after the per-method limiters
-// and the view release, so a stalled client holds one flat []byte and nothing
-// else. rpcv2's deriveLifecycleGrace relies on that deadline. Do not bypass or
-// wrap it: bufferedResponseWriter has no Unwrap, Flusher or SetWriteDeadline.
+// Handler serves JSON-RPC 2.0 for one method table, mounted INSIDE the chain
+// jsonrpc.NewHandler builds: cors -> MaxBytesHandler ->
+// httpRequestDurationLimiter -> BacklogHTTPQLimiter -> Handler. Do not
+// bypass or wrap the duration limiter: it is the slow-client decoupler, has no
+// Unwrap/Flusher/SetWriteDeadline, and deriveLifecycleGrace needs its deadline.
 type Handler struct {
 	methods map[string]jrpc2.Handler
 
-	// sem bounds concurrent handler+marshal work: acquired before dispatch,
-	// released BEFORE the bytes reach the (buffered) ResponseWriter, so a slow
-	// reader cannot hold a permit. ONE semaphore for the whole handler, so a
-	// batch borrows from the process-wide budget instead of multiplying it.
-	//
-	// The weight is GOMAXPROCS, not jrpc2's NumCPU: since Go 1.25 GOMAXPROCS
-	// follows the cgroup CPU quota and NumCPU does not, and this is what caps
-	// the number of fat results marshaled at once. Matches the repo's
-	// convention (rpcv2/backfill.DefaultWorkers).
+	// sem bounds handler+marshal work, released BEFORE the bytes reach the
+	// (buffered) ResponseWriter so a slow reader cannot hold a permit. ONE for
+	// the whole handler, so a batch borrows from the budget rather than
+	// multiplying it. Weight is GOMAXPROCS (cgroup-aware), not NumCPU; it caps
+	// concurrent fat marshals; see backfill.DefaultWorkers.
 	sem *semaphore.Weighted
 
-	// weight is sem's size, kept because semaphore.Weighted does not expose
-	// it and Shutdown drains by acquiring all of it.
+	// weight is sem's size; Weighted does not expose it and Shutdown drains by
+	// acquiring all of it.
 	weight int64
 
-	// root is the SERVER-scoped lifetime every handler runs on. No request
-	// touches it; only Shutdown cancels it, which is what keeps a straggler
-	// from reading a store its daemon has already closed.
+	// root is the SERVER-scoped lifetime handlers run on. Only Shutdown cancels
+	// it, which is what stops a straggler reading an already-closed store.
 	//
 	//nolint:containedctx // a server's own lifetime, as http.Server holds one
 	root     context.Context
@@ -116,8 +89,7 @@ type Handler struct {
 	drainErr  error
 }
 
-// NewHandler returns the JSON-RPC handler over methods, which is the
-// decorated, limiter-wrapped table and is read-only from here on.
+// NewHandler returns the handler over methods, read-only from here on.
 func NewHandler(methods map[string]jrpc2.Handler) *Handler {
 	weight := int64(runtime.GOMAXPROCS(0))
 	//nolint:gosec // G118: stopRoot is the handler's, called by Shutdown
@@ -131,18 +103,11 @@ func NewHandler(methods map[string]jrpc2.Handler) *Handler {
 	}
 }
 
-// Shutdown cancels the context every handler runs on and waits for the running
-// handlers, or for ctx to end. An error means a straggler is still touching
-// whatever the caller is about to close.
-//
-// The wait is an acquire of the whole bound: every invocation happens between
-// an acquirePermit and its Release, so holding every permit IS "no handler is
-// running", with no second counter to keep in step. The permits are never
-// given back — a drained handler stays drained, and a request that arrives
-// anyway unwinds at its own deadline (DELTA (g)).
-//
-// Idempotent. Call it after the HTTP server has stopped accepting and before
-// the resources the handlers read are closed.
+// Shutdown cancels the root and waits by acquiring the whole bound — every
+// invocation holds a permit, so that IS "no handler is running". The permits
+// are never returned, and an error means a straggler is still touching what
+// the caller is about to close. Idempotent; call it after the HTTP server
+// stops accepting and before the handlers' resources are closed.
 func (h *Handler) Shutdown(ctx context.Context) error {
 	h.stopRoot()
 	h.drainOnce.Do(func() {
@@ -153,9 +118,8 @@ func (h *Handler) Shutdown(ctx context.Context) error {
 	return h.drainErr
 }
 
-// ServeHTTP implements http.Handler. The HTTP shell is byte-identical to
-// jhttp.Bridge.ServeHTTP: Accept-Post advertised unconditionally, non-POST 405
-// with no body, wrong media type or charset 415 with jhttp's exact plaintext.
+// ServeHTTP implements http.Handler. The shell is byte-identical to
+// jhttp.Bridge's: Accept-Post always, non-POST 405, bad media type 415.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Accept-Post", contentTypeJSON)
 
@@ -174,20 +138,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
-		// A transport event, not a JSON-RPC one: no request to answer and no
-		// id to echo. MaxBytesHandler takes this path for an oversized body.
+		// A transport event: no request to answer and no id to echo.
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(w, err.Error())
 		return
 	}
 
-	// req.Context() governs the DISPATCH — whether another element may start
-	// (DELTA (g)) — and nothing else. Handlers run on h.root; see invoke.
+	// req.Context() governs the DISPATCH only (DELTA (g)); handlers run on
+	// h.root.
 	h.serve(req.Context(), w, body)
 }
 
-// serve parses body, dispatches it, and writes the response. ctx is the HTTP
-// request's, used only to decide whether to keep dispatching.
+// serve parses, dispatches and writes. ctx is the HTTP request's, used only
+// to decide whether to keep dispatching.
 func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte) {
 	reqs, err := jrpc2.ParseRequests(body)
 	if err != nil {
@@ -196,66 +159,43 @@ func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte)
 		return
 	}
 	if len(reqs) == 0 {
-		// DELTA (b). A non-batch body always parses to exactly one element,
-		// so an empty slice means the body was `[]`.
+		// DELTA (b). A non-batch body parses to exactly one element.
 		writeFrames(w, false, [][]byte{errorFrame("", errEmptyBatch)})
 		return
 	}
 
-	isBatch := reqs[0].Batch // a property of the body, carried on every element
+	isBatch := reqs[0].Batch // a property of the body, on every element
 
 	frames := h.dispatchAll(ctx, reqs)
 	if ctx.Err() != nil {
-		// DELTA (g): the request died mid-dispatch, so there is nobody to
-		// answer. Falling through would have to choose between a partial
-		// batch array and 204ing an abandoned batch as all-notification.
+		// DELTA (g). Nobody to answer, and no honest answer to give.
 		return
 	}
 	if len(frames) == 0 {
-		// Every element was a notification, and DELTA (c) — all of them have
-		// finished, because dispatchAll joins every handler it started.
+		// All notifications, and DELTA (c) — all of them have finished.
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	writeFrames(w, isBatch, frames)
 }
 
-// dispatchAll answers every element of one parsed body and returns the frames
-// in INPUT order (DELTA (e)), the elements that get no response compacted out.
-// It returns only once every handler it started has, which is what lets
-// serve's 204 mean "the notifications have run".
+// dispatchAll answers every element in INPUT order (DELTA (e)), joining every
+// handler it started.
 //
-// A batch's elements run CONCURRENTLY: dispatched serially they sum their
-// latencies under the ONE HTTP deadline the mount enforces, so a batch of
-// individually-fine calls 504s where each call alone succeeds.
+// LOAD-BEARING: the permit is acquired HERE and released by the worker.
+// Acquire inside the worker and every element parks a goroutine on Acquire —
+// one body fits ~260,000 elements under the cap.
 //
-// LOAD-BEARING: the permit is acquired HERE, on the serving goroutine, and
-// released by the worker. Acquire inside the worker instead and every element
-// gets a goroutine parked on Acquire — and one body fits ~260,000 elements
-// under the cap. Acquiring first makes the in-flight worker count the
-// semaphore's weight, whatever the batch's length.
-//
-// Two contexts govern a dispatch and do not overlap: the REQUEST's decides
-// whether an element may START, the server-scoped root whether a running
-// handler may CONTINUE. DELTA (g) is the first of those:
-//
-//   - An element already inside its handler runs to completion; only Shutdown
-//     cancels it. wg.Wait joins every worker that started, so the unwind costs
-//     at most one element's duration.
-//   - An element that never got a permit yields NO FRAME, not an error frame:
-//     there is nobody to answer, and building answers for a departed reader is
-//     the work this stops.
-//   - An element that needs no handler never reaches the permit, so the loop
-//     probes the request's Done channel per element too.
+// Two contexts govern a dispatch: the REQUEST's decides whether an element may
+// START (DELTA (g)), the root whether a running handler may CONTINUE. An
+// element that never started yields NO FRAME, not an error one.
 func (h *Handler) dispatchAll(ctx context.Context, reqs []*jrpc2.ParsedRequest) [][]byte {
-	// One slot per element, by index, so response order is request order
-	// whatever the completion order. A nil slot gets no answer.
+	// By index, so response order is request order. A nil slot gets no answer.
 	frames := make([][]byte, len(reqs))
 
 	if len(reqs) == 1 {
-		// A single-element body never leaves this goroutine. Not an
-		// optimization: it is what lets its panic reach the limiter's recover
-		// with its OWN stack, unwrapped by relayedPanic.
+		// Not an optimization: staying here lets a panic reach the limiter's
+		// recover with its OWN stack.
 		frames[0] = h.dispatchOne(ctx, reqs[0])
 	} else {
 		h.dispatchBatch(ctx, reqs, frames)
@@ -263,8 +203,7 @@ func (h *Handler) dispatchAll(ctx context.Context, reqs []*jrpc2.ParsedRequest) 
 	return slices.DeleteFunc(frames, func(f []byte) bool { return f == nil })
 }
 
-// dispatchBatch runs the elements of a multi-element body into their own slots
-// of frames. See dispatchAll for the permit ordering and the dead-request rule.
+// dispatchBatch runs a multi-element body; see dispatchAll for the rules.
 func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest, frames [][]byte) {
 	var wg sync.WaitGroup
 	var raised atomic.Pointer[relayedPanic]
@@ -295,17 +234,14 @@ func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest
 	wg.Wait()
 
 	if p := raised.Load(); p != nil {
-		// A panic on a worker has nothing above it to recover and would take
-		// the process down. Re-raised here, once every sibling has finished,
-		// it fails only this HTTP request. A safety net, not a live path:
-		// every registered method carries a RequestDurationLimit, whose
-		// limiter recovers a handler panic into -32003 first.
+		// Nothing above a worker recovers, so an escaping panic would take the
+		// process down; re-raised here it fails only this request.
 		panic(p)
 	}
 }
 
-// dispatchOne answers one request on the calling goroutine, releasing its
-// permit before returning so the caller writes without one, panics included.
+// dispatchOne answers one request here, releasing its permit before returning
+// so the caller writes without one, panics included.
 func (h *Handler) dispatchOne(ctx context.Context, pr *jrpc2.ParsedRequest) []byte {
 	method, frame := h.route(pr)
 	if method == nil {
@@ -318,15 +254,12 @@ func (h *Handler) dispatchOne(ctx context.Context, pr *jrpc2.ParsedRequest) []by
 	return h.invoke(pr, method)
 }
 
-// acquirePermit takes one permit from the shared bound, blocking until it gets
-// one or ctx ends, and reports which happened. ctx is the HTTP request's — the
-// one place a request's lifetime reaches into dispatch (DELTA (g)). x/sync
-// gives back a permit won in the race, so false always means "did not run".
+// acquirePermit takes one permit, blocking until it gets one or ctx ends.
+// x/sync gives back a permit won in the race, so false means "did not run".
 func (h *Handler) acquirePermit(ctx context.Context) bool {
 	return h.sem.Acquire(ctx, 1) == nil
 }
 
-// isClosed reports whether c is closed, without blocking.
 func isClosed(c <-chan struct{}) bool {
 	select {
 	case <-c:
@@ -336,17 +269,11 @@ func isClosed(c <-chan struct{}) bool {
 	}
 }
 
-// route decides how one parsed request is answered WITHOUT running anything:
-// it returns the handler to invoke, or a nil handler and the finished frame,
-// which is itself nil for a request that gets no response at all.
-//
-// The order is load-bearing. Parse and shape errors answer with a frame even
-// for a notification, as the spec requires; an empty method name is the same
-// class and answers too (DELTA (d)); only then does notification-ness apply,
-// and only to DISPATCH results, so an unknown method or a handler error on a
-// notification is silent.
-//
-// Notification-ness is ParsedRequest.ID == ""; see the package doc.
+// route decides how one request is answered WITHOUT running anything: the
+// handler, or a nil handler and the frame (itself nil for no response). The
+// ORDER is load-bearing — parse and shape errors answer even for a
+// notification, then an empty method (DELTA (d)), and only then does
+// notification-ness apply, to DISPATCH results only.
 func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, []byte) {
 	if pr.Error != nil {
 		return nil, errorFrame(pr.ID, pr.Error)
@@ -354,63 +281,52 @@ func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, []byte) {
 	if pr.Method == "" {
 		return nil, errorFrame(pr.ID, errEmptyMethod)
 	}
-	// `method != nil` as well as ok: route says "run this" by returning a
-	// non-nil handler, so a nil table entry must not be able to say it.
+	// `method != nil` too: a nil table entry must not read as "run this".
 	if method, ok := h.methods[pr.Method]; ok && method != nil {
 		return method, nil
 	}
 	if pr.ID == "" {
 		return nil, nil // an unknown method on a notification is silent
 	}
-	// jrpc2's errNoSuchMethod frame, byte for byte. Resolved here, so no
-	// handler runs and no metric is labeled: an attacker-chosen method name
-	// cannot grow the per-method summary's cardinality.
+	// Resolved here, so no metric is labeled: an attacker-chosen method name
+	// cannot grow the summary's cardinality.
 	return nil, errorFrame(pr.ID, (&jrpc2.Error{
 		Code:    jrpc2.MethodNotFound,
 		Message: jrpc2.MethodNotFound.String(),
 	}).WithData(pr.Method))
 }
 
-// invoke runs one handler and builds its frame. The caller holds the permit
-// for the whole call and releases it before any byte is written.
+// invoke runs one handler and frames it; the caller holds the permit.
 func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
-	// The SERVER's lifetime, never the http.Request's: a client that hangs up
-	// mid-call still completes it, which sendTransaction depends on.
+	// The SERVER's lifetime: a client that hangs up mid-call still completes
+	// it, which sendTransaction depends on.
 	ctx := h.root
 
-	// DELTA (f): ToRequest hands over the params bytes the body carried, in
-	// the client's key order and whitespace and with its own escapes. rpcv2's
-	// getEventsV2 reads ParamString, so those raw bytes are contract.
+	// DELTA (f): the params bytes go over verbatim, and rpcv2's getEventsV2
+	// reads ParamString, so those raw bytes are contract.
 	result, err := method(ctx, pr.ToRequest())
 	if pr.ID == "" {
 		// "The Server MUST NOT reply to a Notification, including those that
-		// are within a batch request." The work is done, the answer is not
-		// sent, and an error is dropped as jrpc2's invoke drops it.
+		// are within a batch request."
 		return nil
 	}
 	if err != nil {
 		return errorFrame(pr.ID, handlerError(err))
 	}
 
-	// THE one marshal. LOAD-BEARING: json.Marshal, never
-	// json.NewEncoder(w).Encode — Encode's deferred encodeStatePool.Put fires
-	// after enc.w.Write, so N stalled clients pin N full-size pooled buffers,
-	// and under GOEXPERIMENT=jsonv2 it copies through its own buffer,
-	// reintroducing exactly the copy this package deletes. Marshal also lets
-	// Content-Length be set.
+	// THE one marshal. LOAD-BEARING: never json.NewEncoder(w).Encode — its
+	// pool Put fires after the Write, so N stalled clients pin N pooled
+	// buffers, and under jsonv2 it copies through its own buffer.
 	bits, err := json.Marshal(result)
 	if err != nil {
-		// Through handlerError, not a hand-built InternalError: jrpc2 runs a
-		// marshal failure down the same ladder a handler error takes, which
-		// answers -32098, never -32603.
+		// Through handlerError: a marshal failure is -32098, never -32603.
 		return errorFrame(pr.ID, handlerError(err))
 	}
 	return frame(pr.ID, resultKey, bits)
 }
 
-// relayedPanic is a handler panic caught on a batch worker so the serving
-// goroutine can re-raise it, carrying the stack the handler panicked on —
-// the recover that logs it runs elsewhere, where debug.Stack() shows the relay.
+// relayedPanic carries a worker's panic and the stack it panicked on, not the
+// relay's, to the serving goroutine.
 type relayedPanic struct {
 	value any
 	stack []byte
@@ -421,21 +337,17 @@ func (p *relayedPanic) String() string {
 	return fmt.Sprintf("%v (panicked on a batch worker goroutine)\n%s", p.value, p.stack)
 }
 
-// catchPanic must be deferred directly, so its recover is the worker's. The
-// first panic wins; only one can be re-raised.
+// catchPanic must be deferred directly, so its recover is the worker's.
 func catchPanic(raised *atomic.Pointer[relayedPanic]) {
 	if v := recover(); v != nil {
 		raised.CompareAndSwap(nil, &relayedPanic{value: v, stack: debug.Stack()})
 	}
 }
 
-// handlerError maps a handler's error onto the wire error object, reproducing
-// jrpc2's tasks.responses exactly, bare type assertion included: a WRAPPED
-// *jrpc2.Error falls to the ErrorCode branch, keeping the code and taking the
-// wrapper's message. Looks like a bug and is pinned as behavior: network's
-// limiter sentinels are jrpc2.Error VALUES, so the assertion misses them and
-// err.Error() — "[%d] %s" — supplies the message, giving those wire messages a
-// redundant "[-32001] " prefix. They always have.
+// handlerError reproduces jrpc2's tasks.responses exactly, bare type assertion
+// included. Pinned, not a bug: network's limiter sentinels are jrpc2.Error
+// VALUES, so the assertion misses them and their message keeps its own
+// "[-32001] " prefix.
 func handlerError(err error) *jrpc2.Error {
 	if e, ok := err.(*jrpc2.Error); ok { //nolint:errorlint // jrpc2 asserts, it does not unwrap
 		return e
@@ -446,9 +358,7 @@ func handlerError(err error) *jrpc2.Error {
 	return &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()}
 }
 
-// parseError recovers the *jrpc2.Error ParseRequests reports for a body that
-// is not valid JSON. The fallback only guards a future library that returns
-// something other than its errInvalidRequest.
+// parseError recovers the *jrpc2.Error ParseRequests reports for bad JSON.
 func parseError(err error) *jrpc2.Error {
 	if e, ok := err.(*jrpc2.Error); ok { //nolint:errorlint // matching jrpc2's own assertion style
 		return e
@@ -456,14 +366,10 @@ func parseError(err error) *jrpc2.Error {
 	return errInvalidRequestValue
 }
 
-// frame builds {"jsonrpc":"2.0","id":<id>,<key><payload>}. id is the request's
-// raw id text, or "" for one with no usable id, which answers a null id.
-//
-// The capacity is the frame's exact byte length, so a frame is one allocation
-// and one copy — which is why the arithmetic and the appends it predicts sit
-// in the same six lines. No assertion on the RESPONSE can catch it being
-// wrong: append grows silently and the bytes come out identical while the
-// payload is re-copied. TestFrameIsExactlyOneAllocation pins it on cap.
+// frame builds {"jsonrpc":"2.0","id":<id>,<key><payload>}; id is the raw id
+// text, or "" for one with no usable id, which answers a null id. The capacity
+// must be the frame's EXACT length — nothing about the response can catch it
+// being wrong, so TestFrameIsExactlyOneAllocation pins it on cap.
 func frame(id, key string, payload []byte) []byte {
 	out := make([]byte, 0, len(framePrefix)+idLen(id)+len(key)+len(payload)+1)
 	out = append(out, framePrefix...)
@@ -473,13 +379,10 @@ func frame(id, key string, payload []byte) []byte {
 	return append(out, '}')
 }
 
-// errorFrame builds the frame for one error object.
 func errorFrame(id string, e *jrpc2.Error) []byte {
 	bits, err := json.Marshal(e)
 	if err != nil {
-		// Only reachable if a handler hand-built an Error whose Data is not
-		// valid JSON. Answer something well-formed rather than nothing; the
-		// bridge hung the request until its deadline here.
+		// Only reachable for an Error whose Data is not valid JSON.
 		bits, err = json.Marshal(&jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
 		if err != nil {
 			bits = []byte(`{"code":-32603,"message":"internal error"}`)
@@ -488,17 +391,11 @@ func errorFrame(id string, e *jrpc2.Error) []byte {
 	return frame(id, errorKey, bits)
 }
 
-// appendID writes the request's id back exactly as the client sent it —
-// string, number or null — with one transformation that is NOT optional. The
-// id is raw client bytes, escaped today only as a side effect of the
-// compaction passes this package deletes, so splicing it plain would reflect
+// appendID writes the id back exactly as the client sent it, LOAD-BEARINGLY
+// applying stdlib appendCompact(escape=true)'s escaping — <, >, & and
+// U+2028/U+2029 — at the splice. "Simplifying" this to a plain append reflects
 // up to 512KB of client-controlled bytes into a response with no nosniff
-// header from a mount with fully open CORS.
-//
-// LOAD-BEARING: the escaping stdlib's appendCompact(escape=true) applies —
-// <, >, & and U+2028/U+2029 — is applied here at the splice. "Simplifying"
-// this to a plain append is a security regression, not a saving. Numbers pass
-// through untouched, so no id loses a digit and no float round-trip happens.
+// header from a mount with open CORS. Numbers pass through untouched.
 func appendID(dst []byte, id string) []byte {
 	if id == "" {
 		return append(dst, nullID...)
@@ -525,8 +422,7 @@ func idLen(id string) int {
 
 const hexDigits = "0123456789abcdef"
 
-// appendHTMLEscaped is encoding/json's appendHTMLEscape, over a string, for the
-// one field this package writes without routing through the encoder.
+// appendHTMLEscaped is encoding/json's appendHTMLEscape, over a string.
 func appendHTMLEscaped(dst []byte, src string) []byte {
 	start := 0
 	for i := range len(src) {
@@ -547,14 +443,10 @@ func appendHTMLEscaped(dst []byte, src string) []byte {
 	return append(dst, src[start:]...)
 }
 
-// writeFrames writes the response body: one frame bare, or the frames joined
-// inside a JSON array when the request was a batch, a one-element batch
-// included.
-//
-// LOAD-BEARING: the array is hand-appended. json.Marshal of a
-// []json.RawMessage sends every frame through marshalerEncoder, whose
-// unconditional appendCompact re-validates and re-copies the whole payload —
-// the largest thing this package exists to delete, and an invisible mistake.
+// writeFrames writes the body: one frame bare, or the frames joined inside a
+// JSON array for a batch, a one-element batch included. LOAD-BEARING: the
+// array is hand-appended — json.Marshal of a []json.RawMessage sends every
+// frame through marshalerEncoder, which re-copies the whole payload.
 func writeFrames(w http.ResponseWriter, isBatch bool, frames [][]byte) {
 	var body []byte
 	if !isBatch && len(frames) == 1 {
@@ -577,9 +469,7 @@ func writeFrames(w http.ResponseWriter, isBatch bool, frames [][]byte) {
 		body = append(body, ']')
 	}
 
-	// One Write of the finished body, into the duration limiter's buffered
-	// writer. The body is fully materialized, so Content-Length is set rather
-	// than leaving the client to discover it from a chunked stream.
+	// One Write; the body is materialized, so Content-Length is set.
 	w.Header().Set("Content-Type", contentTypeJSON)
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(http.StatusOK)

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -15,23 +15,20 @@
 //     goroutine on the semaphore, and one request body fits ~260,000
 //     elements.
 //
-// # The deltas
+// Deltas from the retired jhttp.Bridge, argued at their sites:
 //
 //	(a) a malformed body is a -32700 frame over 200, not 500 + plaintext
-//	(b) an empty batch `[]` is a -32600 frame, not a 204
-//	(c) notifications have finished, or been answered-at-budget and abandoned
-//	    per the limiter's contract, before the 204
-//	(d) an empty-method notification is answered rather than 204'd
+//	(b) an empty batch is a -32600 frame, not a 204
+//	(c) a notification has finished before its 204, unless its budget expired
+//	(d) an empty-method notification is answered, not 204'd
 //	(e) batch frames come back in input order
-//	(f) params reach handlers verbatim rather than re-marshaled
-//	(g) dispatch stops at the HTTP deadline; started elements still finish
+//	(f) params reach handlers verbatim, not re-marshaled
+//	(g) dispatch stops at the HTTP deadline; started elements finish
 //
-// Handlers run on a SERVER-scoped context, Background-derived, so a client's
-// disconnect does not cancel a handler; the method budget does, and at
-// teardown Handler.Shutdown does. Three jrpc2 accessors are unusable, and a
-// guard test pins that: InboundRequest returns nil, ServerFromContext panics,
-// and IsNotification is false for EVERY request — that one QUIETLY, so
-// notification-ness is ParsedRequest.ID == "".
+// Handlers run on a server-scoped context: no request cancels it, the method
+// budget and Shutdown do. jrpc2.InboundRequest returns nil, ServerFromContext
+// panics, and IsNotification is false for every request; notification-ness is
+// ParsedRequest.ID == "". A guard test pins all three.
 package wire
 
 import (
@@ -57,8 +54,8 @@ import (
 const (
 	contentTypeJSON = "application/json"
 
-	// framePrefix opens every response frame; the id follows immediately, then
-	// resultKey or errorKey. Field order matches jrpc2's jmessage.toJSON.
+	// framePrefix opens every frame; the id follows, then resultKey or
+	// errorKey. Field order matches jrpc2's jmessage.toJSON.
 	framePrefix = `{"jsonrpc":"2.0","id":`
 	resultKey   = `,"result":`
 	errorKey    = `,"error":`
@@ -67,53 +64,42 @@ const (
 	nullID = "null"
 )
 
-// Transcribed from jrpc2's unexported vocabulary; byte-exact tests notice drift.
+// Transcribed from jrpc2's unexported error vocabulary. An upgrade that moves
+// one of the originals leaves these frozen; the byte-exact tests notice.
 var (
 	errEmptyMethod         = &jrpc2.Error{Code: jrpc2.InvalidRequest, Message: "empty method name"}
 	errEmptyBatch          = &jrpc2.Error{Code: jrpc2.InvalidRequest, Message: "empty request batch"}
 	errInvalidRequestValue = &jrpc2.Error{Code: jrpc2.ParseError, Message: "invalid request value"}
 )
 
-// Handler serves JSON-RPC 2.0 for one method table, mounted INSIDE the chain
-// jsonrpc.NewHandler builds: cors -> MaxBytesHandler ->
-// httpRequestDurationLimiter -> BacklogHTTPQLimiter -> Handler. Do not
-// bypass or wrap the duration limiter: it is the slow-client decoupler, has no
-// Unwrap/Flusher/SetWriteDeadline, and deriveLifecycleGrace needs its deadline.
+// Handler serves JSON-RPC 2.0 for one method table, mounted last in the chain
+// jsonrpc.NewHandler builds. Do not bypass or wrap the duration limiter above
+// it: it abandons slow clients, safe only while nothing beneath it has written
+// to the socket, and rpcv2's deriveLifecycleGrace reads its deadline.
 type Handler struct {
 	methods map[string]jrpc2.Handler
 
-	// sem bounds handler+marshal work, released BEFORE the bytes reach the
-	// (buffered) ResponseWriter so a slow reader cannot hold a permit. ONE for
-	// the whole handler, so a batch borrows from the budget rather than
-	// multiplying it. Weight is GOMAXPROCS (cgroup-aware), not NumCPU; it caps
-	// concurrent fat marshals; see backfill.DefaultWorkers.
-	//
-	// It bounds DISPATCHES, not handler goroutines: a request that outruns its
-	// per-method budget gets its permit back while its handler runs on, by
-	// design (network.RPCRequestDurationLimiter, and the graceMargin that
-	// exists for that gap), so goroutines executing handler code can exceed
-	// this by the number of timed-out requests. Shutdown joins them, and what
-	// BOUNDS them is the per-method backlog limiter nested inside the duration
-	// limiter (jsonrpc.wrapWithLimiters), whose slot is held across the real
-	// call: QueueLimit per method, ~10,700 aggregate at v2 defaults. Far too
-	// loose to be an operative memory bound, and invisible from here.
+	// sem bounds handler and marshal work, one for the whole handler, released
+	// before any byte reaches the ResponseWriter. Weight is GOMAXPROCS, which
+	// follows a container's CPU quota. It counts dispatches, not handler
+	// goroutines: a request past its budget returns its permit and keeps
+	// running, bounded instead by QueueLimit.
 	sem *semaphore.Weighted
 
-	// weight is sem's size; Weighted does not expose it and Shutdown drains by
+	// weight is sem's size; Weighted does not expose it, and Shutdown drains by
 	// acquiring all of it.
 	weight int64
 
-	// root is the SERVER-scoped lifetime handlers run on. Only Shutdown cancels
-	// it, which is what stops a straggler reading an already-closed store.
+	// root is the server-scoped context handlers run on. No request cancels it;
+	// Shutdown does, which is what stops a straggler reading a closed store.
 	//
 	//nolint:containedctx // a server's own lifetime, as http.Server holds one
 	root     context.Context
 	stopRoot context.CancelFunc
 
-	// liveHandlers is every handler execution under a budgeted method, not
-	// just the abandoned ones (see network.RPCRequestDurationLimiter). An
-	// abandoned one has given its permit back, so the bound cannot see it and
-	// Shutdown joins the group separately.
+	// liveHandlers counts every handler execution under a budgeted method, not
+	// only the abandoned ones. An abandoned one has returned its permit, so sem
+	// cannot see it and Shutdown joins this group separately.
 	liveHandlers *network.LiveHandlers
 
 	drainOnce sync.Once
@@ -121,8 +107,8 @@ type Handler struct {
 }
 
 // NewHandler returns the handler over methods, read-only from here on.
-// liveHandlers must be the SAME group the method table's duration limiters
-// count into — jsonrpc.NewHandler is the one place that has both.
+// liveHandlers must be the group the method table's duration limiters count
+// into; jsonrpc.NewHandler is the only caller that holds both ends.
 func NewHandler(methods map[string]jrpc2.Handler, liveHandlers *network.LiveHandlers) *Handler {
 	weight := int64(runtime.GOMAXPROCS(0))
 	//nolint:gosec // G118: stopRoot is the handler's, called by Shutdown
@@ -141,23 +127,12 @@ func NewHandler(methods map[string]jrpc2.Handler, liveHandlers *network.LiveHand
 	}
 }
 
-// Shutdown cancels the root and waits for every handler this mount can still
-// be running, in two steps, because two things can be running one: it acquires
-// the whole bound, which IS "no dispatch is in flight" since every invocation
-// holds a permit, and then joins the handlers a per-method duration limiter
-// abandoned at its timeout, which gave their permits back long ago.
-//
-// THREE premises, none of them local. The caller closes its connections FIRST
-// — DELTA (g) gates an element's start on the REQUEST's context, so a live
-// connection keeps authorizing starts and the drain chases a moving target.
-// The method table's limiters count into the same group this handler was
-// built with. And the full-weight Acquire converges against an in-flight batch
-// only because x/sync queues a full-weight waiter ahead of the Acquire(1)s
-// behind it.
-//
-// The permits are never returned. An error means a straggler is still touching
-// what the caller is about to close. Idempotent; call it after the HTTP server
-// stops accepting and before the handlers' resources are closed.
+// Shutdown cancels the root, acquires the whole bound (every invocation holds
+// a permit, so that is "no dispatch in flight"), then joins liveHandlers for
+// the handlers a duration limiter abandoned. Permits are not returned; an
+// error means a straggler is still running. Idempotent. The caller must close
+// its connections first, or live requests keep starting elements; convergence
+// relies on x/sync queueing a full-weight waiter ahead of Acquire(1)s.
 func (h *Handler) Shutdown(ctx context.Context) error {
 	h.stopRoot()
 	h.drainOnce.Do(func() {
@@ -165,8 +140,8 @@ func (h *Handler) Shutdown(ctx context.Context) error {
 			h.drainErr = fmt.Errorf("wire: draining handlers: %w", err)
 			return
 		}
-		// Only now: every permit is held, so no wrapper is running and none
-		// can launch another child behind the Wait.
+		// Safe only with every permit held: no limiter is running, so none can
+		// add to the group behind the Wait.
 		if err := joinLiveHandlers(ctx, h.liveHandlers); err != nil {
 			h.drainErr = fmt.Errorf("wire: joining timed-out handlers: %w", err)
 		}
@@ -174,8 +149,8 @@ func (h *Handler) Shutdown(ctx context.Context) error {
 	return h.drainErr
 }
 
-// joinLiveHandlers waits for wg, or for ctx to end. The waiter outlives this call
-// when ctx wins; it ends when the stragglers do.
+// joinLiveHandlers waits for wg or for ctx, whichever first. On ctx the waiter
+// outlives this call and ends when the stragglers do.
 func joinLiveHandlers(ctx context.Context, wg *network.LiveHandlers) error {
 	done := make(chan struct{})
 	go func() { wg.Wait(); close(done) }()
@@ -187,8 +162,8 @@ func joinLiveHandlers(ctx context.Context, wg *network.LiveHandlers) error {
 	}
 }
 
-// ServeHTTP implements http.Handler. The shell is byte-identical to
-// jhttp.Bridge's: Accept-Post always, non-POST 405, bad media type 415.
+// ServeHTTP implements http.Handler, byte for byte as jhttp.Bridge did:
+// Accept-Post on every response, non-POST 405, wrong media type or charset 415.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Accept-Post", contentTypeJSON)
 
@@ -207,66 +182,65 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
-		// A transport event: no request to answer and no id to echo.
+		// No request to answer and no id to echo. A body over the size cap
+		// also arrives here.
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(w, err.Error())
 		return
 	}
 
-	// req.Context() governs the DISPATCH only (DELTA (g)); handlers run on
-	// h.root.
+	// The request context decides only whether dispatch keeps starting
+	// elements; handlers run on h.root.
 	h.serve(req.Context(), w, body)
 }
 
-// serve parses, dispatches and writes. ctx is the HTTP request's, used only
-// to decide whether to keep dispatching.
+// serve parses, dispatches and writes. ctx is the request's, used only to
+// decide whether dispatch continues.
 func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte) {
 	reqs, err := jrpc2.ParseRequests(body)
 	if err != nil {
-		// DELTA (a).
+		// Delta (a).
 		writeFrames(w, false, [][]byte{errorFrame("", parseError(err))})
 		return
 	}
 	if len(reqs) == 0 {
-		// DELTA (b). A non-batch body parses to exactly one element.
+		// Delta (b). A non-batch body parses to exactly one element, so an
+		// empty result means the body was `[]`.
 		writeFrames(w, false, [][]byte{errorFrame("", errEmptyBatch)})
 		return
 	}
 
-	isBatch := reqs[0].Batch // a property of the body, on every element
+	// Batch-ness is a property of the body, recorded on every element.
+	isBatch := reqs[0].Batch
 
 	frames := h.dispatchAll(ctx, reqs)
 	if ctx.Err() != nil {
-		// DELTA (g). Nobody to answer, and no honest answer to give.
+		// Delta (g). Nobody to answer; a partial array and a 204 are both
+		// wrong.
 		return
 	}
 	if len(frames) == 0 {
-		// All notifications, and DELTA (c) — each has finished, or its
-		// method budget expired and the limiter abandoned it. dispatchAll
-		// joins the dispatches, not the limiter's children.
+		// Delta (c). Each has finished, unless its budget expired first:
+		// dispatchAll joins dispatches, not what a limiter abandoned.
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	writeFrames(w, isBatch, frames)
 }
 
-// dispatchAll answers every element in INPUT order (DELTA (e)), joining every
-// handler it started.
-//
-// LOAD-BEARING: the permit is acquired HERE and released by the worker.
-// Acquire inside the worker and every element parks a goroutine on Acquire —
-// one body fits ~260,000 elements under the cap.
-//
-// Two contexts govern a dispatch: the REQUEST's decides whether an element may
-// START (DELTA (g)), the root whether a running handler may CONTINUE. An
-// element that never started yields NO FRAME, not an error one.
+// dispatchAll answers every element in input order (delta (e)) and returns
+// only once every handler it started has. A batch's elements run concurrently;
+// serially they would sum their durations under one HTTP deadline. The request
+// context decides whether an element may start (delta (g)), the root whether a
+// running handler continues. An element that never started yields no frame.
 func (h *Handler) dispatchAll(ctx context.Context, reqs []*jrpc2.ParsedRequest) [][]byte {
-	// By index, so response order is request order. A nil slot gets no answer.
+	// One slot per element, by index, so response order does not depend on
+	// completion order. A nil slot gets no answer.
 	frames := make([][]byte, len(reqs))
 
 	if len(reqs) == 1 {
 		// Not an optimization: staying here lets a panic reach the limiter's
-		// recover with its OWN stack.
+		// recover with its own stack rather than a relayedPanic.
 		frames[0] = h.dispatchOne(ctx, reqs[0])
 	} else {
 		h.dispatchBatch(ctx, reqs, frames)
@@ -274,21 +248,22 @@ func (h *Handler) dispatchAll(ctx context.Context, reqs []*jrpc2.ParsedRequest) 
 	return slices.DeleteFunc(frames, func(f []byte) bool { return f == nil })
 }
 
-// dispatchBatch runs a multi-element body; see dispatchAll for the rules.
+// dispatchBatch runs a multi-element body into its own slots of frames. See
+// dispatchAll for the permit ordering and the dead-request rule.
 func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest, frames [][]byte) {
 	var wg sync.WaitGroup
 	var raised atomic.Pointer[relayedPanic]
 
-	// Read once: ctx.Err() takes a lock per call, a channel probe does not.
+	// Read once and probe per element: ctx.Err() takes a lock every call.
 	dead := ctx.Done()
 
-	// Errors answerable without a handler, by index, built below rather than
-	// here: one body can carry ~260,000 of them and ~23MB of frames.
+	// Errors answerable without a handler, recorded here and framed below
+	// under one permit: a body holds ~260k of them, ~23MB of frames.
 	var static []*jrpc2.Error
 
 	for i, pr := range reqs {
 		if isClosed(dead) {
-			// DELTA (g) for the elements that never reach acquirePermit.
+			// Delta (g) for elements that never reach acquirePermit.
 			break
 		}
 		method, rerr := h.route(pr)
@@ -299,26 +274,24 @@ func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest
 				}
 				static[i] = rerr
 			}
-			continue // no permit and no goroutine spent on it
+			continue // no permit and no goroutine spent
 		}
 		if !h.acquirePermit(ctx) {
 			break // the request died waiting for the bound
 		}
 		wg.Go(func() {
-			// Released before the caller writes a byte, panics included.
+			// Deferred: returned once the frame is built, before any write,
+			// and on a panicking handler too.
 			defer h.sem.Release(1)
 			defer catchPanic(&raised)
 			frames[i] = h.invoke(pr, method)
 		})
 	}
 
-	// ONE permit for every static frame, not one per element: a hostile body
-	// would otherwise put ~260,000 acquire/release cycles through a semaphore
-	// every legitimate request shares. Safe to take here — this goroutine
-	// holds nothing, so it cannot deadlock against the workers above. The
-	// parse that precedes it is ~7x larger for the same body and is bounded by
-	// the backlog limit times the body cap, not by this; that is pre-existing
-	// and true of the bridge too.
+	// One permit for all of them, not one per element: ~260k acquire cycles
+	// would tax every ordinary request. Safe here — this goroutine holds
+	// nothing, so it cannot deadlock against its workers. The parse costs more
+	// again and is bounded by the backlog limit and the body cap, not by this.
 	if static != nil && !isClosed(dead) && h.acquirePermit(ctx) {
 		for i, rerr := range static {
 			if rerr != nil {
@@ -330,36 +303,37 @@ func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest
 	wg.Wait()
 
 	if p := raised.Load(); p != nil {
-		// Nothing above a worker recovers, so an escaping panic would take the
-		// process down; re-raised here it fails only this request.
+		// Nothing above a worker recovers, so an escaping panic ends the
+		// process; re-raised here it fails only this request.
 		panic(p)
 	}
 }
 
-// dispatchOne answers one request here, releasing its permit before returning
-// so the caller writes without one, panics included.
+// dispatchOne answers one request on the calling goroutine, releasing its
+// permit before returning so the caller writes without one, panics included.
 func (h *Handler) dispatchOne(ctx context.Context, pr *jrpc2.ParsedRequest) []byte {
 	method, rerr := h.route(pr)
 	if method == nil {
 		if rerr == nil {
 			return nil
 		}
-		// One frame, so it is built here rather than deferred as a batch's are.
+		// One frame, so it is not worth deferring as a batch's are.
 		return errorFrame(pr.ID, rerr)
 	}
 	if !h.acquirePermit(ctx) {
-		return nil // DELTA (g): never started, so there is nothing to answer.
+		return nil // delta (g): never started, so nothing to answer
 	}
 	defer h.sem.Release(1)
 	return h.invoke(pr, method)
 }
 
 // acquirePermit takes one permit, blocking until it gets one or ctx ends.
-// x/sync gives back a permit won in the race, so false means "did not run".
+// x/sync returns a permit won in the race, so false means "did not run".
 func (h *Handler) acquirePermit(ctx context.Context) bool {
 	return h.sem.Acquire(ctx, 1) == nil
 }
 
+// isClosed reports whether c has been closed, without blocking on it.
 func isClosed(c <-chan struct{}) bool {
 	select {
 	case <-c:
@@ -369,14 +343,12 @@ func isClosed(c <-chan struct{}) bool {
 	}
 }
 
-// route decides how one request is answered WITHOUT running anything: the
-// handler, or a nil handler and the error to answer with (itself nil when the
-// request gets no response). It returns the error rather than the frame so the
-// caller can choose when to pay for the bytes — see dispatchBatch.
-//
-// The ORDER is load-bearing — parse and shape errors answer even for a
-// notification, then an empty method (DELTA (d)), and only then does
-// notification-ness apply, to DISPATCH results only.
+// route decides how one request is answered without running anything: the
+// handler, or a nil handler and the error (itself nil for no response). It
+// returns the error, not the frame, so the caller chooses when to spend the
+// bytes. Order is load-bearing: parse and shape errors answer even for a
+// notification, then an empty method (delta (d)), and only then does
+// notification-ness suppress dispatch results.
 func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, *jrpc2.Error) {
 	if pr.Error != nil {
 		return nil, pr.Error
@@ -384,64 +356,60 @@ func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, *jrpc2.Error) {
 	if pr.Method == "" {
 		return nil, errEmptyMethod
 	}
-	// `method != nil` too: a nil table entry must not read as "run this".
+	// Checked for nil as well as present: this signals "run this" by returning
+	// a non-nil handler, so a nil entry would drop the element silently.
 	if method, ok := h.methods[pr.Method]; ok && method != nil {
 		return method, nil
 	}
 	if pr.ID == "" {
 		return nil, nil // an unknown method on a notification is silent
 	}
-	// Resolved here, so no metric is labeled: an attacker-chosen method name
-	// cannot grow the summary's cardinality.
+	// Answered without invoking anything, so no metric is labeled: invented
+	// method names cannot grow the summary's cardinality.
 	return nil, (&jrpc2.Error{
 		Code:    jrpc2.MethodNotFound,
 		Message: jrpc2.MethodNotFound.String(),
 	}).WithData(pr.Method)
 }
 
-// invoke runs one handler and frames it; the caller holds the permit.
+// invoke runs one handler and builds its frame; the caller holds the permit.
 func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
-	// The SERVER's lifetime, so a client's disconnect does not cancel a
-	// handler — the METHOD BUDGET does, via the WithTimeout the per-method
-	// duration limiter derives from this. That is the property
-	// sendTransaction depends on: nothing the caller does mid-call decides
-	// whether the submission happens.
+	// The server's lifetime: a client's disconnect does not cancel a handler,
+	// the method budget does. sendTransaction depends on that.
 	ctx := h.root
 
-	// DELTA (f): the params bytes go over verbatim, and rpcv2's getEventsV2
-	// reads ParamString, so those raw bytes are contract.
+	// Delta (f). rpcv2's getEventsV2 reads ParamString, so the raw bytes are
+	// contract.
 	result, err := method(ctx, pr.ToRequest())
 	if pr.ID == "" {
 		// "The Server MUST NOT reply to a Notification, including those that
-		// are within a batch request." Deliberately NOT joined here: waiting
-		// for an over-budget notification would tie the 204 and its backlog
-		// slot to straggler duration — the coupling the duration limiter
-		// exists to break — for a difference no notification client can see.
+		// are within a batch request." An over-budget one is not waited for:
+		// that would tie the 204 and its backlog slot to straggler duration.
 		return nil
 	}
 	if err != nil {
 		return errorFrame(pr.ID, handlerError(err))
 	}
 
-	// THE one marshal. LOAD-BEARING: never json.NewEncoder(w).Encode — its
-	// pool Put fires after the Write, so N stalled clients pin N pooled
-	// buffers, and under jsonv2 it copies through its own buffer.
+	// The one marshal, and it stays json.Marshal: Encode returns its pooled
+	// buffer only after writing, so stalled clients pin one each.
 	bits, err := json.Marshal(result)
 	if err != nil {
-		// Through handlerError: a marshal failure is -32098, never -32603.
+		// Through handlerError: jrpc2 maps a marshal failure down the handler
+		// ladder, which makes it -32098, not -32603.
 		return errorFrame(pr.ID, handlerError(err))
 	}
 	return frame(pr.ID, resultKey, bits)
 }
 
-// relayedPanic carries a worker's panic and the stack it panicked on, not the
-// relay's, to the serving goroutine.
+// relayedPanic carries a worker's panic to the serving goroutine with the
+// stack it panicked on; the recover that logs it runs elsewhere.
 type relayedPanic struct {
 	value any
 	stack []byte
 }
 
-// String is what the limiter's "%v" of the recovered value prints.
+// String is what the limiter prints for the recovered value.
 func (p *relayedPanic) String() string {
 	return fmt.Sprintf("%v (panicked on a batch worker goroutine)\n%s", p.value, p.stack)
 }
@@ -453,10 +421,10 @@ func catchPanic(raised *atomic.Pointer[relayedPanic]) {
 	}
 }
 
-// handlerError reproduces jrpc2's tasks.responses exactly, bare type assertion
-// included. Pinned, not a bug: network's limiter sentinels are jrpc2.Error
-// VALUES, so the assertion misses them and their message keeps its own
-// "[-32001] " prefix.
+// handlerError reproduces jrpc2's tasks.responses, bare type assertion
+// included. network's limiter sentinels are jrpc2.Error values, not pointers,
+// so the assertion misses them and their message keeps its own "[-32001] "
+// prefix. Pinned, not a bug.
 func handlerError(err error) *jrpc2.Error {
 	if e, ok := err.(*jrpc2.Error); ok { //nolint:errorlint // jrpc2 asserts, it does not unwrap
 		return e
@@ -476,9 +444,9 @@ func parseError(err error) *jrpc2.Error {
 }
 
 // frame builds {"jsonrpc":"2.0","id":<id>,<key><payload>}; id is the raw id
-// text, or "" for one with no usable id, which answers a null id. The capacity
-// must be the frame's EXACT length — nothing about the response can catch it
-// being wrong, so TestFrameIsExactlyOneAllocation pins it on cap.
+// text, or "" for one with no usable id, answered as null. The capacity must
+// be the frame's exact length — append grows silently and the bytes come out
+// identical — so TestFrameIsExactlyOneAllocation pins it on cap.
 func frame(id, key string, payload []byte) []byte {
 	out := make([]byte, 0, len(framePrefix)+idLen(id)+len(key)+len(payload)+1)
 	out = append(out, framePrefix...)
@@ -500,11 +468,10 @@ func errorFrame(id string, e *jrpc2.Error) []byte {
 	return frame(id, errorKey, bits)
 }
 
-// appendID writes the id back exactly as the client sent it, LOAD-BEARINGLY
-// applying stdlib appendCompact(escape=true)'s escaping — <, >, & and
-// U+2028/U+2029 — at the splice. "Simplifying" this to a plain append reflects
-// up to 512KB of client-controlled bytes into a response with no nosniff
-// header from a mount with open CORS. Numbers pass through untouched.
+// appendID writes the id back as the client sent it, applying the stdlib's
+// HTML escaping (<, >, & and U+2028/U+2029) at the splice. A plain append
+// reflects up to 512KB of client bytes into a response with no nosniff header
+// from a mount with open CORS. Numbers pass through untouched.
 func appendID(dst []byte, id string) []byte {
 	if id == "" {
 		return append(dst, nullID...)
@@ -553,16 +520,16 @@ func appendHTMLEscaped(dst []byte, src string) []byte {
 }
 
 // writeFrames writes the body: one frame bare, or the frames joined inside a
-// JSON array for a batch, a one-element batch included. LOAD-BEARING: the
-// array is hand-appended — json.Marshal of a []json.RawMessage sends every
-// frame through marshalerEncoder, which re-copies the whole payload.
+// JSON array for a batch, a one-element batch included. The array is
+// hand-appended; json.Marshal of a []json.RawMessage re-validates and re-copies
+// every frame.
 func writeFrames(w http.ResponseWriter, isBatch bool, frames [][]byte) {
 	var body []byte
 	if !isBatch && len(frames) == 1 {
 		// The fat case: the frame the dispatcher already built, uncopied.
 		body = frames[0]
 	} else {
-		// '[' + ']' is 2, and n frames carry n-1 commas: 1 + sum(len+1).
+		// Brackets are 2 and n frames carry n-1 commas: 1 + sum(len+1).
 		size := 1
 		for _, f := range frames {
 			size += len(f) + 1

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -37,10 +37,21 @@
 //
 // Neither is fabricated here. There is no jrpc2.Server to hand back, a fake one
 // would be a worse answer than a loud one, and a handler that wants its request
-// already has it as its second argument. Nothing in this tree calls either
-// accessor — `grep -rn 'InboundRequest\|ServerFromContext' --include='*.go' .`
-// reports nothing — and TestNoJRPC2ContextValueCallersInProductionCode fails if
-// that stops being true.
+// already has it as its second argument.
+//
+// A third accessor is worse than either, because it fails QUIETLY:
+// (*jrpc2.Request).IsNotification() is now false for every request, including
+// notifications. It tests id == nil, and ParsedRequest.ToRequest builds the id
+// as fixID(json.RawMessage(p.ID)) from a string — for an absent id that is an
+// empty-but-non-nil RawMessage, which fixID passes through because its isNull
+// only matches the four bytes "null". Under the bridge the handler was reached
+// through jrpc2's own server, which had the real nil. Notification-ness is
+// ParsedRequest.ID == "" here, and route says so at its site.
+//
+// Nothing in this tree calls any of the three: grepping the names across cmd/
+// finds only this paragraph and the test that enforces it, and
+// TestNoJRPC2ContextValueCallersInProductionCode fails if that stops being
+// true.
 package wire
 
 import (
@@ -114,8 +125,19 @@ type Handler struct {
 	// did: acquired before dispatch, released after the envelope is built and
 	// BEFORE the bytes are handed to the (buffered) ResponseWriter, so the
 	// socket write stays outside the bound and a slow reader cannot hold a
-	// permit. jrpc2 defaults ServerOptions.Concurrency to runtime.NumCPU();
-	// this reproduces that number rather than inventing one.
+	// permit.
+	//
+	// The weight is runtime.GOMAXPROCS(0), which is the one number in here
+	// that deliberately does NOT reproduce jrpc2's — its ServerOptions
+	// defaults Concurrency to runtime.NumCPU(). Since Go 1.25, and this module
+	// is `go 1.26`, the default GOMAXPROCS is derived from the cgroup CPU
+	// quota as well as from the machine, while NumCPU still reports the node's
+	// CPUs and its affinity mask only. In a container limited to 2 CPUs on a
+	// 64-core node the two differ by 32x, and this bound is what caps the
+	// number of fat results being marshaled at once: 64 x 17MB rather than
+	// 2 x 17MB is the difference between a bound and a decoration. The repo
+	// already takes GOMAXPROCS as its parallelism convention — see
+	// rpcv2/backfill.DefaultWorkers.
 	//
 	// It is ONE semaphore for the whole handler, and a batch's elements take
 	// their permits from it individually, just as jrpc2's Server.invoke did.
@@ -130,7 +152,7 @@ type Handler struct {
 func NewHandler(methods map[string]jrpc2.Handler) *Handler {
 	return &Handler{
 		methods: methods,
-		sem:     semaphore.NewWeighted(int64(runtime.NumCPU())),
+		sem:     semaphore.NewWeighted(int64(runtime.GOMAXPROCS(0))),
 	}
 }
 
@@ -211,7 +233,7 @@ func (h *Handler) serve(w http.ResponseWriter, body []byte) {
 }
 
 // dispatchAll answers every element of one parsed body and returns the frames
-// in INPUT order (DELTA (f)), with the elements that get no response — the
+// in INPUT order (DELTA (e)), with the elements that get no response — the
 // notifications — compacted out. It returns only once every handler it started
 // has returned, which is what lets serve's 204 mean "the notifications have
 // run" rather than "the notifications have been queued".
@@ -231,9 +253,28 @@ func (h *Handler) serve(w http.ResponseWriter, body []byte) {
 // file. Acquire inside the worker instead and every element gets a goroutine
 // parked on Acquire — and the body cap bounds elements only by their minimum
 // size, so a 512KB body of `[5,5,5,...]` is ~260,000 of them. Acquiring first
-// makes the in-flight worker count runtime.NumCPU(), whatever the batch's
+// makes the in-flight worker count the semaphore's weight, whatever the batch's
 // length; the batch's length still bounds the frames, which is where the
 // (pre-existing, bridge-identical) response amplification lives.
+//
+// DELTA (g), and the open one: this loop does not unwind when the HTTP
+// request's context ends. The permit is taken with context.Background, so
+// after httpRequestDurationLimiter answers 504 and returns, the serving
+// goroutine keeps taking permits and starting elements — for as long as
+// ceil(elements/weight) x the per-method duration limit — and the global
+// backlog slot BacklogHTTPQLimiter holds is inside that abandoned goroutine.
+// The bridge unwound here: jhttp passed req.Context() to Client.Batch, whose
+// waitComplete failed each pending response when the context ended, so the
+// framing layer returned at the deadline while the handlers ran on.
+//
+// It is not fixed here because the fix is a choice, not a repair. Passing the
+// request context to Acquire would stop the loop at the deadline, at the cost
+// of the guarantee that every element of an accepted batch runs — which the
+// bridge did keep (it handed the whole batch to its server before waiting on
+// anything), and which is the guarantee sendTransaction cares about. Serial
+// dispatch had the same shape and a factor of `weight` more of it, so this is
+// strictly better than the commit before it and strictly worse than the
+// bridge, in different units.
 func (h *Handler) dispatchAll(reqs []*jrpc2.ParsedRequest) [][]byte {
 	// One slot per element, filled by index, so the response order is the
 	// request order and does not depend on completion order. A nil slot is an
@@ -266,7 +307,7 @@ func (h *Handler) dispatchBatch(reqs []*jrpc2.ParsedRequest, frames [][]byte) {
 			frames[i] = frame
 			continue
 		}
-		if denied := h.acquirePermit(pr); denied != nil {
+		if ok, denied := h.acquirePermit(pr); !ok {
 			frames[i] = denied
 			continue
 		}
@@ -289,7 +330,11 @@ func (h *Handler) dispatchBatch(reqs []*jrpc2.ParsedRequest, frames [][]byte) {
 		// sibling has finished, keeps a batch element's panic failing exactly
 		// the request it already failed and nothing else. (No parity is lost:
 		// jrpc2 ran batch elements on goroutines it did not recover either, so
-		// under the bridge this bug class was a crash.)
+		// under the bridge this bug class was a crash.) In this mount it is a
+		// safety net and not a live path: every method both daemons register
+		// carries a RequestDurationLimit, and network's RPCRequestDurationLimiter
+		// recovers a handler panic into its own -32003 error before wire can
+		// see it.
 		panic(p)
 	}
 }
@@ -303,23 +348,31 @@ func (h *Handler) dispatchOne(pr *jrpc2.ParsedRequest) []byte {
 	if method == nil {
 		return frame
 	}
-	if denied := h.acquirePermit(pr); denied != nil {
+	if ok, denied := h.acquirePermit(pr); !ok {
 		return denied
 	}
 	defer h.sem.Release(1)
 	return h.invoke(pr, method)
 }
 
-// acquirePermit takes one permit from the shared bound and returns nil. If the
-// permit cannot be taken it returns the error frame that answers pr instead —
-// unreachable today, because Background is never canceled and Acquire only
-// fails on a canceled context. Answered rather than dropped so that a future
-// change of context cannot turn this into a silent 200 with no body.
-func (h *Handler) acquirePermit(pr *jrpc2.ParsedRequest) []byte {
+// acquirePermit takes one permit from the shared bound and reports whether it
+// got one. When it did not, the second result is what goes in the element's
+// slot: the error frame for a call, and nothing at all for a notification,
+// which must never be answered whatever went wrong.
+//
+// The failure is unreachable today, because Background is never canceled and
+// Acquire only fails on a canceled context. It is answered rather than dropped
+// so that a future change of context cannot turn this into a silent 200 with
+// no body — and for the same reason it has to get the notification case right
+// now, while nothing exercises it.
+func (h *Handler) acquirePermit(pr *jrpc2.ParsedRequest) (bool, []byte) {
 	if err := h.sem.Acquire(context.Background(), 1); err != nil {
-		return errorFrame(pr.ID, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
+		if pr.ID == "" {
+			return false, nil
+		}
+		return false, errorFrame(pr.ID, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
 	}
-	return nil
+	return true, nil
 }
 
 // route decides how one parsed request is answered, WITHOUT running anything:
@@ -337,7 +390,7 @@ func (h *Handler) acquirePermit(pr *jrpc2.ParsedRequest) []byte {
 //     element carries one of those two codes, so reporting them all is the
 //     same set, not a wider one.
 //  2. An empty method name is the same class of request-level protocol error,
-//     so it answers with a frame too. DELTA (e): today an empty-method
+//     so it answers with a frame too. DELTA (d): today an empty-method
 //     NOTIFICATION returns 204, and only by accident — jrpc2's server does
 //     emit the InvalidRequest frame, but with an empty id, so the bridge's
 //     in-process client discards it as a response to an unknown id and the
@@ -394,7 +447,7 @@ func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
 
 	// ToRequest hands the handler the params bytes the body carried, in the
 	// client's key order and whitespace and with the client's own escapes.
-	// DELTA (g): the bridge re-marshaled them on the way in — Client.req ->
+	// DELTA (f): the bridge re-marshaled them on the way in — Client.req ->
 	// marshalParams -> json.Marshal of a json.RawMessage, which compacts and
 	// HTML-escapes — so a handler used to see `{"a":"x\u003cy"}` where it now
 	// sees `{"a": "x<y"}`. Both decode to the same value, and every handler
@@ -424,7 +477,13 @@ func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
 	// Content-Length be set.
 	bits, err := json.Marshal(result)
 	if err != nil {
-		return errorFrame(pr.ID, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
+		// Through handlerError, not a hand-built InternalError: jrpc2's own
+		// invoke returns the marshal failure as the task's error, so
+		// tasks.responses runs it down the SAME ladder a handler error takes
+		// and answers -32098 (SystemError), never -32603. Measured against the
+		// live bridge, both for an unmarshalable value and for a MarshalJSON
+		// that fails.
+		return errorFrame(pr.ID, handlerError(err))
 	}
 	return resultFrame(pr.ID, bits)
 }
@@ -501,7 +560,10 @@ func errorFrame(id string, e *jrpc2.Error) []byte {
 	bits, err := json.Marshal(e)
 	if err != nil {
 		// Only reachable if a handler hand-built an Error whose Data is not
-		// valid JSON. Answer something well-formed rather than nothing.
+		// valid JSON. Answer something well-formed rather than nothing — an
+		// improvement, not parity: the bridge's server-side encode failed on
+		// the same input, which killed its channel, so ServeHTTP never
+		// returned and the request hung until the deadline.
 		bits, err = json.Marshal(&jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
 		if err != nil {
 			bits = []byte(`{"code":-32603,"message":"internal error"}`)

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -356,7 +356,11 @@ func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, []byte) {
 	if pr.Method == "" {
 		return nil, errorFrame(pr.ID, errEmptyMethod)
 	}
-	if method, ok := h.methods[pr.Method]; ok {
+	// `ok && method != nil`: route says "run this" by returning a non-nil
+	// handler, so a nil entry in the table must not be able to say it. The
+	// mount cannot register one (handler.New never returns nil), and answering
+	// -32601 for one is a better failure than dropping the element silently.
+	if method, ok := h.methods[pr.Method]; ok && method != nil {
 		return method, nil
 	}
 	if pr.ID == "" {
@@ -388,6 +392,15 @@ func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
 	// see the package doc.
 	ctx := context.Background()
 
+	// ToRequest hands the handler the params bytes the body carried, in the
+	// client's key order and whitespace and with the client's own escapes.
+	// DELTA (g): the bridge re-marshaled them on the way in — Client.req ->
+	// marshalParams -> json.Marshal of a json.RawMessage, which compacts and
+	// HTML-escapes — so a handler used to see `{"a":"x\u003cy"}` where it now
+	// sees `{"a": "x<y"}`. Both decode to the same value, and every handler
+	// here decodes (including getEventsV2, the one that reads ParamString
+	// rather than UnmarshalParams), so the only visible difference is that the
+	// debug log's "params" field now shows what the client actually sent.
 	result, err := method(ctx, pr.ToRequest())
 	if pr.ID == "" {
 		// "The Server MUST NOT reply to a Notification, including those that

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -72,6 +72,13 @@ type Handler struct {
 	// the whole handler, so a batch borrows from the budget rather than
 	// multiplying it. Weight is GOMAXPROCS (cgroup-aware), not NumCPU; it caps
 	// concurrent fat marshals; see backfill.DefaultWorkers.
+	//
+	// It bounds DISPATCHES, not handler goroutines: a request that outruns its
+	// per-method budget gets its permit back while its handler runs on, by
+	// design (network.RPCRequestDurationLimiter, and the graceMargin that
+	// exists for that gap), so goroutines executing handler code can exceed
+	// this by the number of timed-out requests. Shutdown joins them; nothing
+	// bounds them.
 	sem *semaphore.Weighted
 
 	// weight is sem's size; Weighted does not expose it and Shutdown drains by
@@ -85,37 +92,71 @@ type Handler struct {
 	root     context.Context
 	stopRoot context.CancelFunc
 
+	// detached is the handler goroutines the per-method duration limiter
+	// abandoned at its own timeout. They have already given their permits
+	// back, so the bound cannot see them and Shutdown joins them separately.
+	detached *sync.WaitGroup
+
 	drainOnce sync.Once
 	drainErr  error
 }
 
 // NewHandler returns the handler over methods, read-only from here on.
-func NewHandler(methods map[string]jrpc2.Handler) *Handler {
+// detached is the group the method table's duration limiters count their
+// abandoned handler goroutines into; nil means nothing registers any.
+func NewHandler(methods map[string]jrpc2.Handler, detached *sync.WaitGroup) *Handler {
 	weight := int64(runtime.GOMAXPROCS(0))
 	//nolint:gosec // G118: stopRoot is the handler's, called by Shutdown
 	root, stopRoot := context.WithCancel(context.Background())
+	if detached == nil {
+		detached = new(sync.WaitGroup)
+	}
 	return &Handler{
 		methods:  methods,
 		sem:      semaphore.NewWeighted(weight),
 		weight:   weight,
 		root:     root,
 		stopRoot: stopRoot,
+		detached: detached,
 	}
 }
 
-// Shutdown cancels the root and waits by acquiring the whole bound — every
-// invocation holds a permit, so that IS "no handler is running". The permits
-// are never returned, and an error means a straggler is still touching what
-// the caller is about to close. Idempotent; call it after the HTTP server
+// Shutdown cancels the root and waits for every handler this mount can still
+// be running, in two steps, because two things can be running one: it acquires
+// the whole bound, which IS "no dispatch is in flight" since every invocation
+// holds a permit, and then joins the handlers a per-method duration limiter
+// abandoned at its timeout, which gave their permits back long ago.
+//
+// The permits are never returned. An error means a straggler is still touching
+// what the caller is about to close. Idempotent; call it after the HTTP server
 // stops accepting and before the handlers' resources are closed.
 func (h *Handler) Shutdown(ctx context.Context) error {
 	h.stopRoot()
 	h.drainOnce.Do(func() {
 		if err := h.sem.Acquire(ctx, h.weight); err != nil {
 			h.drainErr = fmt.Errorf("wire: draining handlers: %w", err)
+			return
+		}
+		// Only now: every permit is held, so no wrapper is running and none
+		// can start another detached handler behind the Wait.
+		if err := joinDetached(ctx, h.detached); err != nil {
+			h.drainErr = fmt.Errorf("wire: joining timed-out handlers: %w", err)
 		}
 	})
 	return h.drainErr
+}
+
+// joinDetached waits for wg, or for ctx to end. The waiter outlives this call
+// when ctx wins; it ends when the stragglers do.
+func joinDetached(ctx context.Context, wg *sync.WaitGroup) error {
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // ServeHTTP implements http.Handler. The shell is byte-identical to

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -313,17 +313,19 @@ func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest
 // permit before returning so the caller writes without one, panics included.
 func (h *Handler) dispatchOne(ctx context.Context, pr *jrpc2.ParsedRequest) []byte {
 	method, rerr := h.route(pr)
-	if method == nil {
-		if rerr == nil {
-			return nil
-		}
-		// One frame, so it is not worth deferring as a batch's are.
-		return errorFrame(pr.ID, rerr)
+	if method == nil && rerr == nil {
+		return nil
 	}
 	if !h.acquirePermit(ctx) {
 		return nil // delta (g): never started, so nothing to answer
 	}
 	defer h.sem.Release(1)
+	if method == nil {
+		// Framed under the same bound as every other frame construction: an
+		// id near the body cap escapes to megabytes. A dead request builds
+		// nothing.
+		return errorFrame(pr.ID, rerr)
+	}
 	return h.invoke(pr, method)
 }
 

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -40,9 +40,13 @@
 //
 // # What the jrpc2.Server took with it
 //
-// Handlers run on a context derived from context.Background, which is what
-// jrpc2's ServerOptions.NewContext default gave them, so a client hangup still
-// does not cancel work in flight. What it does NOT carry is the pair of values
+// Handlers run on a SERVER-scoped context: derived from context.Background,
+// as jrpc2's ServerOptions.NewContext default was, so no request cancels it
+// and a client hangup still does not cancel work in flight — and canceled by
+// Handler.Shutdown, as jrpc2's Server.stopLocked canceled every in-flight
+// request's context at stop (server.go, `for id, cancel := range s.used`).
+// Per-request semantics are unchanged; the server's own lifetime is back.
+// What it does NOT carry is the pair of values
 // jrpc2's Server.invoke attached to every handler context: the inbound
 // *jrpc2.Request (inboundRequestKey) and the *jrpc2.Server itself (serverKey).
 // The delta those two values leave is exactly two accessors:
@@ -161,16 +165,67 @@ type Handler struct {
 	// A batch therefore borrows from the process-wide budget instead of
 	// multiplying it — see dispatchAll.
 	sem *semaphore.Weighted
+
+	// weight is sem's size, kept because semaphore.Weighted does not expose
+	// it and Shutdown drains by acquiring all of it.
+	weight int64
+
+	// root is the SERVER-scoped lifetime every handler runs on. No request
+	// touches it; only Shutdown cancels it. jrpc2's Server owned this and
+	// canceled it at stop (server.go stopLocked, `for id, cancel := range
+	// s.used`), which is what kept a straggler from reading a store its
+	// daemon had already closed.
+	//
+	//nolint:containedctx // a server's own lifetime, as http.Server holds one
+	root     context.Context
+	stopRoot context.CancelFunc
+
+	drainOnce sync.Once
+	drainErr  error
 }
 
 // NewHandler returns the JSON-RPC handler over methods. The map is the
 // decorated, limiter-wrapped table the bridge would otherwise have been given;
 // it is read-only from here on.
 func NewHandler(methods map[string]jrpc2.Handler) *Handler {
+	weight := int64(runtime.GOMAXPROCS(0))
+	//nolint:gosec // G118: stopRoot is the handler's, called by Shutdown
+	root, stopRoot := context.WithCancel(context.Background())
 	return &Handler{
-		methods: methods,
-		sem:     semaphore.NewWeighted(int64(runtime.GOMAXPROCS(0))),
+		methods:  methods,
+		sem:      semaphore.NewWeighted(weight),
+		weight:   weight,
+		root:     root,
+		stopRoot: stopRoot,
 	}
+}
+
+// Shutdown cancels the context every handler runs on and waits for the
+// handlers still running to return, or for ctx to end, whichever comes first.
+// It reports the drain's failure to finish in time; a caller that gets one has
+// a straggler still touching whatever it is about to close.
+//
+// The wait is an acquire of the whole bound. Every handler invocation happens
+// between an acquirePermit and its Release, so holding every permit is exactly
+// "no handler is running" — no second counter to keep in step with the first.
+// The permits are not released afterwards: a drained handler stays drained, so
+// nothing can start against resources being torn down. A request that arrives
+// anyway blocks in acquirePermit and unwinds at its own deadline (DELTA (g));
+// the two cancellation sources compose that way, the request's context
+// governing whether an element may START and this one whether a running
+// handler may CONTINUE.
+//
+// Idempotent — the first call's result answers every later one. Call it after
+// the HTTP server has stopped accepting, and before the resources the handlers
+// read are closed.
+func (h *Handler) Shutdown(ctx context.Context) error {
+	h.stopRoot()
+	h.drainOnce.Do(func() {
+		if err := h.sem.Acquire(ctx, h.weight); err != nil {
+			h.drainErr = fmt.Errorf("wire: draining handlers: %w", err)
+		}
+	})
+	return h.drainErr
 }
 
 // ServeHTTP implements http.Handler.
@@ -313,6 +368,12 @@ func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte)
 //     There is no answer to give it and nobody to give one to: the 504 is
 //     already on the wire. serve writes nothing at all rather than assembling
 //     a response out of the survivors.
+//
+// Two contexts govern a dispatch and they do not overlap: the request's
+// decides whether an element may START (here), and the handler's — the
+// server-scoped root, canceled only by Shutdown — whether a running handler
+// may CONTINUE.
+//
 //   - An element that needs no handler at all — a parse or shape error, an
 //     empty method, an unknown method — never reaches the permit, so the loop
 //     probes the request's Done channel per element as well. Without that,
@@ -380,7 +441,6 @@ func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest
 			// answer as above: stop, and leave the rest unstarted.
 			break
 		}
-		//nolint:contextcheck // invoke's context is Background by design; see invoke
 		wg.Go(func() {
 			// Released once the frame is built and strictly before the caller
 			// writes a byte, exactly as dispatchOne releases it — and released
@@ -424,7 +484,6 @@ func (h *Handler) dispatchOne(ctx context.Context, pr *jrpc2.ParsedRequest) []by
 		return nil // DELTA (g): never started, so there is nothing to answer.
 	}
 	defer h.sem.Release(1)
-	//nolint:contextcheck // invoke's context is Background by design; see invoke
 	return h.invoke(pr, method)
 }
 
@@ -510,16 +569,11 @@ func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, []byte) {
 // invoke runs one handler and builds its frame. The caller holds the permit
 // for the whole call and releases it before any byte is written.
 func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
-	// context.Background, never the http.Request's context, and never a
-	// timeout of our own: this reproduces jrpc2's ServerOptions.NewContext
-	// default byte for byte. Handlers keep today's hangup semantics (a client
-	// that disconnects mid-call still completes it, which matters for
-	// sendTransaction) and today's deadline shape (the per-method duration
-	// limiter derives its own timeout from this). Deriving from r.Context()
-	// is a separate, deliberate decision that has not been taken. The two
-	// values jrpc2's server used to attach to this context are gone with it;
-	// see the package doc.
-	ctx := context.Background()
+	// The SERVER's lifetime, never the http.Request's: a client that
+	// disconnects mid-call still completes it, which matters for
+	// sendTransaction, and the per-method duration limiter derives its own
+	// timeout from this. Only Shutdown cancels it.
+	ctx := h.root
 
 	// ToRequest hands the handler the params bytes the body carried, in the
 	// client's key order and whitespace and with the client's own escapes.

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -8,7 +8,8 @@
 //
 //	(a) a malformed body is a -32700 frame over 200, not 500 + plaintext
 //	(b) an empty batch `[]` is a -32600 frame, not a 204
-//	(c) notifications have finished when their 204 is written
+//	(c) notifications have finished, or been answered-at-budget and abandoned
+//	    per the limiter's contract, before the 204
 //	(d) an empty-method notification is answered rather than 204'd
 //	(e) batch frames come back in input order
 //	(f) params reach handlers verbatim rather than re-marshaled
@@ -229,7 +230,9 @@ func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte)
 		return
 	}
 	if len(frames) == 0 {
-		// All notifications, and DELTA (c) — all of them have finished.
+		// All notifications, and DELTA (c) — each has finished, or its
+		// method budget expired and the limiter abandoned it. dispatchAll
+		// joins the dispatches, not the limiter's children.
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
@@ -399,7 +402,10 @@ func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
 	result, err := method(ctx, pr.ToRequest())
 	if pr.ID == "" {
 		// "The Server MUST NOT reply to a Notification, including those that
-		// are within a batch request."
+		// are within a batch request." Deliberately NOT joined here: waiting
+		// for an over-budget notification would tie the 204 and its backlog
+		// slot to straggler duration — the coupling the duration limiter
+		// exists to break — for a difference no notification client can see.
 		return nil
 	}
 	if err != nil {

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -1,8 +1,19 @@
 // Package wire frames JSON-RPC 2.0 over HTTP; both mounts use it.
 //
-// Three rules are LOAD-BEARING: json.Marshal + Write (never json.NewEncoder),
-// hand-appended batch frames (never json.Marshal of a []json.RawMessage), and
-// a batch worker's permit taken before its goroutine starts (never inside it).
+// Three things here look like they could be written more idiomatically, and
+// must not be:
+//
+//   - Results are marshaled with json.Marshal and written with one Write.
+//     Switching to json.NewEncoder(w).Encode re-adds a full copy of every
+//     large response under GOEXPERIMENT=jsonv2, silently.
+//   - Batch responses are assembled by appending frames between brackets.
+//     json.Marshal of a []json.RawMessage makes the stdlib re-validate and
+//     re-copy every frame — the multi-pass waste this package exists to
+//     remove.
+//   - A batch worker's semaphore permit is acquired before its goroutine is
+//     started. Acquired inside the goroutine, every element parks a
+//     goroutine on the semaphore, and one request body fits ~260,000
+//     elements.
 //
 // # The deltas
 //

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -22,6 +22,25 @@
 // json.NewEncoder), hand-appended batch frames (never json.Marshal of a
 // []json.RawMessage), and a batch worker's permit taken before its goroutine
 // is started (never inside it).
+//
+// # The handler context, and the one thing it no longer carries
+//
+// Handlers run on a context derived from context.Background, which is what
+// jrpc2's ServerOptions.NewContext default gave them, so a client hangup still
+// does not cancel work in flight. What it does NOT carry is the pair of values
+// jrpc2's Server.invoke attached to every handler context: the inbound
+// *jrpc2.Request (inboundRequestKey) and the *jrpc2.Server itself (serverKey).
+// The observable delta is exactly two accessors:
+// jrpc2.InboundRequest(ctx) returns nil where it used to return the request,
+// and jrpc2.ServerFromContext(ctx) panics where it used to return the server —
+// it is documented to panic on a non-handler context, and this is one.
+//
+// Neither is fabricated here. There is no jrpc2.Server to hand back, a fake one
+// would be a worse answer than a loud one, and a handler that wants its request
+// already has it as its second argument. Nothing in this tree calls either
+// accessor — `grep -rn 'InboundRequest\|ServerFromContext' --include='*.go' .`
+// reports nothing — and TestNoJRPC2ContextValueCallersInProductionCode fails if
+// that stops being true.
 package wire
 
 import (
@@ -150,7 +169,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	// The handler context is deliberately NOT derived from req: invoke
 	// builds context.Background(), reproducing jrpc2's NewContext default so
-	// that a client hangup does not cancel work in flight. See invoke.
+	// that a client hangup does not cancel work in flight. See invoke, and the
+	// package doc for the two jrpc2 server values that context no longer has.
 	h.serve(w, body) //nolint:contextcheck // deliberate; see invoke
 }
 
@@ -363,7 +383,9 @@ func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
 	// that disconnects mid-call still completes it, which matters for
 	// sendTransaction) and today's deadline shape (the per-method duration
 	// limiter derives its own timeout from this). Deriving from r.Context()
-	// is a separate, deliberate decision that has not been taken.
+	// is a separate, deliberate decision that has not been taken. The two
+	// values jrpc2's server used to attach to this context are gone with it;
+	// see the package doc.
 	ctx := context.Background()
 
 	result, err := method(ctx, pr.ToRequest())

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -1,34 +1,19 @@
 // Package wire frames JSON-RPC 2.0 over HTTP. Both mounts use it; it is the
 // only framing this repo serves.
 //
-// It replaced jrpc2's jhttp.Bridge, which is no longer built here. The bridge
-// was a loopback, not a framing layer: jhttp.NewBridge builds a jrpc2.Server
-// and a jrpc2.Client joined by an in-memory pipe, so every response was
-// marshaled by the server, re-parsed by the client, and marshaled twice more
-// by the bridge.
-// In the 2026-08-30 fat-response profile that cost 10.34s of 18.10s of daemon
-// CPU (57.1%) and 3.29GB of 9.36GB allocated (35%), for zero semantic work.
+// It replaced jrpc2's jhttp.Bridge, a loopback that marshaled every response
+// four times over. jrpc2 remains the parser and the vocabulary; this package
+// owns the envelope: one json.Marshal, one hand-appended envelope, one Write.
 //
-// jrpc2 is kept, demoted from a runtime to a parser and a vocabulary:
-// ParseRequests does the parse and every shape check, and Request, Error,
-// Code and ErrorCode remain the types on the handler contract. This package
-// owns exactly one thing the bridge used to own four times over — the
-// envelope: one json.Marshal of the handler's result, one hand-appended
-// envelope around it, one Write.
-//
-// Three rules in here are load-bearing and are commented at their site,
-// because each has a plausible-looking "improvement" that silently reverses
-// this package's reason to exist: json.Marshal + Write (never
-// json.NewEncoder), hand-appended batch frames (never json.Marshal of a
-// []json.RawMessage), and a batch worker's permit taken before its goroutine
-// is started (never inside it).
+// Three rules here are LOAD-BEARING, each with a plausible-looking
+// "improvement" that silently reverses this package's reason to exist:
+// json.Marshal + Write (never json.NewEncoder), hand-appended batch frames
+// (never json.Marshal of a []json.RawMessage), and a batch worker's permit
+// taken before its goroutine is started (never inside it).
 //
 // # The deltas
 //
-// Seven places answer differently from the bridge. Each is argued where it is
-// implemented; they are indexed here so the set is countable, because a
-// lettered list whose letters are scattered is exactly the kind of thing that
-// silently loses one.
+// Seven places answer differently from the bridge, argued at their sites:
 //
 //	(a) a malformed body is a -32700 frame over 200, not 500 + plaintext
 //	(b) an empty batch `[]` is a -32600 frame, not a 204
@@ -38,40 +23,17 @@
 //	(f) params reach handlers verbatim rather than re-marshaled
 //	(g) dispatch stops at the HTTP deadline; started elements still finish
 //
-// # What the jrpc2.Server took with it
+// # Three jrpc2 accessors a handler must not use
 //
-// Handlers run on a SERVER-scoped context: derived from context.Background,
-// as jrpc2's ServerOptions.NewContext default was, so no request cancels it
-// and a client hangup still does not cancel work in flight — and canceled by
-// Handler.Shutdown, as jrpc2's Server.stopLocked canceled every in-flight
-// request's context at stop (server.go, `for id, cancel := range s.used`).
-// Per-request semantics are unchanged; the server's own lifetime is back.
-// What it does NOT carry is the pair of values
-// jrpc2's Server.invoke attached to every handler context: the inbound
-// *jrpc2.Request (inboundRequestKey) and the *jrpc2.Server itself (serverKey).
-// The delta those two values leave is exactly two accessors:
-// jrpc2.InboundRequest(ctx) returns nil where it used to return the request,
-// and jrpc2.ServerFromContext(ctx) panics where it used to return the server —
-// it is documented to panic on a non-handler context, and this is one.
-//
-// Neither is fabricated here. There is no jrpc2.Server to hand back, a fake one
-// would be a worse answer than a loud one, and a handler that wants its request
-// already has it as its second argument.
-//
-// A third accessor is not about the context at all, and is worse than either,
-// because it fails QUIETLY:
-// (*jrpc2.Request).IsNotification() is now false for every request, including
-// notifications. It tests id == nil, and ParsedRequest.ToRequest builds the id
-// as fixID(json.RawMessage(p.ID)) from a string — for an absent id that is an
-// empty-but-non-nil RawMessage, which fixID passes through because its isNull
-// only matches the four bytes "null". Under the bridge the handler was reached
-// through jrpc2's own server, which had the real nil. Notification-ness is
-// ParsedRequest.ID == "" here, and route says so at its site.
-//
-// Nothing in this tree calls any of the three: grepping the names across cmd/
-// finds only this paragraph and the test that enforces it, and
-// TestNoJRPC2ContextValueCallersInProductionCode fails if that stops being
-// true.
+// Handlers run on a SERVER-scoped context: derived from context.Background, so
+// no request cancels it, and canceled by Handler.Shutdown. It carries none of
+// the values jrpc2's Server.invoke attached, and none is fabricated back —
+// jrpc2.InboundRequest(ctx) returns nil, jrpc2.ServerFromContext(ctx) panics,
+// and (*jrpc2.Request).IsNotification() is false for EVERY request. The last
+// is the dangerous one because it fails quietly: it tests id == nil, and
+// ToRequest builds an empty-but-non-nil id for an absent one. Notification-ness
+// is ParsedRequest.ID == "". Take the request from the handler's second
+// argument. TestNoJRPC2ContextValueCallersInProductionCode fails on a caller.
 package wire
 
 import (
@@ -95,27 +57,19 @@ import (
 const (
 	contentTypeJSON = "application/json"
 
-	// framePrefix opens every response frame. The id follows it immediately,
-	// then either ,"result": or ,"error":. Field order matches
-	// jrpc2's jmessage.toJSON, which is what the bridge emits today.
+	// framePrefix opens every response frame; the id follows immediately, then
+	// resultKey or errorKey. Field order matches jrpc2's jmessage.toJSON.
 	framePrefix = `{"jsonrpc":"2.0","id":`
 	resultKey   = `,"result":`
 	errorKey    = `,"error":`
 
-	// nullID is the id of a frame answering a request whose own id was
-	// absent, null, or unparseable — jhttp's marshalError convention.
+	// nullID answers a request whose id was absent, null or unparseable.
 	nullID = "null"
 )
 
-// These are transcriptions of jrpc2's unexported error vocabulary
-// (jrpc2/error.go: errEmptyMethod, errEmptyBatch, errInvalidRequest). They are
-// the wire strings the bridge emits today and this mount keeps emitting;
-// errNoSuchMethod is built at its one use site in dispatch.
-//
-// Transcribing an unexported vocabulary is a real, permanent cost: a
-// `go get -u` of jrpc2 moves rpcv1's strings and leaves these frozen. That is
-// accepted, not overlooked — see the wire-parity tests, which pin every one of
-// these strings against the bytes measured from the bridge on 2026-08-30.
+// Transcriptions of jrpc2's unexported error vocabulary (jrpc2/error.go). The
+// cost is permanent: a `go get -u` moves the library's strings and leaves
+// these frozen. The byte-exact tests are what notice.
 var (
 	errEmptyMethod         = &jrpc2.Error{Code: jrpc2.InvalidRequest, Message: "empty method name"}
 	errEmptyBatch          = &jrpc2.Error{Code: jrpc2.InvalidRequest, Message: "empty request batch"}
@@ -124,46 +78,26 @@ var (
 
 // Handler serves JSON-RPC 2.0 over HTTP for one method table.
 //
-// It is mounted INSIDE the shared middleware chain jsonrpc.NewHandler builds
-// for both daemons, in the bridge's place:
+// Mounted INSIDE the shared middleware chain jsonrpc.NewHandler builds:
 // cors -> MaxBytesHandler -> httpRequestDurationLimiter -> BacklogHTTPQLimiter
-// -> Handler. That is deliberate. The duration limiter's bufferedResponseWriter
-// is the slow-client decoupler: it answers a timed-out client with 504 and
-// returns while the handler goroutine is still live, which is only safe because
-// nothing has reached the socket; and the buffer is written out after the
-// per-method limiters have released and after wrapAdapterRequest's
-// `defer view.Release()` has run, so a stalled client holds one flat []byte and
-// nothing else — no semaphore, no backlog slot, no store view, no lock.
-// rpcv2's deriveLifecycleGrace comment records that its daemon relies on that
-// hard deadline. Do not bypass, wrap, or "replace it with a write deadline":
-// bufferedResponseWriter has no Unwrap, Flusher, or SetWriteDeadline, so
-// http.NewResponseController over it reports ErrNotSupported.
+// -> Handler. The duration limiter is the slow-client decoupler — it answers a
+// timed-out client with 504 while the handler is still live, safe only because
+// nothing has reached the socket, and flushes after the per-method limiters
+// and the view release, so a stalled client holds one flat []byte and nothing
+// else. rpcv2's deriveLifecycleGrace relies on that deadline. Do not bypass or
+// wrap it: bufferedResponseWriter has no Unwrap, Flusher or SetWriteDeadline.
 type Handler struct {
 	methods map[string]jrpc2.Handler
 
-	// sem bounds concurrent handler+marshal work exactly as jrpc2's Server.sem
-	// did: acquired before dispatch, released after the envelope is built and
-	// BEFORE the bytes are handed to the (buffered) ResponseWriter, so the
-	// socket write stays outside the bound and a slow reader cannot hold a
-	// permit.
+	// sem bounds concurrent handler+marshal work: acquired before dispatch,
+	// released BEFORE the bytes reach the (buffered) ResponseWriter, so a slow
+	// reader cannot hold a permit. ONE semaphore for the whole handler, so a
+	// batch borrows from the process-wide budget instead of multiplying it.
 	//
-	// The weight is runtime.GOMAXPROCS(0), which is the one number in here
-	// that deliberately does NOT reproduce jrpc2's — its ServerOptions
-	// defaults Concurrency to runtime.NumCPU(). Since Go 1.25, and this module
-	// is `go 1.26`, the default GOMAXPROCS is derived from the cgroup CPU
-	// quota as well as from the machine, while NumCPU still reports the node's
-	// CPUs and its affinity mask only. In a container limited to 2 CPUs on a
-	// 64-core node the two differ by 32x, and this bound is what caps the
-	// number of fat results being marshaled at once: 64 x 17MB rather than
-	// 2 x 17MB is the difference between a bound and a decoration. The repo
-	// already takes GOMAXPROCS as its parallelism convention — see
-	// rpcv2/backfill.DefaultWorkers. It is read once, here, which is enough:
-	// the quota that matters is in effect before the daemon binds a port.
-	//
-	// It is ONE semaphore for the whole handler, and a batch's elements take
-	// their permits from it individually, just as jrpc2's Server.invoke did.
-	// A batch therefore borrows from the process-wide budget instead of
-	// multiplying it — see dispatchAll.
+	// The weight is GOMAXPROCS, not jrpc2's NumCPU: since Go 1.25 GOMAXPROCS
+	// follows the cgroup CPU quota and NumCPU does not, and this is what caps
+	// the number of fat results marshaled at once. Matches the repo's
+	// convention (rpcv2/backfill.DefaultWorkers).
 	sem *semaphore.Weighted
 
 	// weight is sem's size, kept because semaphore.Weighted does not expose
@@ -171,10 +105,8 @@ type Handler struct {
 	weight int64
 
 	// root is the SERVER-scoped lifetime every handler runs on. No request
-	// touches it; only Shutdown cancels it. jrpc2's Server owned this and
-	// canceled it at stop (server.go stopLocked, `for id, cancel := range
-	// s.used`), which is what kept a straggler from reading a store its
-	// daemon had already closed.
+	// touches it; only Shutdown cancels it, which is what keeps a straggler
+	// from reading a store its daemon has already closed.
 	//
 	//nolint:containedctx // a server's own lifetime, as http.Server holds one
 	root     context.Context
@@ -184,9 +116,8 @@ type Handler struct {
 	drainErr  error
 }
 
-// NewHandler returns the JSON-RPC handler over methods. The map is the
-// decorated, limiter-wrapped table the bridge would otherwise have been given;
-// it is read-only from here on.
+// NewHandler returns the JSON-RPC handler over methods, which is the
+// decorated, limiter-wrapped table and is read-only from here on.
 func NewHandler(methods map[string]jrpc2.Handler) *Handler {
 	weight := int64(runtime.GOMAXPROCS(0))
 	//nolint:gosec // G118: stopRoot is the handler's, called by Shutdown
@@ -200,24 +131,18 @@ func NewHandler(methods map[string]jrpc2.Handler) *Handler {
 	}
 }
 
-// Shutdown cancels the context every handler runs on and waits for the
-// handlers still running to return, or for ctx to end, whichever comes first.
-// It reports the drain's failure to finish in time; a caller that gets one has
-// a straggler still touching whatever it is about to close.
+// Shutdown cancels the context every handler runs on and waits for the running
+// handlers, or for ctx to end. An error means a straggler is still touching
+// whatever the caller is about to close.
 //
-// The wait is an acquire of the whole bound. Every handler invocation happens
-// between an acquirePermit and its Release, so holding every permit is exactly
-// "no handler is running" — no second counter to keep in step with the first.
-// The permits are not released afterwards: a drained handler stays drained, so
-// nothing can start against resources being torn down. A request that arrives
-// anyway blocks in acquirePermit and unwinds at its own deadline (DELTA (g));
-// the two cancellation sources compose that way, the request's context
-// governing whether an element may START and this one whether a running
-// handler may CONTINUE.
+// The wait is an acquire of the whole bound: every invocation happens between
+// an acquirePermit and its Release, so holding every permit IS "no handler is
+// running", with no second counter to keep in step. The permits are never
+// given back — a drained handler stays drained, and a request that arrives
+// anyway unwinds at its own deadline (DELTA (g)).
 //
-// Idempotent — the first call's result answers every later one. Call it after
-// the HTTP server has stopped accepting, and before the resources the handlers
-// read are closed.
+// Idempotent. Call it after the HTTP server has stopped accepting and before
+// the resources the handlers read are closed.
 func (h *Handler) Shutdown(ctx context.Context) error {
 	h.stopRoot()
 	h.drainOnce.Do(func() {
@@ -228,12 +153,9 @@ func (h *Handler) Shutdown(ctx context.Context) error {
 	return h.drainErr
 }
 
-// ServeHTTP implements http.Handler.
-//
-// The HTTP shell is byte-identical to jhttp.Bridge.ServeHTTP: Accept-Post is
-// advertised unconditionally (it is set on 200 bodies too), non-POST is 405
-// with no body, and a wrong media type or charset is 415 with jhttp's exact
-// plaintext.
+// ServeHTTP implements http.Handler. The HTTP shell is byte-identical to
+// jhttp.Bridge.ServeHTTP: Accept-Post advertised unconditionally, non-POST 405
+// with no body, wrong media type or charset 415 with jhttp's exact plaintext.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Accept-Post", contentTypeJSON)
 
@@ -252,20 +174,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
-		// A body that could not be read is a transport event, not a JSON-RPC
-		// one: there is no request to answer and no id to echo. This is the
-		// path MaxBytesHandler takes for a body over the 512KB cap, and it
-		// keeps the bridge's 500 + plaintext ("http: request body too large").
+		// A transport event, not a JSON-RPC one: no request to answer and no
+		// id to echo. MaxBytesHandler takes this path for an oversized body.
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(w, err.Error())
 		return
 	}
 
-	// req.Context() governs the DISPATCH — whether another element is allowed
-	// to start (DELTA (g)) — and nothing else. The HANDLER context is still
-	// context.Background, so a client hangup does not cancel work in flight;
-	// see invoke, and the package doc for the two jrpc2 server values that
-	// context no longer has.
+	// req.Context() governs the DISPATCH — whether another element may start
+	// (DELTA (g)) — and nothing else. Handlers run on h.root; see invoke.
 	h.serve(req.Context(), w, body)
 }
 
@@ -274,42 +191,29 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte) {
 	reqs, err := jrpc2.ParseRequests(body)
 	if err != nil {
-		// DELTA (a): the bridge answers a malformed body with HTTP 500 and the
-		// plaintext "[-32700] invalid request value", which is not a JSON-RPC
-		// response at all. A parse failure is exactly what -32700 is for.
+		// DELTA (a).
 		writeFrames(w, false, [][]byte{errorFrame("", parseError(err))})
 		return
 	}
 	if len(reqs) == 0 {
-		// DELTA (b): the bridge answers `[]` with 204. The spec (and jrpc2's
-		// own server) calls an empty batch an invalid request. A non-batch
-		// body always parses to exactly one element, so an empty slice means
-		// the body was `[]` and nothing else.
+		// DELTA (b). A non-batch body always parses to exactly one element,
+		// so an empty slice means the body was `[]`.
 		writeFrames(w, false, [][]byte{errorFrame("", errEmptyBatch)})
 		return
 	}
 
-	// Batch-ness is a property of the body, carried on every element.
-	isBatch := reqs[0].Batch
+	isBatch := reqs[0].Batch // a property of the body, carried on every element
 
 	frames := h.dispatchAll(ctx, reqs)
 	if ctx.Err() != nil {
-		// DELTA (g): the request died while we were dispatching, so there is
-		// nobody to answer — httpRequestDurationLimiter has already written
-		// its 504 and returned, or the client is gone and its buffered body
-		// would be discarded. Writing anything here would have to choose
-		// between a partial batch array and mistaking an abandoned batch for
-		// an all-notification one and 204ing it. Neither is a response; this
-		// is not one either, and it is the honest one.
+		// DELTA (g): the request died mid-dispatch, so there is nobody to
+		// answer. Falling through would have to choose between a partial
+		// batch array and 204ing an abandoned batch as all-notification.
 		return
 	}
 	if len(frames) == 0 {
-		// Every element was a notification. DELTA (c): they have all run to
-		// completion by the time this 204 is written, because dispatchAll
-		// returns only after every handler it started has returned. The bridge
-		// fires notifications at its in-process client and 204s immediately,
-		// so today a notification is free to the caller and its work races the
-		// response.
+		// Every element was a notification, and DELTA (c) — all of them have
+		// finished, because dispatchAll joins every handler it started.
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
@@ -317,88 +221,41 @@ func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte)
 }
 
 // dispatchAll answers every element of one parsed body and returns the frames
-// in INPUT order (DELTA (e)), with the elements that get no response — the
-// notifications — compacted out. It returns only once every handler it started
-// has returned, which is what lets serve's 204 mean "the notifications have
-// run" rather than "the notifications have been queued".
+// in INPUT order (DELTA (e)), the elements that get no response compacted out.
+// It returns only once every handler it started has, which is what lets
+// serve's 204 mean "the notifications have run".
 //
-// A batch's elements run CONCURRENTLY, as jrpc2's dispatchLocked ran them.
-// Dispatching them serially would sum their latencies under the ONE HTTP
-// deadline the mount enforces (httpRequestDurationLimiter, 25s by default), so
-// a batch of individually-fine calls would 504 where each call on its own
-// succeeds, and would hold its global backlog slot for the sum rather than the
-// max. It is not free: a worker costs about 2.6us in goroutine and closure,
-// measured on this table, so a batch of instant calls is slower than a serial
-// one and a batch of anything real is faster by the semaphore's weight. At a
-// weight of 1 the elements serialize anyway and the workers are pure loss —
-// accepted rather than special-cased, because a third dispatch path costs more
-// than microseconds on a one-CPU deployment saves.
+// A batch's elements run CONCURRENTLY: dispatched serially they sum their
+// latencies under the ONE HTTP deadline the mount enforces, so a batch of
+// individually-fine calls 504s where each call alone succeeds.
 //
-// The concurrency is the process-wide semaphore's, not a second budget: a batch
-// borrows permits from the same bound a single request takes one from, so N
-// elements cannot buy N times the handler parallelism. It also cannot buy N
-// goroutines. The permit is acquired HERE, on the serving goroutine, and
-// released by the worker; that ordering is the third load-bearing rule in this
-// file. Acquire inside the worker instead and every element gets a goroutine
-// parked on Acquire — and the body cap bounds elements only by their minimum
-// size, so a 512KB body of `[5,5,5,...]` is ~260,000 of them. Acquiring first
-// makes the in-flight worker count the semaphore's weight, whatever the batch's
-// length; the batch's length still bounds the frames, which is where the
-// (pre-existing, bridge-identical) response amplification lives.
+// LOAD-BEARING: the permit is acquired HERE, on the serving goroutine, and
+// released by the worker. Acquire inside the worker instead and every element
+// gets a goroutine parked on Acquire — and one body fits ~260,000 elements
+// under the cap. Acquiring first makes the in-flight worker count the
+// semaphore's weight, whatever the batch's length.
 //
-// DELTA (g): the permit is acquired against the HTTP REQUEST's context, so
-// this loop stops feeding the bound the moment the request is dead — when
-// httpRequestDurationLimiter has answered 504, or the client has hung up.
-// Without that it kept starting elements for ceil(elements/weight) x the
-// per-method duration limit AFTER the 504, with the global backlog slot
-// BacklogHTTPQLimiter holds sitting inside an abandoned goroutine. The bridge
-// did unwind here (jhttp passed req.Context() to Client.Batch, whose
-// waitComplete failed every pending response when the context ended), so this
-// is parity restored, not a new behavior.
+// Two contexts govern a dispatch and do not overlap: the REQUEST's decides
+// whether an element may START, the server-scoped root whether a running
+// handler may CONTINUE. DELTA (g) is the first of those:
 //
-// The line it draws is between STARTED and QUEUED, and only queued work is
-// canceled:
-//
-//   - An element already inside its handler runs to completion. Its context is
-//     context.Background and nothing cancels it — that is the guarantee
-//     sendTransaction depends on, and it is untouched. wg.Wait still joins
-//     every worker that started, so the unwind costs at most one element's
-//     duration, which is exactly what a single request has always cost.
-//   - An element that never got a permit never runs, and produces no frame.
-//     There is no answer to give it and nobody to give one to: the 504 is
-//     already on the wire. serve writes nothing at all rather than assembling
-//     a response out of the survivors.
-//
-// Two contexts govern a dispatch and they do not overlap: the request's
-// decides whether an element may START (here), and the handler's — the
-// server-scoped root, canceled only by Shutdown — whether a running handler
-// may CONTINUE.
-//
-//   - An element that needs no handler at all — a parse or shape error, an
-//     empty method, an unknown method — never reaches the permit, so the loop
-//     probes the request's Done channel per element as well. Without that,
-//     the one body that is ALL such elements (`[5,5,5,...]`, ~260,000 of them
-//     inside the 512KB cap) would keep building its 22MB of answers after the
-//     deadline. The permit covers the slow batches; this covers the cheap
-//     enormous one.
-//
-// So a canceled CALL element yields no frame, not an error frame. Building
-// one would allocate up to 22MB of answers for a batch whose reader is gone,
-// which is the work this delta exists to stop.
+//   - An element already inside its handler runs to completion; only Shutdown
+//     cancels it. wg.Wait joins every worker that started, so the unwind costs
+//     at most one element's duration.
+//   - An element that never got a permit yields NO FRAME, not an error frame:
+//     there is nobody to answer, and building answers for a departed reader is
+//     the work this stops.
+//   - An element that needs no handler never reaches the permit, so the loop
+//     probes the request's Done channel per element too.
 func (h *Handler) dispatchAll(ctx context.Context, reqs []*jrpc2.ParsedRequest) [][]byte {
-	// One slot per element, filled by index, so the response order is the
-	// request order and does not depend on completion order. A nil slot is an
-	// element that gets no response.
+	// One slot per element, by index, so response order is request order
+	// whatever the completion order. A nil slot gets no answer.
 	frames := make([][]byte, len(reqs))
 
 	if len(reqs) == 1 {
-		// A single-element body — every non-batch request, including the fat
-		// ones this package exists for — never leaves this goroutine. The
-		// saving is a goroutine and a WaitGroup, which is noise beside a 17MB
-		// marshal; what this branch really buys is that a single request's
-		// panic reaches the limiter's recover with its OWN stack rather than
-		// wrapped in a relayedPanic. Deleting it as premature optimization
-		// would quietly change that.
+		// A single-element body never leaves this goroutine. Not an
+		// optimization: it is what lets its panic reach the limiter's recover
+		// with its OWN stack, unwrapped by relayedPanic.
 		frames[0] = h.dispatchOne(ctx, reqs[0])
 	} else {
 		h.dispatchBatch(ctx, reqs, frames)
@@ -406,45 +263,30 @@ func (h *Handler) dispatchAll(ctx context.Context, reqs []*jrpc2.ParsedRequest) 
 	return slices.DeleteFunc(frames, func(f []byte) bool { return f == nil })
 }
 
-// dispatchBatch runs the elements of a multi-element body, writing each one's
-// frame into its own slot of frames. See dispatchAll for why the permit is
-// taken on this goroutine rather than in the worker, and for what a dead
-// request leaves behind.
+// dispatchBatch runs the elements of a multi-element body into their own slots
+// of frames. See dispatchAll for the permit ordering and the dead-request rule.
 func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest, frames [][]byte) {
 	var wg sync.WaitGroup
 	var raised atomic.Pointer[relayedPanic]
 
-	// Read once: this loop asks per element, and ctx.Err() takes a lock every
-	// time where a closed-channel probe takes none.
+	// Read once: ctx.Err() takes a lock per call, a channel probe does not.
 	dead := ctx.Done()
 
 	for i, pr := range reqs {
 		if isClosed(dead) {
-			// DELTA (g), the half the permit does not cover: an element that
-			// answers without a handler — a parse or shape error, an empty
-			// method, an unknown method — never reaches acquirePermit, so
-			// without this check a batch of nothing but those would keep
-			// building frames after the request was dead. That is the
-			// adversarial shape: `[5,5,5,...]` fits ~260,000 elements into the
-			// 512KB cap and 22MB of answers into a response nobody will read.
+			// DELTA (g) for the elements that never reach acquirePermit.
 			break
 		}
 		method, frame := h.route(pr)
 		if method == nil {
-			// Answered without running anything. No permit and no goroutine
-			// are spent on it.
-			frames[i] = frame
+			frames[i] = frame // answered without a permit or a goroutine
 			continue
 		}
 		if !h.acquirePermit(ctx) {
-			// The request died while this element waited for the bound. Same
-			// answer as above: stop, and leave the rest unstarted.
-			break
+			break // the request died waiting for the bound
 		}
 		wg.Go(func() {
-			// Released once the frame is built and strictly before the caller
-			// writes a byte, exactly as dispatchOne releases it — and released
-			// on a panicking handler too, because it is deferred.
+			// Released before the caller writes a byte, panics included.
 			defer h.sem.Release(1)
 			defer catchPanic(&raised)
 			frames[i] = h.invoke(pr, method)
@@ -453,28 +295,17 @@ func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest
 	wg.Wait()
 
 	if p := raised.Load(); p != nil {
-		// A panic on a worker goroutine has nothing above it to recover, so it
-		// would take the whole process down; the same handler bug on a single
-		// request unwinds into httpRequestDurationLimiter's recover, which
-		// answers 500 and logs the stack. Re-raising it here, after every
-		// sibling has finished, keeps a batch element's panic inside the HTTP
-		// request it belongs to instead of the process — the batch's other
-		// frames go down with it, which is what the serial dispatch this
-		// replaced did too. (No parity is lost:
-		// jrpc2 ran batch elements on goroutines it did not recover either, so
-		// under the bridge this bug class was a crash.) In this mount it is a
-		// safety net and not a live path: every method both daemons register
-		// carries a RequestDurationLimit, and network's RPCRequestDurationLimiter
-		// recovers a handler panic into its own -32003 error before wire can
-		// see it.
+		// A panic on a worker has nothing above it to recover and would take
+		// the process down. Re-raised here, once every sibling has finished,
+		// it fails only this HTTP request. A safety net, not a live path:
+		// every registered method carries a RequestDurationLimit, whose
+		// limiter recovers a handler panic into -32003 first.
 		panic(p)
 	}
 }
 
-// dispatchOne answers one request on the calling goroutine, holding a permit
-// across the handler and the marshal and releasing it before it returns the
-// finished frame — so the caller writes with no permit held, and a panicking
-// handler still releases on the way out.
+// dispatchOne answers one request on the calling goroutine, releasing its
+// permit before returning so the caller writes without one, panics included.
 func (h *Handler) dispatchOne(ctx context.Context, pr *jrpc2.ParsedRequest) []byte {
 	method, frame := h.route(pr)
 	if method == nil {
@@ -487,15 +318,10 @@ func (h *Handler) dispatchOne(ctx context.Context, pr *jrpc2.ParsedRequest) []by
 	return h.invoke(pr, method)
 }
 
-// acquirePermit takes one permit from the shared bound, blocking until either
-// it gets one or ctx ends, and reports which happened.
-//
-// ctx is the HTTP request's, never the handler's: this is the one place the
-// request's lifetime reaches into dispatch (DELTA (g)). Acquire fails only on
-// a canceled context and never keeps a permit it won in the race — x/sync
-// checks Done before, after, and while waiting, releasing the tokens if it has
-// to — so false here always means "this element did not run, and the request
-// it belongs to is over".
+// acquirePermit takes one permit from the shared bound, blocking until it gets
+// one or ctx ends, and reports which happened. ctx is the HTTP request's — the
+// one place a request's lifetime reaches into dispatch (DELTA (g)). x/sync
+// gives back a permit won in the race, so false always means "did not run".
 func (h *Handler) acquirePermit(ctx context.Context) bool {
 	return h.sem.Acquire(ctx, 1) == nil
 }
@@ -510,33 +336,17 @@ func isClosed(c <-chan struct{}) bool {
 	}
 }
 
-// route decides how one parsed request is answered, WITHOUT running anything:
-// it returns the handler to invoke, or a nil handler and the finished frame —
+// route decides how one parsed request is answered WITHOUT running anything:
+// it returns the handler to invoke, or a nil handler and the finished frame,
 // which is itself nil for a request that gets no response at all.
 //
-// Order is load-bearing and is not jrpc2's stated order, because jrpc2's
-// composite behavior is not its stated order either:
+// The order is load-bearing. Parse and shape errors answer with a frame even
+// for a notification, as the spec requires; an empty method name is the same
+// class and answers too (DELTA (d)); only then does notification-ness apply,
+// and only to DISPATCH results, so an unknown method or a handler error on a
+// notification is silent.
 //
-//  1. Parse and shape errors answer with a frame even for a notification —
-//     that is what the bridge does today (it filters invalid elements before
-//     it ever looks at notification-ness) and what the spec requires. jrpc2's
-//     own responses() reports a notification's error only when its code is
-//     ParseError or InvalidRequest; every error ParseRequests can attach to an
-//     element carries one of those two codes, so reporting them all is the
-//     same set, not a wider one.
-//  2. An empty method name is the same class of request-level protocol error,
-//     so it answers with a frame too. DELTA (d): today an empty-method
-//     NOTIFICATION returns 204, and only by accident — jrpc2's server does
-//     emit the InvalidRequest frame, but with an empty id, so the bridge's
-//     in-process client discards it as a response to an unknown id and the
-//     bridge sees zero results.
-//  3. Only then is notification-ness applied, and only to DISPATCH results:
-//     an unknown method or a handler error on a notification is silent.
-//
-// Notification-ness is decided on ParsedRequest.ID, never Request.IsNotification:
-// ToRequest builds the id with fixID(json.RawMessage(p.ID)) from a string, so
-// for an absent id it yields an empty-but-non-nil RawMessage and
-// IsNotification (which tests id == nil) cannot be trusted.
+// Notification-ness is ParsedRequest.ID == ""; see the package doc.
 func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, []byte) {
 	if pr.Error != nil {
 		return nil, errorFrame(pr.ID, pr.Error)
@@ -544,22 +354,17 @@ func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, []byte) {
 	if pr.Method == "" {
 		return nil, errorFrame(pr.ID, errEmptyMethod)
 	}
-	// `ok && method != nil`: route says "run this" by returning a non-nil
-	// handler, so a nil entry in the table must not be able to say it. The
-	// mount cannot register one (handler.New never returns nil), and answering
-	// -32601 for one is a better failure than dropping the element silently.
+	// `method != nil` as well as ok: route says "run this" by returning a
+	// non-nil handler, so a nil table entry must not be able to say it.
 	if method, ok := h.methods[pr.Method]; ok && method != nil {
 		return method, nil
 	}
 	if pr.ID == "" {
 		return nil, nil // an unknown method on a notification is silent
 	}
-	// jrpc2's own errNoSuchMethod frame, byte for byte: code -32601, message
-	// "method not found", data the method name. Resolving it here means no
-	// jrpc2.Server ever sees the request, which is also why the library's
-	// unknown-method in-flight-map leak is unreachable from this serving path.
-	// No handler is invoked and no metric is labeled, so an attacker-chosen
-	// method name cannot grow the per-method summary's cardinality either.
+	// jrpc2's errNoSuchMethod frame, byte for byte. Resolved here, so no
+	// handler runs and no metric is labeled: an attacker-chosen method name
+	// cannot grow the per-method summary's cardinality.
 	return nil, errorFrame(pr.ID, (&jrpc2.Error{
 		Code:    jrpc2.MethodNotFound,
 		Message: jrpc2.MethodNotFound.String(),
@@ -569,73 +374,55 @@ func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, []byte) {
 // invoke runs one handler and builds its frame. The caller holds the permit
 // for the whole call and releases it before any byte is written.
 func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
-	// The SERVER's lifetime, never the http.Request's: a client that
-	// disconnects mid-call still completes it, which matters for
-	// sendTransaction, and the per-method duration limiter derives its own
-	// timeout from this. Only Shutdown cancels it.
+	// The SERVER's lifetime, never the http.Request's: a client that hangs up
+	// mid-call still completes it, which sendTransaction depends on.
 	ctx := h.root
 
-	// ToRequest hands the handler the params bytes the body carried, in the
-	// client's key order and whitespace and with the client's own escapes.
-	// DELTA (f): the bridge re-marshaled them on the way in — Client.req ->
-	// marshalParams -> json.Marshal of a json.RawMessage, which compacts and
-	// HTML-escapes — so a handler used to see `{"a":"x\u003cy"}` where it now
-	// sees `{"a": "x<y"}`. Both decode to the same value, and every handler
-	// here decodes (including getEventsV2, the one that reads ParamString
-	// rather than UnmarshalParams), so the only visible difference is that the
-	// debug log's "params" field now shows what the client actually sent.
+	// DELTA (f): ToRequest hands over the params bytes the body carried, in
+	// the client's key order and whitespace and with its own escapes. rpcv2's
+	// getEventsV2 reads ParamString, so those raw bytes are contract.
 	result, err := method(ctx, pr.ToRequest())
 	if pr.ID == "" {
 		// "The Server MUST NOT reply to a Notification, including those that
-		// are within a batch request." The work is done; the answer is not
-		// sent. Errors are dropped exactly as jrpc2's invoke drops them.
+		// are within a batch request." The work is done, the answer is not
+		// sent, and an error is dropped as jrpc2's invoke drops it.
 		return nil
 	}
 	if err != nil {
 		return errorFrame(pr.ID, handlerError(err))
 	}
 
-	// THE one marshal. json.Marshal, never json.NewEncoder(w).Encode:
-	//   - Encode's deferred encodeStatePool.Put fires after enc.w.Write, so N
-	//     stalled clients would pin N full-size pooled buffers; Marshal
-	//     returns its state to the pool before the caller writes a byte.
-	//   - under GOEXPERIMENT=jsonv2 (present in this toolchain, one env var
-	//     away) Encoder.Encode marshals into its own buffer and then copies
-	//     that into w — reintroducing precisely the copy this package deletes,
-	//     byte-identically, with no test able to see it.
-	// Marshal+Write is stable across both encoder generations and lets
+	// THE one marshal. LOAD-BEARING: json.Marshal, never
+	// json.NewEncoder(w).Encode — Encode's deferred encodeStatePool.Put fires
+	// after enc.w.Write, so N stalled clients pin N full-size pooled buffers,
+	// and under GOEXPERIMENT=jsonv2 it copies through its own buffer,
+	// reintroducing exactly the copy this package deletes. Marshal also lets
 	// Content-Length be set.
 	bits, err := json.Marshal(result)
 	if err != nil {
-		// Through handlerError, not a hand-built InternalError: jrpc2's own
-		// invoke returns the marshal failure as the task's error, so
-		// tasks.responses runs it down the SAME ladder a handler error takes
-		// and answers -32098 (SystemError), never -32603. Measured against the
-		// live bridge, both for an unmarshalable value and for a MarshalJSON
-		// that fails.
+		// Through handlerError, not a hand-built InternalError: jrpc2 runs a
+		// marshal failure down the same ladder a handler error takes, which
+		// answers -32098, never -32603.
 		return errorFrame(pr.ID, handlerError(err))
 	}
 	return frame(pr.ID, resultKey, bits)
 }
 
 // relayedPanic is a handler panic caught on a batch worker so the serving
-// goroutine can re-raise it. It carries the stack the handler actually
-// panicked on, because the recover that ends up logging it runs on a different
-// goroutine and debug.Stack() there would show only the relay.
+// goroutine can re-raise it, carrying the stack the handler panicked on —
+// the recover that logs it runs elsewhere, where debug.Stack() shows the relay.
 type relayedPanic struct {
 	value any
 	stack []byte
 }
 
-// String is what httpRequestDurationLimiter's "%v" of the recovered value
-// prints, so the original panic and its stack land in the log.
+// String is what the limiter's "%v" of the recovered value prints.
 func (p *relayedPanic) String() string {
 	return fmt.Sprintf("%v (panicked on a batch worker goroutine)\n%s", p.value, p.stack)
 }
 
-// catchPanic must be deferred directly, so that its recover is the worker's.
-// The first panic wins; later ones are dropped, exactly as only one panic can
-// be re-raised.
+// catchPanic must be deferred directly, so its recover is the worker's. The
+// first panic wins; only one can be re-raised.
 func catchPanic(raised *atomic.Pointer[relayedPanic]) {
 	if v := recover(); v != nil {
 		raised.CompareAndSwap(nil, &relayedPanic{value: v, stack: debug.Stack()})
@@ -643,17 +430,12 @@ func catchPanic(raised *atomic.Pointer[relayedPanic]) {
 }
 
 // handlerError maps a handler's error onto the wire error object, reproducing
-// jrpc2's tasks.responses exactly — including its bare type assertion. A
-// WRAPPED *jrpc2.Error deliberately does not pass through verbatim: it falls to
-// the ErrorCode branch, which keeps the code but takes the wrapper's message.
-//
-// One repo-local consequence worth naming, because it looks like a bug and is
-// pinned as behavior: network.ErrRequestExceededProcessingLimitThreshold and
-// ErrFailToProcessDueToInternalIssue are declared as jrpc2.Error VALUES, not
-// pointers, so the assertion below misses them; ErrorCode's errors.As(ErrCoder)
-// branch then supplies the code while err.Error() supplies the message — which
-// for jrpc2.Error is "[%d] %s". The wire message therefore carries a redundant
-// "[-32001] " prefix, and has for as long as the limiter has existed.
+// jrpc2's tasks.responses exactly, bare type assertion included: a WRAPPED
+// *jrpc2.Error falls to the ErrorCode branch, keeping the code and taking the
+// wrapper's message. Looks like a bug and is pinned as behavior: network's
+// limiter sentinels are jrpc2.Error VALUES, so the assertion misses them and
+// err.Error() — "[%d] %s" — supplies the message, giving those wire messages a
+// redundant "[-32001] " prefix. They always have.
 func handlerError(err error) *jrpc2.Error {
 	if e, ok := err.(*jrpc2.Error); ok { //nolint:errorlint // jrpc2 asserts, it does not unwrap
 		return e
@@ -664,10 +446,9 @@ func handlerError(err error) *jrpc2.Error {
 	return &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()}
 }
 
-// parseError recovers the *jrpc2.Error ParseRequests reports for a body that is
-// not valid JSON. jrpc2 returns its unexported errInvalidRequest there, which
-// is already the right object; the fallback only guards a future library that
-// returns something else.
+// parseError recovers the *jrpc2.Error ParseRequests reports for a body that
+// is not valid JSON. The fallback only guards a future library that returns
+// something other than its errInvalidRequest.
 func parseError(err error) *jrpc2.Error {
 	if e, ok := err.(*jrpc2.Error); ok { //nolint:errorlint // matching jrpc2's own assertion style
 		return e
@@ -675,18 +456,14 @@ func parseError(err error) *jrpc2.Error {
 	return errInvalidRequestValue
 }
 
-// frame builds {"jsonrpc":"2.0","id":<id>,<key><payload>}, where key is
-// resultKey or errorKey. id is the request's raw id text, or "" for a request
-// with no usable id, which answers with a null id per jhttp's marshalError.
+// frame builds {"jsonrpc":"2.0","id":<id>,<key><payload>}. id is the request's
+// raw id text, or "" for one with no usable id, which answers a null id.
 //
 // The capacity is the frame's exact byte length, so a frame is one allocation
-// and one copy — which is why the arithmetic and the appends it predicts live
-// in the same six lines. Getting it wrong is not a correctness bug and no
-// assertion on the RESPONSE can see it: append grows silently and the bytes
-// come out identical. It is an expensive bug, though — an append that outgrows
-// its capacity reallocates and re-copies the whole payload, which on a fat
-// getLedgers response is another 17MB moved. TestFrameIsExactlyOneAllocation
-// pins it the only way it is observable, on cap.
+// and one copy — which is why the arithmetic and the appends it predicts sit
+// in the same six lines. No assertion on the RESPONSE can catch it being
+// wrong: append grows silently and the bytes come out identical while the
+// payload is re-copied. TestFrameIsExactlyOneAllocation pins it on cap.
 func frame(id, key string, payload []byte) []byte {
 	out := make([]byte, 0, len(framePrefix)+idLen(id)+len(key)+len(payload)+1)
 	out = append(out, framePrefix...)
@@ -701,10 +478,8 @@ func errorFrame(id string, e *jrpc2.Error) []byte {
 	bits, err := json.Marshal(e)
 	if err != nil {
 		// Only reachable if a handler hand-built an Error whose Data is not
-		// valid JSON. Answer something well-formed rather than nothing — an
-		// improvement, not parity: the bridge's server-side encode failed on
-		// the same input, which killed its channel, so ServeHTTP never
-		// returned and the request hung until the deadline.
+		// valid JSON. Answer something well-formed rather than nothing; the
+		// bridge hung the request until its deadline here.
 		bits, err = json.Marshal(&jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
 		if err != nil {
 			bits = []byte(`{"code":-32603,"message":"internal error"}`)
@@ -714,27 +489,16 @@ func errorFrame(id string, e *jrpc2.Error) []byte {
 }
 
 // appendID writes the request's id back exactly as the client sent it —
-// string, number, or null — with one transformation, which is not optional.
+// string, number or null — with one transformation that is NOT optional. The
+// id is raw client bytes, escaped today only as a side effect of the
+// compaction passes this package deletes, so splicing it plain would reflect
+// up to 512KB of client-controlled bytes into a response with no nosniff
+// header from a mount with fully open CORS.
 //
-// The id text is raw client bytes: ParseRequests keeps the id as the
-// json.RawMessage the body carried, and validates only that its first byte
-// looks like a string or a number. jrpc2's own jmessage.toJSON splices those
-// bytes into the response unescaped; today's responses are nonetheless escaped,
-// but only as a side effect of the two compaction passes this package deletes.
-// Delete them and stop escaping here and up to 512KB of client-controlled bytes
-// are reflected verbatim into a response that carries no nosniff header, from a
-// mount with fully open CORS.
-//
-// So the same escaping the stdlib's appendCompact(escape=true) applies is
-// applied here, at the splice: <, >, & and U+2028/U+2029 inside the token. That
-// makes the id byte-identical to what the bridge emits today, and it is the one
-// place where hand-building the envelope would have been a security regression
-// rather than a saving. Anyone "simplifying" this to a plain append is
-// reintroducing that regression.
-//
-// Numbers pass through untouched — none of the five characters can occur in a
-// JSON number — so a large integer id keeps every digit and a fractional id
-// keeps its exact text. No float round-trip happens anywhere on this path.
+// LOAD-BEARING: the escaping stdlib's appendCompact(escape=true) applies —
+// <, >, & and U+2028/U+2029 — is applied here at the splice. "Simplifying"
+// this to a plain append is a security regression, not a saving. Numbers pass
+// through untouched, so no id loses a digit and no float round-trip happens.
 func appendID(dst []byte, id string) []byte {
 	if id == "" {
 		return append(dst, nullID...)
@@ -784,19 +548,17 @@ func appendHTMLEscaped(dst []byte, src string) []byte {
 }
 
 // writeFrames writes the response body: one frame bare, or the frames joined
-// inside a JSON array when the request was a batch. A one-element batch stays
-// an array, matching jhttp.encodeResponses.
+// inside a JSON array when the request was a batch, a one-element batch
+// included.
 //
-// The array is hand-appended. json.Marshal of a []json.RawMessage would send
-// every frame through marshalerEncoder, whose unconditional appendCompact
-// re-validates and re-copies the whole payload — that pass is 4.64s of the
-// profile and the single largest thing this package exists to delete. It is an
-// easy and completely invisible mistake to make here.
+// LOAD-BEARING: the array is hand-appended. json.Marshal of a
+// []json.RawMessage sends every frame through marshalerEncoder, whose
+// unconditional appendCompact re-validates and re-copies the whole payload —
+// the largest thing this package exists to delete, and an invisible mistake.
 func writeFrames(w http.ResponseWriter, isBatch bool, frames [][]byte) {
 	var body []byte
 	if !isBatch && len(frames) == 1 {
-		// The single-frame case is the fat one, and it writes the frame the
-		// dispatcher already built: no second copy of a 17MB body.
+		// The fat case: the frame the dispatcher already built, uncopied.
 		body = frames[0]
 	} else {
 		// '[' + ']' is 2, and n frames carry n-1 commas: 1 + sum(len+1).
@@ -816,9 +578,8 @@ func writeFrames(w http.ResponseWriter, isBatch bool, frames [][]byte) {
 	}
 
 	// One Write of the finished body, into the duration limiter's buffered
-	// writer. Content-Length is set for the same reason jhttp.writeJSON sets
-	// it: the body is fully materialized, so the client should not have to
-	// discover its length from a chunked stream.
+	// writer. The body is fully materialized, so Content-Length is set rather
+	// than leaving the client to discover it from a chunked stream.
 	w.Header().Set("Content-Type", contentTypeJSON)
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(http.StatusOK)

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -252,15 +252,24 @@ func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest
 	// Read once: ctx.Err() takes a lock per call, a channel probe does not.
 	dead := ctx.Done()
 
+	// Errors answerable without a handler, by index, built below rather than
+	// here: one body can carry ~260,000 of them and ~23MB of frames.
+	var static []*jrpc2.Error
+
 	for i, pr := range reqs {
 		if isClosed(dead) {
 			// DELTA (g) for the elements that never reach acquirePermit.
 			break
 		}
-		method, frame := h.route(pr)
+		method, rerr := h.route(pr)
 		if method == nil {
-			frames[i] = frame // answered without a permit or a goroutine
-			continue
+			if rerr != nil {
+				if static == nil {
+					static = make([]*jrpc2.Error, len(reqs))
+				}
+				static[i] = rerr
+			}
+			continue // no permit and no goroutine spent on it
 		}
 		if !h.acquirePermit(ctx) {
 			break // the request died waiting for the bound
@@ -271,6 +280,22 @@ func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest
 			defer catchPanic(&raised)
 			frames[i] = h.invoke(pr, method)
 		})
+	}
+
+	// ONE permit for every static frame, not one per element: a hostile body
+	// would otherwise put ~260,000 acquire/release cycles through a semaphore
+	// every legitimate request shares. Safe to take here — this goroutine
+	// holds nothing, so it cannot deadlock against the workers above. The
+	// parse that precedes it is ~7x larger for the same body and is bounded by
+	// the backlog limit times the body cap, not by this; that is pre-existing
+	// and true of the bridge too.
+	if static != nil && !isClosed(dead) && h.acquirePermit(ctx) {
+		for i, rerr := range static {
+			if rerr != nil {
+				frames[i] = errorFrame(reqs[i].ID, rerr)
+			}
+		}
+		h.sem.Release(1)
 	}
 	wg.Wait()
 
@@ -284,9 +309,13 @@ func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest
 // dispatchOne answers one request here, releasing its permit before returning
 // so the caller writes without one, panics included.
 func (h *Handler) dispatchOne(ctx context.Context, pr *jrpc2.ParsedRequest) []byte {
-	method, frame := h.route(pr)
+	method, rerr := h.route(pr)
 	if method == nil {
-		return frame
+		if rerr == nil {
+			return nil
+		}
+		// One frame, so it is built here rather than deferred as a batch's are.
+		return errorFrame(pr.ID, rerr)
 	}
 	if !h.acquirePermit(ctx) {
 		return nil // DELTA (g): never started, so there is nothing to answer.
@@ -311,16 +340,19 @@ func isClosed(c <-chan struct{}) bool {
 }
 
 // route decides how one request is answered WITHOUT running anything: the
-// handler, or a nil handler and the frame (itself nil for no response). The
-// ORDER is load-bearing — parse and shape errors answer even for a
+// handler, or a nil handler and the error to answer with (itself nil when the
+// request gets no response). It returns the error rather than the frame so the
+// caller can choose when to pay for the bytes — see dispatchBatch.
+//
+// The ORDER is load-bearing — parse and shape errors answer even for a
 // notification, then an empty method (DELTA (d)), and only then does
 // notification-ness apply, to DISPATCH results only.
-func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, []byte) {
+func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, *jrpc2.Error) {
 	if pr.Error != nil {
-		return nil, errorFrame(pr.ID, pr.Error)
+		return nil, pr.Error
 	}
 	if pr.Method == "" {
-		return nil, errorFrame(pr.ID, errEmptyMethod)
+		return nil, errEmptyMethod
 	}
 	// `method != nil` too: a nil table entry must not read as "run this".
 	if method, ok := h.methods[pr.Method]; ok && method != nil {
@@ -331,10 +363,10 @@ func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, []byte) {
 	}
 	// Resolved here, so no metric is labeled: an attacker-chosen method name
 	// cannot grow the summary's cardinality.
-	return nil, errorFrame(pr.ID, (&jrpc2.Error{
+	return nil, (&jrpc2.Error{
 		Code:    jrpc2.MethodNotFound,
 		Message: jrpc2.MethodNotFound.String(),
-	}).WithData(pr.Method))
+	}).WithData(pr.Method)
 }
 
 // invoke runs one handler and frames it; the caller holds the permit.

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -260,7 +260,12 @@ func (h *Handler) serve(w http.ResponseWriter, body []byte) {
 // deadline the mount enforces (httpRequestDurationLimiter, 25s by default), so
 // a batch of individually-fine calls would 504 where each call on its own
 // succeeds, and would hold its global backlog slot for the sum rather than the
-// max.
+// max. It is not free: a worker costs about 2.6us in goroutine and closure,
+// measured on this table, so a batch of instant calls is slower than a serial
+// one and a batch of anything real is faster by the semaphore's weight. At a
+// weight of 1 the elements serialize anyway and the workers are pure loss —
+// accepted rather than special-cased, because a third dispatch path costs more
+// than microseconds on a one-CPU deployment saves.
 //
 // The concurrency is the process-wide semaphore's, not a second budget: a batch
 // borrows permits from the same bound a single request takes one from, so N
@@ -512,7 +517,7 @@ func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
 		// that fails.
 		return errorFrame(pr.ID, handlerError(err))
 	}
-	return resultFrame(pr.ID, bits)
+	return frame(pr.ID, resultKey, bits)
 }
 
 // relayedPanic is a handler panic caught on a batch worker so the serving
@@ -572,17 +577,28 @@ func parseError(err error) *jrpc2.Error {
 	return errInvalidRequestValue
 }
 
-// resultFrame builds {"jsonrpc":"2.0","id":<id>,"result":<result>}.
-func resultFrame(id string, result []byte) []byte {
-	out := make([]byte, 0, frameSize(id, len(resultKey), len(result)))
-	out = appendEnvelope(out, id, resultKey)
-	out = append(out, result...)
+// frame builds {"jsonrpc":"2.0","id":<id>,<key><payload>}, where key is
+// resultKey or errorKey. id is the request's raw id text, or "" for a request
+// with no usable id, which answers with a null id per jhttp's marshalError.
+//
+// The capacity is the frame's exact byte length, so a frame is one allocation
+// and one copy — which is why the arithmetic and the appends it predicts live
+// in the same six lines. Getting it wrong is not a correctness bug and no
+// assertion on the RESPONSE can see it: append grows silently and the bytes
+// come out identical. It is an expensive bug, though — an append that outgrows
+// its capacity reallocates and re-copies the whole payload, which on a fat
+// getLedgers response is another 17MB moved. TestFrameIsExactlyOneAllocation
+// pins it the only way it is observable, on cap.
+func frame(id, key string, payload []byte) []byte {
+	out := make([]byte, 0, len(framePrefix)+idLen(id)+len(key)+len(payload)+1)
+	out = append(out, framePrefix...)
+	out = appendID(out, id)
+	out = append(out, key...)
+	out = append(out, payload...)
 	return append(out, '}')
 }
 
-// errorFrame builds {"jsonrpc":"2.0","id":<id>,"error":<error>}. id is the
-// request's raw id text, or "" for a request with no usable id, which answers
-// with a null id per jhttp's marshalError.
+// errorFrame builds the frame for one error object.
 func errorFrame(id string, e *jrpc2.Error) []byte {
 	bits, err := json.Marshal(e)
 	if err != nil {
@@ -596,24 +612,7 @@ func errorFrame(id string, e *jrpc2.Error) []byte {
 			bits = []byte(`{"code":-32603,"message":"internal error"}`)
 		}
 	}
-	out := make([]byte, 0, frameSize(id, len(errorKey), len(bits)))
-	out = appendEnvelope(out, id, errorKey)
-	out = append(out, bits...)
-	return append(out, '}')
-}
-
-// frameSize is the frame's exact byte length, so a frame is one allocation and
-// one copy. Getting it wrong is not a correctness bug but it is an expensive
-// one: an append that outgrows its capacity reallocates and re-copies the whole
-// payload, which on a fat getLedgers response is another 17MB moved.
-func frameSize(id string, keyLen, payloadLen int) int {
-	return len(framePrefix) + idLen(id) + keyLen + payloadLen + 1
-}
-
-func appendEnvelope(dst []byte, id, key string) []byte {
-	dst = append(dst, framePrefix...)
-	dst = appendID(dst, id)
-	return append(dst, key...)
+	return frame(id, errorKey, bits)
 }
 
 // appendID writes the request's id back exactly as the client sent it —

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -1,0 +1,476 @@
+// Package wire frames JSON-RPC 2.0 over HTTP. Both mounts use it; it is the
+// only framing this repo serves.
+//
+// It replaced jrpc2's jhttp.Bridge, which is no longer built here. The bridge
+// was a
+// loopback, not a framing layer: jhttp.NewBridge builds a jrpc2.Server and a
+// jrpc2.Client joined by an in-memory pipe, so every response was marshaled by
+// the server, re-parsed by the client, and marshaled twice more by the bridge.
+// In the 2026-08-30 fat-response profile that cost 10.34s of 18.10s of daemon
+// CPU (57.1%) and 3.29GB of 9.36GB allocated (35%), for zero semantic work.
+//
+// jrpc2 is kept, demoted from a runtime to a parser and a vocabulary:
+// ParseRequests does the parse and every shape check, and Request, Error,
+// Code and ErrorCode remain the types on the handler contract. This package
+// owns exactly one thing the bridge used to own four times over — the
+// envelope: one json.Marshal of the handler's result, one hand-appended
+// envelope around it, one Write.
+//
+// Two rules in here are load-bearing and are commented at their site, because
+// each has a plausible-looking "improvement" that silently reverses this
+// package's reason to exist: json.Marshal + Write (never json.NewEncoder), and
+// hand-appended batch frames (never json.Marshal of a []json.RawMessage).
+package wire
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"runtime"
+	"strconv"
+
+	"github.com/creachadair/jrpc2"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	contentTypeJSON = "application/json"
+
+	// framePrefix opens every response frame. The id follows it immediately,
+	// then either ,"result": or ,"error":. Field order matches
+	// jrpc2's jmessage.toJSON, which is what the bridge emits today.
+	framePrefix = `{"jsonrpc":"2.0","id":`
+	resultKey   = `,"result":`
+	errorKey    = `,"error":`
+
+	// nullID is the id of a frame answering a request whose own id was
+	// absent, null, or unparseable — jhttp's marshalError convention.
+	nullID = "null"
+)
+
+// These are transcriptions of jrpc2's unexported error vocabulary
+// (jrpc2/error.go: errEmptyMethod, errEmptyBatch, errInvalidRequest). They are
+// the wire strings the bridge emits today and this mount keeps emitting;
+// errNoSuchMethod is built at its one use site in dispatch.
+//
+// Transcribing an unexported vocabulary is a real, permanent cost: a
+// `go get -u` of jrpc2 moves rpcv1's strings and leaves these frozen. That is
+// accepted, not overlooked — see the wire-parity tests, which pin every one of
+// these strings against the bytes measured from the bridge on 2026-08-30.
+var (
+	errEmptyMethod         = &jrpc2.Error{Code: jrpc2.InvalidRequest, Message: "empty method name"}
+	errEmptyBatch          = &jrpc2.Error{Code: jrpc2.InvalidRequest, Message: "empty request batch"}
+	errInvalidRequestValue = &jrpc2.Error{Code: jrpc2.ParseError, Message: "invalid request value"}
+)
+
+// Handler serves JSON-RPC 2.0 over HTTP for one method table.
+//
+// It is mounted INSIDE the shared middleware chain jsonrpc.NewHandler builds
+// for both daemons, in the bridge's place:
+// cors -> MaxBytesHandler -> httpRequestDurationLimiter -> BacklogHTTPQLimiter
+// -> Handler. That is deliberate. The duration limiter's bufferedResponseWriter
+// is the slow-client decoupler: it answers a timed-out client with 504 and
+// returns while the handler goroutine is still live, which is only safe because
+// nothing has reached the socket; and the buffer is written out after the
+// per-method limiters have released and after wrapAdapterRequest's
+// `defer view.Release()` has run, so a stalled client holds one flat []byte and
+// nothing else — no semaphore, no backlog slot, no store view, no lock.
+// rpcv2's deriveLifecycleGrace comment records that its daemon relies on that
+// hard deadline. Do not bypass, wrap, or "replace it with a write deadline":
+// bufferedResponseWriter has no Unwrap, Flusher, or SetWriteDeadline, so
+// http.NewResponseController over it reports ErrNotSupported.
+type Handler struct {
+	methods map[string]jrpc2.Handler
+
+	// sem bounds concurrent handler+marshal work exactly as jrpc2's Server.sem
+	// did: acquired before dispatch, released after the envelope is built and
+	// BEFORE the bytes are handed to the (buffered) ResponseWriter, so the
+	// socket write stays outside the bound and a slow reader cannot hold a
+	// permit. jrpc2 defaults ServerOptions.Concurrency to runtime.NumCPU();
+	// this reproduces that number rather than inventing one.
+	sem *semaphore.Weighted
+}
+
+// NewHandler returns the JSON-RPC handler over methods. The map is the
+// decorated, limiter-wrapped table the bridge would otherwise have been given;
+// it is read-only from here on.
+func NewHandler(methods map[string]jrpc2.Handler) *Handler {
+	return &Handler{
+		methods: methods,
+		sem:     semaphore.NewWeighted(int64(runtime.NumCPU())),
+	}
+}
+
+// ServeHTTP implements http.Handler.
+//
+// The HTTP shell is byte-identical to jhttp.Bridge.ServeHTTP: Accept-Post is
+// advertised unconditionally (it is set on 200 bodies too), non-POST is 405
+// with no body, and a wrong media type or charset is 415 with jhttp's exact
+// plaintext.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Accept-Post", contentTypeJSON)
+
+	if req.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	mt, params, _ := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	if mt != contentTypeJSON {
+		http.Error(w, "content-type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	} else if cs, ok := params["charset"]; ok && cs != "utf-8" && cs != "utf8" {
+		http.Error(w, "invalid content-type charset", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		// A body that could not be read is a transport event, not a JSON-RPC
+		// one: there is no request to answer and no id to echo. This is the
+		// path MaxBytesHandler takes for a body over the 512KB cap, and it
+		// keeps the bridge's 500 + plaintext ("http: request body too large").
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, err.Error())
+		return
+	}
+
+	// The handler context is deliberately NOT derived from req: invoke
+	// builds context.Background(), reproducing jrpc2's NewContext default so
+	// that a client hangup does not cancel work in flight. See invoke.
+	h.serve(w, body) //nolint:contextcheck // deliberate; see invoke
+}
+
+// serve parses body, dispatches it, and writes the response.
+func (h *Handler) serve(w http.ResponseWriter, body []byte) {
+	reqs, err := jrpc2.ParseRequests(body)
+	if err != nil {
+		// DELTA (a): the bridge answers a malformed body with HTTP 500 and the
+		// plaintext "[-32700] invalid request value", which is not a JSON-RPC
+		// response at all. A parse failure is exactly what -32700 is for.
+		writeFrames(w, false, [][]byte{errorFrame("", parseError(err))})
+		return
+	}
+	if len(reqs) == 0 {
+		// DELTA (b): the bridge answers `[]` with 204. The spec (and jrpc2's
+		// own server) calls an empty batch an invalid request. A non-batch
+		// body always parses to exactly one element, so an empty slice means
+		// the body was `[]` and nothing else.
+		writeFrames(w, false, [][]byte{errorFrame("", errEmptyBatch)})
+		return
+	}
+
+	// Batch-ness is a property of the body, carried on every element.
+	isBatch := reqs[0].Batch
+
+	// DELTA (f): frames come back in input order. The bridge emits every
+	// statically-invalid element first and the valid ones after, so any mixed
+	// batch is reordered against the request. Spec-legal, but client-visible
+	// and needless.
+	frames := make([][]byte, 0, len(reqs))
+	for _, pr := range reqs {
+		if frame := h.dispatch(pr); frame != nil {
+			frames = append(frames, frame)
+		}
+	}
+
+	if len(frames) == 0 {
+		// Every element was a notification. DELTA (c): they have all run to
+		// completion by the time this 204 is written, because dispatch is
+		// synchronous. The bridge fires notifications at its in-process client
+		// and 204s immediately, so today a notification is free to the caller
+		// and its work races the response.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	writeFrames(w, isBatch, frames)
+}
+
+// dispatch answers one parsed request, returning its response frame or nil if
+// the request gets no response.
+//
+// Order is load-bearing and is not jrpc2's stated order, because jrpc2's
+// composite behavior is not its stated order either:
+//
+//  1. Parse and shape errors answer with a frame even for a notification —
+//     that is what the bridge does today (it filters invalid elements before
+//     it ever looks at notification-ness) and what the spec requires.
+//  2. An empty method name is the same class of request-level protocol error,
+//     so it answers with a frame too. DELTA (e): today an empty-method
+//     NOTIFICATION returns 204, and only by accident — jrpc2's server does
+//     emit the InvalidRequest frame, but with an empty id, so the bridge's
+//     in-process client discards it as a response to an unknown id and the
+//     bridge sees zero results.
+//  3. Only then is notification-ness applied, and only to DISPATCH results:
+//     an unknown method or a handler error on a notification is silent.
+//
+// Notification-ness is decided on ParsedRequest.ID, never Request.IsNotification:
+// ToRequest builds the id with fixID(json.RawMessage(p.ID)) from a string, so
+// for an absent id it yields an empty-but-non-nil RawMessage and
+// IsNotification (which tests id == nil) cannot be trusted.
+func (h *Handler) dispatch(pr *jrpc2.ParsedRequest) []byte {
+	if pr.Error != nil {
+		return errorFrame(pr.ID, pr.Error)
+	}
+	if pr.Method == "" {
+		return errorFrame(pr.ID, errEmptyMethod)
+	}
+
+	notification := pr.ID == ""
+
+	method, ok := h.methods[pr.Method]
+	if !ok {
+		if notification {
+			return nil
+		}
+		// jrpc2's own errNoSuchMethod frame, byte for byte: code -32601,
+		// message "method not found", data the method name. Resolving it here
+		// means no jrpc2.Server ever sees the request, which is also why the
+		// library's unknown-method in-flight-map leak is unreachable from this
+		// serving path. No handler is invoked and no metric is labeled, so an
+		// attacker-chosen method name cannot grow the per-method summary's
+		// cardinality either.
+		return errorFrame(pr.ID, (&jrpc2.Error{
+			Code:    jrpc2.MethodNotFound,
+			Message: jrpc2.MethodNotFound.String(),
+		}).WithData(pr.Method))
+	}
+
+	return h.invoke(pr, method, notification)
+}
+
+// invoke runs one handler and builds its frame under the concurrency bound.
+func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler, notification bool) []byte {
+	// context.Background, never the http.Request's context, and never a
+	// timeout of our own: this reproduces jrpc2's ServerOptions.NewContext
+	// default byte for byte. Handlers keep today's hangup semantics (a client
+	// that disconnects mid-call still completes it, which matters for
+	// sendTransaction) and today's deadline shape (the per-method duration
+	// limiter derives its own timeout from this). Deriving from r.Context()
+	// is a separate, deliberate decision that has not been taken.
+	ctx := context.Background()
+
+	if err := h.sem.Acquire(ctx, 1); err != nil {
+		// Unreachable: Background is never canceled and Acquire only fails on
+		// a canceled context. Answered rather than dropped so a future ctx
+		// change cannot turn this into a silent 200 with no body.
+		return errorFrame(pr.ID, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
+	}
+	// Deferred, so the permit is released when this function returns the
+	// finished frame — i.e. strictly before the caller writes any byte.
+	defer h.sem.Release(1)
+
+	result, err := method(ctx, pr.ToRequest())
+	if notification {
+		// "The Server MUST NOT reply to a Notification, including those that
+		// are within a batch request." The work is done; the answer is not
+		// sent. Errors are dropped exactly as jrpc2's invoke drops them.
+		return nil
+	}
+	if err != nil {
+		return errorFrame(pr.ID, handlerError(err))
+	}
+
+	// THE one marshal. json.Marshal, never json.NewEncoder(w).Encode:
+	//   - Encode's deferred encodeStatePool.Put fires after enc.w.Write, so N
+	//     stalled clients would pin N full-size pooled buffers; Marshal
+	//     returns its state to the pool before the caller writes a byte.
+	//   - under GOEXPERIMENT=jsonv2 (present in this toolchain, one env var
+	//     away) Encoder.Encode marshals into its own buffer and then copies
+	//     that into w — reintroducing precisely the copy this package deletes,
+	//     byte-identically, with no test able to see it.
+	// Marshal+Write is stable across both encoder generations and lets
+	// Content-Length be set.
+	bits, err := json.Marshal(result)
+	if err != nil {
+		return errorFrame(pr.ID, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
+	}
+	return resultFrame(pr.ID, bits)
+}
+
+// handlerError maps a handler's error onto the wire error object, reproducing
+// jrpc2's tasks.responses exactly — including its bare type assertion. A
+// WRAPPED *jrpc2.Error deliberately does not pass through verbatim: it falls to
+// the ErrorCode branch, which keeps the code but takes the wrapper's message.
+//
+// One repo-local consequence worth naming, because it looks like a bug and is
+// pinned as behavior: network.ErrRequestExceededProcessingLimitThreshold and
+// ErrFailToProcessDueToInternalIssue are declared as jrpc2.Error VALUES, not
+// pointers, so the assertion below misses them; ErrorCode's errors.As(ErrCoder)
+// branch then supplies the code while err.Error() supplies the message — which
+// for jrpc2.Error is "[%d] %s". The wire message therefore carries a redundant
+// "[-32001] " prefix, and has for as long as the limiter has existed.
+func handlerError(err error) *jrpc2.Error {
+	if e, ok := err.(*jrpc2.Error); ok { //nolint:errorlint // jrpc2 asserts, it does not unwrap
+		return e
+	}
+	if code := jrpc2.ErrorCode(err); code != jrpc2.NoError {
+		return &jrpc2.Error{Code: code, Message: err.Error()}
+	}
+	return &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()}
+}
+
+// parseError recovers the *jrpc2.Error ParseRequests reports for a body that is
+// not valid JSON. jrpc2 returns its unexported errInvalidRequest there, which
+// is already the right object; the fallback only guards a future library that
+// returns something else.
+func parseError(err error) *jrpc2.Error {
+	if e, ok := err.(*jrpc2.Error); ok { //nolint:errorlint // matching jrpc2's own assertion style
+		return e
+	}
+	return errInvalidRequestValue
+}
+
+// resultFrame builds {"jsonrpc":"2.0","id":<id>,"result":<result>}.
+func resultFrame(id string, result []byte) []byte {
+	out := make([]byte, 0, frameSize(id, len(resultKey), len(result)))
+	out = appendEnvelope(out, id, resultKey)
+	out = append(out, result...)
+	return append(out, '}')
+}
+
+// errorFrame builds {"jsonrpc":"2.0","id":<id>,"error":<error>}. id is the
+// request's raw id text, or "" for a request with no usable id, which answers
+// with a null id per jhttp's marshalError.
+func errorFrame(id string, e *jrpc2.Error) []byte {
+	bits, err := json.Marshal(e)
+	if err != nil {
+		// Only reachable if a handler hand-built an Error whose Data is not
+		// valid JSON. Answer something well-formed rather than nothing.
+		bits, err = json.Marshal(&jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
+		if err != nil {
+			bits = []byte(`{"code":-32603,"message":"internal error"}`)
+		}
+	}
+	out := make([]byte, 0, frameSize(id, len(errorKey), len(bits)))
+	out = appendEnvelope(out, id, errorKey)
+	out = append(out, bits...)
+	return append(out, '}')
+}
+
+// frameSize is the frame's exact byte length, so a frame is one allocation and
+// one copy. Getting it wrong is not a correctness bug but it is an expensive
+// one: an append that outgrows its capacity reallocates and re-copies the whole
+// payload, which on a fat getLedgers response is another 17MB moved.
+func frameSize(id string, keyLen, payloadLen int) int {
+	return len(framePrefix) + idLen(id) + keyLen + payloadLen + 1
+}
+
+func appendEnvelope(dst []byte, id, key string) []byte {
+	dst = append(dst, framePrefix...)
+	dst = appendID(dst, id)
+	return append(dst, key...)
+}
+
+// appendID writes the request's id back exactly as the client sent it —
+// string, number, or null — with one transformation, which is not optional.
+//
+// The id text is raw client bytes: ParseRequests keeps the id as the
+// json.RawMessage the body carried, and validates only that its first byte
+// looks like a string or a number. jrpc2's own jmessage.toJSON splices those
+// bytes into the response unescaped; today's responses are nonetheless escaped,
+// but only as a side effect of the two compaction passes this package deletes.
+// Delete them and stop escaping here and up to 512KB of client-controlled bytes
+// are reflected verbatim into a response that carries no nosniff header, from a
+// mount with fully open CORS.
+//
+// So the same escaping the stdlib's appendCompact(escape=true) applies is
+// applied here, at the splice: <, >, & and U+2028/U+2029 inside the token. That
+// makes the id byte-identical to what the bridge emits today, and it is the one
+// place where hand-building the envelope would have been a security regression
+// rather than a saving. Anyone "simplifying" this to a plain append is
+// reintroducing that regression.
+//
+// Numbers pass through untouched — none of the five characters can occur in a
+// JSON number — so a large integer id keeps every digit and a fractional id
+// keeps its exact text. No float round-trip happens anywhere on this path.
+func appendID(dst []byte, id string) []byte {
+	if id == "" {
+		return append(dst, nullID...)
+	}
+	return appendHTMLEscaped(dst, id)
+}
+
+// idLen is the number of bytes appendID will write for id.
+func idLen(id string) int {
+	if id == "" {
+		return len(nullID)
+	}
+	n := len(id)
+	for i := range len(id) {
+		switch c := id[i]; {
+		case c == '<' || c == '>' || c == '&':
+			n += 5 // one byte becomes the six of \u003c
+		case c == 0xE2 && i+2 < len(id) && id[i+1] == 0x80 && id[i+2]&^1 == 0xA8:
+			n += 3 // three bytes become the six of \u2028
+		}
+	}
+	return n
+}
+
+const hexDigits = "0123456789abcdef"
+
+// appendHTMLEscaped is encoding/json's appendHTMLEscape, over a string, for the
+// one field this package writes without routing through the encoder.
+func appendHTMLEscaped(dst []byte, src string) []byte {
+	start := 0
+	for i := range len(src) {
+		c := src[i]
+		if c == '<' || c == '>' || c == '&' {
+			dst = append(dst, src[start:i]...)
+			dst = append(dst, '\\', 'u', '0', '0', hexDigits[c>>4], hexDigits[c&0xF])
+			start = i + 1
+			continue
+		}
+		// U+2028 and U+2029 are E2 80 A8 and E2 80 A9.
+		if c == 0xE2 && i+2 < len(src) && src[i+1] == 0x80 && src[i+2]&^1 == 0xA8 {
+			dst = append(dst, src[start:i]...)
+			dst = append(dst, '\\', 'u', '2', '0', '2', hexDigits[src[i+2]&0xF])
+			start = i + 3
+		}
+	}
+	return append(dst, src[start:]...)
+}
+
+// writeFrames writes the response body: one frame bare, or the frames joined
+// inside a JSON array when the request was a batch. A one-element batch stays
+// an array, matching jhttp.encodeResponses.
+//
+// The array is hand-appended. json.Marshal of a []json.RawMessage would send
+// every frame through marshalerEncoder, whose unconditional appendCompact
+// re-validates and re-copies the whole payload — that pass is 4.64s of the
+// profile and the single largest thing this package exists to delete. It is an
+// easy and completely invisible mistake to make here.
+func writeFrames(w http.ResponseWriter, isBatch bool, frames [][]byte) {
+	var body []byte
+	if !isBatch && len(frames) == 1 {
+		// The single-frame case is the fat one, and it writes the frame the
+		// dispatcher already built: no second copy of a 17MB body.
+		body = frames[0]
+	} else {
+		size := 2
+		for _, f := range frames {
+			size += len(f) + 1
+		}
+		body = make([]byte, 0, size)
+		body = append(body, '[')
+		for i, f := range frames {
+			if i > 0 {
+				body = append(body, ',')
+			}
+			body = append(body, f...)
+		}
+		body = append(body, ']')
+	}
+
+	// One Write of the finished body, into the duration limiter's buffered
+	// writer. Content-Length is set for the same reason jhttp.writeJSON sets
+	// it: the body is fully materialized, so the client should not have to
+	// discover its length from a chunked stream.
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(body) //nolint:errcheck // nothing actionable remains once the body is committed
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -14,8 +14,9 @@
 //	(f) params reach handlers verbatim rather than re-marshaled
 //	(g) dispatch stops at the HTTP deadline; started elements still finish
 //
-// Handlers run on a SERVER-scoped context, Background-derived and canceled only
-// by Handler.Shutdown. Three jrpc2 accessors are therefore unusable, and a
+// Handlers run on a SERVER-scoped context, Background-derived, so a client's
+// disconnect does not cancel a handler; the method budget does, and at
+// teardown Handler.Shutdown does. Three jrpc2 accessors are unusable, and a
 // guard test pins that: InboundRequest returns nil, ServerFromContext panics,
 // and IsNotification is false for EVERY request — that one QUIETLY, so
 // notification-ness is ParsedRequest.ID == "".
@@ -383,8 +384,11 @@ func (h *Handler) route(pr *jrpc2.ParsedRequest) (jrpc2.Handler, *jrpc2.Error) {
 
 // invoke runs one handler and frames it; the caller holds the permit.
 func (h *Handler) invoke(pr *jrpc2.ParsedRequest, method jrpc2.Handler) []byte {
-	// The SERVER's lifetime: a client that hangs up mid-call still completes
-	// it, which sendTransaction depends on.
+	// The SERVER's lifetime, so a client's disconnect does not cancel a
+	// handler — the METHOD BUDGET does, via the WithTimeout the per-method
+	// duration limiter derives from this. That is the property
+	// sendTransaction depends on: nothing the caller does mid-call decides
+	// whether the submission happens.
 	ctx := h.root
 
 	// DELTA (f): the params bytes go over verbatim, and rpcv2's getEventsV2

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -38,6 +38,8 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"golang.org/x/sync/semaphore"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/network"
 )
 
 const (
@@ -100,21 +102,22 @@ type Handler struct {
 	// just the abandoned ones (see network.RPCRequestDurationLimiter). An
 	// abandoned one has given its permit back, so the bound cannot see it and
 	// Shutdown joins the group separately.
-	liveHandlers *sync.WaitGroup
+	liveHandlers *network.LiveHandlers
 
 	drainOnce sync.Once
 	drainErr  error
 }
 
 // NewHandler returns the handler over methods, read-only from here on.
-// liveHandlers is the group the method table's duration limiters count their
-// abandoned handler goroutines into; nil means nothing registers any.
-func NewHandler(methods map[string]jrpc2.Handler, liveHandlers *sync.WaitGroup) *Handler {
+// liveHandlers must be the SAME group the method table's duration limiters
+// count into — jsonrpc.NewHandler is the one place that has both.
+func NewHandler(methods map[string]jrpc2.Handler, liveHandlers *network.LiveHandlers) *Handler {
 	weight := int64(runtime.GOMAXPROCS(0))
 	//nolint:gosec // G118: stopRoot is the handler's, called by Shutdown
 	root, stopRoot := context.WithCancel(context.Background())
 	if liveHandlers == nil {
-		liveHandlers = new(sync.WaitGroup)
+		panic("wire: NewHandler needs the mount's LiveHandlers; " +
+			"jsonrpc.NewHandler is the one place that builds it")
 	}
 	return &Handler{
 		methods:      methods,
@@ -161,7 +164,7 @@ func (h *Handler) Shutdown(ctx context.Context) error {
 
 // joinLiveHandlers waits for wg, or for ctx to end. The waiter outlives this call
 // when ctx wins; it ends when the stragglers do.
-func joinLiveHandlers(ctx context.Context, wg *sync.WaitGroup) error {
+func joinLiveHandlers(ctx context.Context, wg *network.LiveHandlers) error {
 	done := make(chan struct{})
 	go func() { wg.Wait(); close(done) }()
 	select {

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -2,10 +2,10 @@
 // only framing this repo serves.
 //
 // It replaced jrpc2's jhttp.Bridge, which is no longer built here. The bridge
-// was a
-// loopback, not a framing layer: jhttp.NewBridge builds a jrpc2.Server and a
-// jrpc2.Client joined by an in-memory pipe, so every response was marshaled by
-// the server, re-parsed by the client, and marshaled twice more by the bridge.
+// was a loopback, not a framing layer: jhttp.NewBridge builds a jrpc2.Server
+// and a jrpc2.Client joined by an in-memory pipe, so every response was
+// marshaled by the server, re-parsed by the client, and marshaled twice more
+// by the bridge.
 // In the 2026-08-30 fat-response profile that cost 10.34s of 18.10s of daemon
 // CPU (57.1%) and 3.29GB of 9.36GB allocated (35%), for zero semantic work.
 //
@@ -23,14 +23,14 @@
 // []json.RawMessage), and a batch worker's permit taken before its goroutine
 // is started (never inside it).
 //
-// # The handler context, and the one thing it no longer carries
+// # What the jrpc2.Server took with it
 //
 // Handlers run on a context derived from context.Background, which is what
 // jrpc2's ServerOptions.NewContext default gave them, so a client hangup still
 // does not cancel work in flight. What it does NOT carry is the pair of values
 // jrpc2's Server.invoke attached to every handler context: the inbound
 // *jrpc2.Request (inboundRequestKey) and the *jrpc2.Server itself (serverKey).
-// The observable delta is exactly two accessors:
+// The delta those two values leave is exactly two accessors:
 // jrpc2.InboundRequest(ctx) returns nil where it used to return the request,
 // and jrpc2.ServerFromContext(ctx) panics where it used to return the server —
 // it is documented to panic on a non-handler context, and this is one.
@@ -39,7 +39,8 @@
 // would be a worse answer than a loud one, and a handler that wants its request
 // already has it as its second argument.
 //
-// A third accessor is worse than either, because it fails QUIETLY:
+// A third accessor is not about the context at all, and is worse than either,
+// because it fails QUIETLY:
 // (*jrpc2.Request).IsNotification() is now false for every request, including
 // notifications. It tests id == nil, and ParsedRequest.ToRequest builds the id
 // as fixID(json.RawMessage(p.ID)) from a string — for an absent id that is an
@@ -263,6 +264,9 @@ func (h *Handler) serve(w http.ResponseWriter, body []byte) {
 // goroutine keeps taking permits and starting elements — for as long as
 // ceil(elements/weight) x the per-method duration limit — and the global
 // backlog slot BacklogHTTPQLimiter holds is inside that abandoned goroutine.
+// A single request has the same shape bounded at one per-method limit, since
+// RPCRequestDurationLimiter returns at its threshold whatever the context
+// does; a batch is that hole times its element count, not a new one.
 // The bridge unwound here: jhttp passed req.Context() to Client.Batch, whose
 // waitComplete failed each pending response when the context ended, so the
 // framing layer returned at the deadline while the handlers ran on.

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -200,13 +200,13 @@ func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte)
 	reqs, err := jrpc2.ParseRequests(body)
 	if err != nil {
 		// Delta (a).
-		writeFrames(w, false, [][]byte{errorFrame("", parseError(err))})
+		h.writeFrames(ctx, w, false, [][]byte{errorFrame("", parseError(err))})
 		return
 	}
 	if len(reqs) == 0 {
 		// Delta (b). A non-batch body parses to exactly one element, so an
 		// empty result means the body was `[]`.
-		writeFrames(w, false, [][]byte{errorFrame("", errEmptyBatch)})
+		h.writeFrames(ctx, w, false, [][]byte{errorFrame("", errEmptyBatch)})
 		return
 	}
 
@@ -225,7 +225,7 @@ func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte)
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	writeFrames(w, isBatch, frames)
+	h.writeFrames(ctx, w, isBatch, frames)
 }
 
 // dispatchAll answers every element in input order (delta (e)) and returns
@@ -525,26 +525,21 @@ func appendHTMLEscaped(dst []byte, src string) []byte {
 // JSON array for a batch, a one-element batch included. The array is
 // hand-appended; json.Marshal of a []json.RawMessage re-validates and re-copies
 // every frame.
-func writeFrames(w http.ResponseWriter, isBatch bool, frames [][]byte) {
+//
+// The array copy is as large as the whole response, so it is built under a
+// permit like the frames it joins, and released before the write. The bare
+// case takes no permit: it writes the frame the dispatcher already built.
+func (h *Handler) writeFrames(ctx context.Context, w http.ResponseWriter, isBatch bool, frames [][]byte) {
 	var body []byte
 	if !isBatch && len(frames) == 1 {
 		// The fat case: the frame the dispatcher already built, uncopied.
 		body = frames[0]
 	} else {
-		// Brackets are 2 and n frames carry n-1 commas: 1 + sum(len+1).
-		size := 1
-		for _, f := range frames {
-			size += len(f) + 1
+		if !h.acquirePermit(ctx) {
+			return // delta (g): nobody left to answer
 		}
-		body = make([]byte, 0, size)
-		body = append(body, '[')
-		for i, f := range frames {
-			if i > 0 {
-				body = append(body, ',')
-			}
-			body = append(body, f...)
-		}
-		body = append(body, ']')
+		body = joinFrames(frames)
+		h.sem.Release(1)
 	}
 
 	// One Write; the body is materialized, so Content-Length is set.
@@ -552,4 +547,22 @@ func writeFrames(w http.ResponseWriter, isBatch bool, frames [][]byte) {
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(http.StatusOK)
 	w.Write(body) //nolint:errcheck // nothing actionable remains once the body is committed
+}
+
+// joinFrames concatenates frames inside a JSON array in one allocation.
+func joinFrames(frames [][]byte) []byte {
+	// Brackets are 2 and n frames carry n-1 commas: 1 + sum(len+1).
+	size := 1
+	for _, f := range frames {
+		size += len(f) + 1
+	}
+	body := make([]byte, 0, size)
+	body = append(body, '[')
+	for i, f := range frames {
+		if i > 0 {
+			body = append(body, ',')
+		}
+		body = append(body, f...)
+	}
+	return append(body, ']')
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire.go
@@ -36,7 +36,7 @@
 //	(d) an empty-method notification is answered rather than 204'd
 //	(e) batch frames come back in input order
 //	(f) params reach handlers verbatim rather than re-marshaled
-//	(g) OPEN: the serving goroutine does not unwind at the HTTP deadline
+//	(g) dispatch stops at the HTTP deadline; started elements still finish
 //
 // # What the jrpc2.Server took with it
 //
@@ -206,15 +206,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// The handler context is deliberately NOT derived from req: invoke
-	// builds context.Background(), reproducing jrpc2's NewContext default so
-	// that a client hangup does not cancel work in flight. See invoke, and the
-	// package doc for the two jrpc2 server values that context no longer has.
-	h.serve(w, body) //nolint:contextcheck // deliberate; see invoke
+	// req.Context() governs the DISPATCH — whether another element is allowed
+	// to start (DELTA (g)) — and nothing else. The HANDLER context is still
+	// context.Background, so a client hangup does not cancel work in flight;
+	// see invoke, and the package doc for the two jrpc2 server values that
+	// context no longer has.
+	h.serve(req.Context(), w, body)
 }
 
-// serve parses body, dispatches it, and writes the response.
-func (h *Handler) serve(w http.ResponseWriter, body []byte) {
+// serve parses body, dispatches it, and writes the response. ctx is the HTTP
+// request's, used only to decide whether to keep dispatching.
+func (h *Handler) serve(ctx context.Context, w http.ResponseWriter, body []byte) {
 	reqs, err := jrpc2.ParseRequests(body)
 	if err != nil {
 		// DELTA (a): the bridge answers a malformed body with HTTP 500 and the
@@ -235,7 +237,17 @@ func (h *Handler) serve(w http.ResponseWriter, body []byte) {
 	// Batch-ness is a property of the body, carried on every element.
 	isBatch := reqs[0].Batch
 
-	frames := h.dispatchAll(reqs)
+	frames := h.dispatchAll(ctx, reqs)
+	if ctx.Err() != nil {
+		// DELTA (g): the request died while we were dispatching, so there is
+		// nobody to answer — httpRequestDurationLimiter has already written
+		// its 504 and returned, or the client is gone and its buffered body
+		// would be discarded. Writing anything here would have to choose
+		// between a partial batch array and mistaking an abandoned batch for
+		// an all-notification one and 204ing it. Neither is a response; this
+		// is not one either, and it is the honest one.
+		return
+	}
 	if len(frames) == 0 {
 		// Every element was a notification. DELTA (c): they have all run to
 		// completion by the time this 204 is written, because dispatchAll
@@ -279,28 +291,33 @@ func (h *Handler) serve(w http.ResponseWriter, body []byte) {
 // length; the batch's length still bounds the frames, which is where the
 // (pre-existing, bridge-identical) response amplification lives.
 //
-// DELTA (g), and the open one: this loop does not unwind when the HTTP
-// request's context ends. The permit is taken with context.Background, so
-// after httpRequestDurationLimiter answers 504 and returns, the serving
-// goroutine keeps taking permits and starting elements — for as long as
-// ceil(elements/weight) x the per-method duration limit — and the global
-// backlog slot BacklogHTTPQLimiter holds is inside that abandoned goroutine.
-// A single request has the same shape bounded at one per-method limit, since
-// RPCRequestDurationLimiter returns at its threshold whatever the context
-// does; a batch is that hole times its element count, not a new one.
-// The bridge unwound here: jhttp passed req.Context() to Client.Batch, whose
-// waitComplete failed each pending response when the context ended, so the
-// framing layer returned at the deadline while the handlers ran on.
+// DELTA (g): the permit is acquired against the HTTP REQUEST's context, so
+// this loop stops feeding the bound the moment the request is dead — when
+// httpRequestDurationLimiter has answered 504, or the client has hung up.
+// Without that it kept starting elements for ceil(elements/weight) x the
+// per-method duration limit AFTER the 504, with the global backlog slot
+// BacklogHTTPQLimiter holds sitting inside an abandoned goroutine. The bridge
+// did unwind here (jhttp passed req.Context() to Client.Batch, whose
+// waitComplete failed every pending response when the context ended), so this
+// is parity restored, not a new behavior.
 //
-// It is not fixed here because the fix is a choice, not a repair. Passing the
-// request context to Acquire would stop the loop at the deadline, at the cost
-// of the guarantee that every element of an accepted batch runs — which the
-// bridge did keep (it handed the whole batch to its server before waiting on
-// anything), and which is the guarantee sendTransaction cares about. Serial
-// dispatch had the same shape and a factor of `weight` more of it, so this is
-// strictly better than the commit before it and strictly worse than the
-// bridge, in different units.
-func (h *Handler) dispatchAll(reqs []*jrpc2.ParsedRequest) [][]byte {
+// The line it draws is between STARTED and QUEUED, and only queued work is
+// canceled:
+//
+//   - An element already inside its handler runs to completion. Its context is
+//     context.Background and nothing cancels it — that is the guarantee
+//     sendTransaction depends on, and it is untouched. wg.Wait still joins
+//     every worker that started, so the unwind costs at most one element's
+//     duration, which is exactly what a single request has always cost.
+//   - An element that never got a permit never runs, and produces no frame.
+//     There is no answer to give it and nobody to give one to: the 504 is
+//     already on the wire. serve writes nothing at all rather than assembling
+//     a response out of the survivors.
+//
+// So a canceled CALL element yields no frame, not an error frame. Building
+// one would allocate up to 22MB of answers for a batch whose reader is gone,
+// which is the work this delta exists to stop.
+func (h *Handler) dispatchAll(ctx context.Context, reqs []*jrpc2.ParsedRequest) [][]byte {
 	// One slot per element, filled by index, so the response order is the
 	// request order and does not depend on completion order. A nil slot is an
 	// element that gets no response.
@@ -314,17 +331,18 @@ func (h *Handler) dispatchAll(reqs []*jrpc2.ParsedRequest) [][]byte {
 		// panic reaches the limiter's recover with its OWN stack rather than
 		// wrapped in a relayedPanic. Deleting it as premature optimization
 		// would quietly change that.
-		frames[0] = h.dispatchOne(reqs[0])
+		frames[0] = h.dispatchOne(ctx, reqs[0])
 	} else {
-		h.dispatchBatch(reqs, frames)
+		h.dispatchBatch(ctx, reqs, frames)
 	}
 	return slices.DeleteFunc(frames, func(f []byte) bool { return f == nil })
 }
 
 // dispatchBatch runs the elements of a multi-element body, writing each one's
 // frame into its own slot of frames. See dispatchAll for why the permit is
-// taken on this goroutine rather than in the worker.
-func (h *Handler) dispatchBatch(reqs []*jrpc2.ParsedRequest, frames [][]byte) {
+// taken on this goroutine rather than in the worker, and for what a dead
+// request leaves behind.
+func (h *Handler) dispatchBatch(ctx context.Context, reqs []*jrpc2.ParsedRequest, frames [][]byte) {
 	var wg sync.WaitGroup
 	var raised atomic.Pointer[relayedPanic]
 
@@ -337,10 +355,14 @@ func (h *Handler) dispatchBatch(reqs []*jrpc2.ParsedRequest, frames [][]byte) {
 			frames[i] = frame
 			continue
 		}
-		if ok, denied := h.acquirePermit(pr); !ok {
-			frames[i] = denied
-			continue
+		if !h.acquirePermit(ctx) {
+			// DELTA (g): the request is dead, so this element and every one
+			// after it stays unstarted and unanswered. Breaking rather than
+			// continuing is the point — routing the rest would build frames
+			// for a reader that is already gone.
+			break
 		}
+		//nolint:contextcheck // invoke's context is Background by design; see invoke
 		wg.Go(func() {
 			// Released once the frame is built and strictly before the caller
 			// writes a byte, exactly as dispatchOne releases it — and released
@@ -375,36 +397,30 @@ func (h *Handler) dispatchBatch(reqs []*jrpc2.ParsedRequest, frames [][]byte) {
 // across the handler and the marshal and releasing it before it returns the
 // finished frame — so the caller writes with no permit held, and a panicking
 // handler still releases on the way out.
-func (h *Handler) dispatchOne(pr *jrpc2.ParsedRequest) []byte {
+func (h *Handler) dispatchOne(ctx context.Context, pr *jrpc2.ParsedRequest) []byte {
 	method, frame := h.route(pr)
 	if method == nil {
 		return frame
 	}
-	if ok, denied := h.acquirePermit(pr); !ok {
-		return denied
+	if !h.acquirePermit(ctx) {
+		return nil // DELTA (g): never started, so there is nothing to answer.
 	}
 	defer h.sem.Release(1)
+	//nolint:contextcheck // invoke's context is Background by design; see invoke
 	return h.invoke(pr, method)
 }
 
-// acquirePermit takes one permit from the shared bound and reports whether it
-// got one. When it did not, the second result is what goes in the element's
-// slot: the error frame for a call, and nothing at all for a notification,
-// which must never be answered whatever went wrong.
+// acquirePermit takes one permit from the shared bound, blocking until either
+// it gets one or ctx ends, and reports which happened.
 //
-// The failure is unreachable today, because Background is never canceled and
-// Acquire only fails on a canceled context. It is answered rather than dropped
-// so that a future change of context cannot turn this into a silent 200 with
-// no body — and for the same reason it has to get the notification case right
-// now, while nothing exercises it.
-func (h *Handler) acquirePermit(pr *jrpc2.ParsedRequest) (bool, []byte) {
-	if err := h.sem.Acquire(context.Background(), 1); err != nil {
-		if pr.ID == "" {
-			return false, nil
-		}
-		return false, errorFrame(pr.ID, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()})
-	}
-	return true, nil
+// ctx is the HTTP request's, never the handler's: this is the one place the
+// request's lifetime reaches into dispatch (DELTA (g)). Acquire fails only on
+// a canceled context and never keeps a permit it won in the race — x/sync
+// checks Done before, after, and while waiting, releasing the tokens if it has
+// to — so false here always means "this element did not run, and the request
+// it belongs to is over".
+func (h *Handler) acquirePermit(ctx context.Context) bool {
+	return h.sem.Acquire(ctx, 1) == nil
 }
 
 // route decides how one parsed request is answered, WITHOUT running anything:

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -1098,7 +1098,7 @@ func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
 	// The accessor name, and the receiver that makes a hit a real call: the
 	// two context accessors are package functions of jrpc2, and
 	// IsNotification is a method on a *jrpc2.Request under any name.
-	banned := map[string]string{
+	receiverOf := map[string]string{
 		"InboundRequest":    "jrpc2",
 		"ServerFromContext": "jrpc2",
 		"IsNotification":    "",
@@ -1121,7 +1121,7 @@ func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
 			if !ok {
 				return true
 			}
-			recv, banned := banned[sel.Sel.Name]
+			recv, banned := receiverOf[sel.Sel.Name]
 			if !banned {
 				return true
 			}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -134,6 +134,12 @@ func TestWire_SingleRequests(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id"  :  7  ,"method":"echo"}`,
 		want: `{"jsonrpc":"2.0","id":7,"result":{"method":"echo"}}`,
 	}, {
+		// Both the bridge and this package take the id from encoding/json's
+		// object decode, where a repeated key keeps the last value.
+		name: "a repeated id key echoes the last one",
+		body: `{"jsonrpc":"2.0","id":1,"id":2,"method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":2,"result":{"method":"echo"}}`,
+	}, {
 		name: "a nil result is null, not omitted",
 		body: `{"jsonrpc":"2.0","id":1,"method":"nilResult"}`,
 		want: `{"jsonrpc":"2.0","id":1,"result":null}`,
@@ -168,6 +174,17 @@ func TestWire_IDIsHTMLEscapedExactlyAsTheBridgeEscapedIt(t *testing.T) {
 		name: "U+2029 paragraph separator",
 		body: "{\"jsonrpc\":\"2.0\",\"id\":\"a\u2029b\",\"method\":\"echo\"}",
 		want: `{"jsonrpc":"2.0","id":"a\u2029b","result":{"method":"echo"}}`,
+	}, {
+		// The escape covers exactly five characters; every other byte of the
+		// id is spliced raw. That includes bytes that are not valid UTF-8:
+		// the bridge's compaction pass let them through too, because
+		// encoding/json's scanner checks JSON syntax and not encoding. A
+		// non-UTF-8 id therefore produces a non-UTF-8 response body, here and
+		// before. This is the boundary of the escaping guarantee, not an
+		// oversight in it.
+		name: "bytes that are not valid UTF-8 are spliced raw, as the bridge spliced them",
+		body: "{\"jsonrpc\":\"2.0\",\"id\":\"a\xffb\",\"method\":\"echo\"}",
+		want: "{\"jsonrpc\":\"2.0\",\"id\":\"a\xffb\",\"result\":{\"method\":\"echo\"}}",
 	}, {
 		name: "a script tag cannot escape the id",
 		body: `{"jsonrpc":"2.0","id":"</script><script>alert(1)</script>","method":"echo"}`,
@@ -270,6 +287,11 @@ func TestWire_RequestLevelProtocolErrors(t *testing.T) {
 	}, {
 		name:   "an empty body is the same -32700 frame",
 		body:   `   `,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"invalid request value"}}`,
+	}, {
+		name:   "trailing bytes after a complete request are a parse error",
+		body:   `{"jsonrpc":"2.0","id":1,"method":"echo"} trailing`,
 		status: http.StatusOK,
 		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"invalid request value"}}`,
 	}, {
@@ -1070,4 +1092,54 @@ func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
 	assert.Empty(t, callers, "wire runs handlers on a context with none of jrpc2's server values: "+
 		"InboundRequest returns nil and ServerFromContext panics. Take the request from the handler's "+
 		"second argument instead")
+}
+
+// Params reach the handler as the exact bytes the body carried, by position or
+// by name. DELTA (g): the bridge re-marshaled every params value through
+// json.Marshal of a json.RawMessage, which compacted it and HTML-escaped it.
+// Both forms decode to the same value and every handler here decodes, so the
+// delta is invisible in behavior — but rpcv2's getEventsV2 reads
+// r.ParamString() rather than UnmarshalParams, so the raw bytes are part of
+// the handler contract and are pinned rather than left to chance.
+//
+//nolint:nilnil,unparam // the handler literal must match the fixed jrpc2.Handler signature
+func TestWire_ParamsReachTheHandlerVerbatim(t *testing.T) {
+	var seen string
+	h := NewHandler(map[string]jrpc2.Handler{
+		"params": func(_ context.Context, r *jrpc2.Request) (any, error) {
+			seen = r.ParamString()
+			return nil, nil
+		},
+	})
+
+	for _, tc := range []struct{ name, body, want string }{{
+		name: "by position",
+		body: `{"jsonrpc":"2.0","id":1,"method":"params","params":[1,"two",null]}`,
+		want: `[1,"two",null]`,
+	}, {
+		name: "by name, in the client's key order and with the client's whitespace",
+		body: `{"jsonrpc":"2.0","id":1,"method":"params","params":{"b": 2,  "a":1}}`,
+		want: `{"b": 2,  "a":1}`,
+	}, {
+		name: "characters the bridge's re-marshal would have escaped are not escaped",
+		body: `{"jsonrpc":"2.0","id":1,"method":"params","params":{"a":"x<y&z"}}`,
+		want: `{"a":"x<y&z"}`,
+	}, {
+		name: "absent params are the empty string",
+		body: `{"jsonrpc":"2.0","id":1,"method":"params"}`,
+		want: ``,
+	}, {
+		// jrpc2's parser reduces "null" params to nil, so a handler cannot
+		// tell an explicit null from an absent params.
+		name: "an explicit null is reduced to absent",
+		body: `{"jsonrpc":"2.0","id":1,"method":"params","params":null}`,
+		want: ``,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			seen = "<unset>"
+			status, _, _ := post(t, h, tc.body)
+			require.Equal(t, http.StatusOK, status)
+			assert.Equal(t, tc.want, seen)
+		})
+	}
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -1322,3 +1322,94 @@ func TestWire_ADeadRequestStopsBuildingStaticErrorFrames(t *testing.T) {
 		"a dead request spent %.1fMB framing against a %.1fMB control: it is still answering its elements",
 		mb(deadFraming), mb(liveFraming))
 }
+
+// Shutdown is the server-scoped lifetime jrpc2's Server used to own: its
+// stopLocked canceled every in-flight request's context at stop. Nothing
+// replaced that when the bridge retired, so a straggler could keep reading a
+// store its daemon had already closed.
+//
+//nolint:unparam // the handler literals must match the fixed jrpc2.Handler signature
+func TestWire_Shutdown(t *testing.T) {
+	t.Run("cancels a running handler and returns once it is gone", func(t *testing.T) {
+		entered := make(chan struct{}, 1)
+		observed := make(chan error, 1)
+		h := NewHandler(map[string]jrpc2.Handler{
+			"watch": func(ctx context.Context, _ *jrpc2.Request) (any, error) {
+				entered <- struct{}{}
+				<-ctx.Done() // no request deadline reaches here; only Shutdown
+				observed <- ctx.Err()
+				return held, nil
+			},
+		})
+		rec, done := serveAsync(t, h, `{"jsonrpc":"2.0","id":1,"method":"watch"}`)
+		<-entered
+
+		drained := make(chan error, 1)
+		go func() { drained <- h.Shutdown(context.Background()) }()
+
+		select {
+		case err := <-observed:
+			assert.ErrorIs(t, err, context.Canceled)
+		case <-time.After(10 * time.Second):
+			t.Fatal("Shutdown did not cancel the running handler's context")
+		}
+		select {
+		case err := <-drained:
+			assert.NoError(t, err, "the drain must report success once its handlers are gone")
+		case <-time.After(10 * time.Second):
+			t.Fatal("Shutdown returned before, or never after, its handlers finished")
+		}
+		<-done
+		assert.Equal(t, http.StatusOK, rec.Code, "the request in flight still gets its answer")
+	})
+
+	t.Run("reports a drain that runs out of time, and stays idempotent", func(t *testing.T) {
+		entered := make(chan struct{}, 1)
+		release := make(chan struct{})
+		h := NewHandler(map[string]jrpc2.Handler{
+			"stuck": func(context.Context, *jrpc2.Request) (any, error) {
+				entered <- struct{}{}
+				<-release // ignores cancellation, as a scan loop between checks does
+				return held, nil
+			},
+		})
+		_, done := serveAsync(t, h, `{"jsonrpc":"2.0","id":1,"method":"stuck"}`)
+		<-entered
+
+		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+		defer cancel()
+		err := h.Shutdown(ctx)
+		require.Error(t, err, "a straggler that outlasts the budget must be reported")
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Equal(t, err, h.Shutdown(t.Context()),
+			"the first result must answer every later call, without re-taking a bound it cannot have")
+
+		close(release)
+		<-done
+	})
+
+	// The two cancellation sources compose: Shutdown holds the bound, so a
+	// later request cannot start a handler, and unwinds at its own deadline
+	// instead of hanging (DELTA (g)).
+	t.Run("nothing new starts after a completed drain", func(t *testing.T) {
+		var ran atomic.Int64
+		h := NewHandler(map[string]jrpc2.Handler{
+			"count": func(context.Context, *jrpc2.Request) (any, error) {
+				ran.Add(1)
+				return held, nil
+			},
+		})
+		require.NoError(t, h.Shutdown(t.Context()))
+
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+		defer cancel()
+		req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/",
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"count"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		assert.Zero(t, ran.Load(), "a handler ran against resources that are being torn down")
+		assert.Empty(t, rec.Body.String())
+	})
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -770,16 +770,18 @@ func TestAppendHTMLEscaped(t *testing.T) {
 
 // batchOf builds a batch body of n calls to method, with ids 1..n.
 func batchOf(n int, method string) string {
-	var b strings.Builder
-	b.WriteByte('[')
-	for i := 1; i <= n; i++ {
-		if i > 1 {
-			b.WriteByte(',')
-		}
-		fmt.Fprintf(&b, `{"jsonrpc":"2.0","id":%d,"method":%q}`, i, method)
+	return jsonArray(n, func(id int) string {
+		return fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":%q}`, id, method)
+	})
+}
+
+// jsonArray joins n elements, built from ids 1..n, into a JSON array.
+func jsonArray(n int, element func(id int) string) string {
+	elems := make([]string, n)
+	for i := range elems {
+		elems[i] = element(i + 1)
 	}
-	b.WriteByte(']')
-	return b.String()
+	return "[" + strings.Join(elems, ",") + "]"
 }
 
 // serveAsync runs one body through h on its own goroutine and returns the
@@ -838,19 +840,13 @@ func TestWire_BatchElementsRunConcurrently(t *testing.T) {
 	close(release)
 	<-done
 
-	var want strings.Builder
-	want.WriteByte('[')
-	for i := 1; i <= n; i++ {
-		if i > 1 {
-			want.WriteByte(',')
-		}
-		fmt.Fprintf(&want, `{"jsonrpc":"2.0","id":%d,"result":%q}`, i, held)
-	}
-	want.WriteByte(']')
+	want := jsonArray(n, func(id int) string {
+		return fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"result":%q}`, id, held)
+	})
 
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, want.String(), rec.Body.String())
-	assert.Equal(t, strconv.Itoa(want.Len()), rec.Header().Get("Content-Length"))
+	assert.Equal(t, want, rec.Body.String())
+	assert.Equal(t, strconv.Itoa(len(want)), rec.Header().Get("Content-Length"))
 }
 
 // The stopwatch form of the test above, because "the batch took N times one

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -1436,3 +1436,38 @@ func TestWire_ADeadSingleRequestBuildsNoStaticFrame(t *testing.T) {
 		"a dead request allocated %.1fMB against a %.1fMB control: it is still framing",
 		float64(deadAlloc)/(1<<20), float64(liveAlloc)/(1<<20))
 }
+
+// The batch body is a copy as large as the whole response, so it is assembled
+// under a permit; the bare single-frame path must stay permit-free, since it
+// only writes the frame the dispatcher already built.
+func TestWire_BatchAssemblyIsBuiltInsideTheBound(t *testing.T) {
+	h := NewHandler(map[string]jrpc2.Handler{}, new(network.LiveHandlers))
+	weight := int64(runtime.GOMAXPROCS(0))
+	require.NoError(t, h.sem.Acquire(context.Background(), weight))
+
+	// The bare path does not assemble anything, so it must not block.
+	bare := httptest.NewRecorder()
+	h.writeFrames(context.Background(), bare, false, [][]byte{[]byte(`{"a":1}`)})
+	assert.Equal(t, `{"a":1}`, bare.Body.String())
+
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.writeFrames(context.Background(), rec, true, [][]byte{[]byte(`{"a":1}`), []byte(`{"b":2}`)})
+	}()
+	select {
+	case <-done:
+		h.sem.Release(weight)
+		t.Fatal("a batch body was assembled while every permit was held")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	h.sem.Release(weight)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the batch body was never assembled after a permit came back")
+	}
+	assert.Equal(t, `[{"a":1},{"b":2}]`, rec.Body.String())
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -1,0 +1,704 @@
+package wire
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every `want` in this file is a byte string, not a shape. They were captured
+// from jrpc2 v1.3.3's jhttp.Bridge — the framing this package replaces — on
+// 2026-08-30, except where a case is annotated with the delta that changes it
+// deliberately. The point of pinning bytes rather than structure is that the
+// error vocabulary these frames carry (errEmptyMethod, errNoSuchMethod,
+// errEmptyBatch, "invalid request value", "invalid version marker", "extra
+// fields in request", ...) is unexported in jrpc2 and transcribed here: only an
+// exact-byte pin will notice if a library bump or a refactor moves one.
+
+// testMethods is the table under test. notified counts calls to "note" so a
+// notification's completion is observable.
+//
+//nolint:unparam // every literal here must match the fixed jrpc2.Handler signature
+func testMethods(notified *atomic.Int64) map[string]jrpc2.Handler {
+	return map[string]jrpc2.Handler{
+		"echo": func(_ context.Context, r *jrpc2.Request) (any, error) {
+			return map[string]any{"method": r.Method()}, nil
+		},
+		"note": func(context.Context, *jrpc2.Request) (any, error) {
+			notified.Add(1)
+			return "noted", nil
+		},
+		"nilResult": func(context.Context, *jrpc2.Request) (any, error) { return nil, nil },
+		"plainError": func(context.Context, *jrpc2.Request) (any, error) {
+			return nil, errors.New("something went wrong")
+		},
+		"jrpcError": func(context.Context, *jrpc2.Request) (any, error) {
+			return nil, (&jrpc2.Error{Code: -32123, Message: "custom failure"}).WithData([]string{"a", "b"})
+		},
+		"wrappedJRPCError": func(context.Context, *jrpc2.Request) (any, error) {
+			return nil, fmt.Errorf("while doing the thing: %w", &jrpc2.Error{Code: -32123, Message: "custom failure"})
+		},
+		"valueJRPCError": func(context.Context, *jrpc2.Request) (any, error) {
+			// The repo's own limiter sentinels are jrpc2.Error VALUES; see
+			// handlerError's comment for why that changes the wire message.
+			return nil, jrpc2.Error{Code: -32001, Message: "request exceeded processing limit threshold"}
+		},
+		"contextCanceled": func(context.Context, *jrpc2.Request) (any, error) {
+			return nil, fmt.Errorf("gave up: %w", context.Canceled)
+		},
+		"unmarshalable": func(context.Context, *jrpc2.Request) (any, error) {
+			return map[string]any{"ch": make(chan int)}, nil
+		},
+	}
+}
+
+// post drives one request through the handler and returns status, headers, body.
+func post(t *testing.T, h http.Handler, body string) (int, http.Header, string) {
+	t.Helper()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	res := rec.Result()
+	defer res.Body.Close()
+	raw, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	return res.StatusCode, res.Header, string(raw)
+}
+
+func newTestHandler(t *testing.T) (*Handler, *atomic.Int64) {
+	t.Helper()
+	var notified atomic.Int64
+	return NewHandler(testMethods(&notified)), &notified
+}
+
+func TestWire_SingleRequests(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{{
+		name: "number id",
+		body: `{"jsonrpc":"2.0","id":1,"method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}}`,
+	}, {
+		name: "string id",
+		body: `{"jsonrpc":"2.0","id":"abc","method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":"abc","result":{"method":"echo"}}`,
+	}, {
+		// The id is echoed as raw bytes, never decoded and re-encoded: a
+		// float64 round trip would render this 12345678901234567000.
+		name: "integer id beyond float64 precision keeps every digit",
+		body: `{"jsonrpc":"2.0","id":12345678901234567890,"method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":12345678901234567890,"result":{"method":"echo"}}`,
+	}, {
+		name: "fractional id keeps its exact text",
+		body: `{"jsonrpc":"2.0","id":1.500,"method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":1.500,"result":{"method":"echo"}}`,
+	}, {
+		name: "exponent id keeps its exact text",
+		body: `{"jsonrpc":"2.0","id":1e2,"method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":1e2,"result":{"method":"echo"}}`,
+	}, {
+		name: "escapes inside a string id are passed through untouched",
+		body: `{"jsonrpc":"2.0","id":"a\"b\nc\u00e9","method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":"a\"b\nc\u00e9","result":{"method":"echo"}}`,
+	}, {
+		name: "whitespace around the id is not echoed",
+		body: `{"jsonrpc":"2.0","id"  :  7  ,"method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":7,"result":{"method":"echo"}}`,
+	}, {
+		name: "a nil result is null, not omitted",
+		body: `{"jsonrpc":"2.0","id":1,"method":"nilResult"}`,
+		want: `{"jsonrpc":"2.0","id":1,"result":null}`,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, header, got := post(t, h, tc.body)
+			assert.Equal(t, http.StatusOK, status)
+			assert.Equal(t, "application/json", header.Get("Content-Type"))
+			assert.Equal(t, strconv.Itoa(len(tc.want)), header.Get("Content-Length"))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The id is client-controlled and reflected. jrpc2 splices it into the response
+// unescaped; today's responses are escaped only as a side effect of the
+// compaction passes this package deletes. If this test ever fails because
+// someone "simplified" appendID to a plain append, the mount has started
+// reflecting arbitrary client bytes into a response with no nosniff header.
+func TestWire_IDIsHTMLEscapedExactlyAsTheBridgeEscapedIt(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	for _, tc := range []struct{ name, body, want string }{{
+		name: "angle brackets and ampersand",
+		body: `{"jsonrpc":"2.0","id":"a<b&c>d","method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":"a\u003cb\u0026c\u003ed","result":{"method":"echo"}}`,
+	}, {
+		name: "U+2028 line separator",
+		body: "{\"jsonrpc\":\"2.0\",\"id\":\"a\u2028b\",\"method\":\"echo\"}",
+		want: `{"jsonrpc":"2.0","id":"a\u2028b","result":{"method":"echo"}}`,
+	}, {
+		name: "U+2029 paragraph separator",
+		body: "{\"jsonrpc\":\"2.0\",\"id\":\"a\u2029b\",\"method\":\"echo\"}",
+		want: `{"jsonrpc":"2.0","id":"a\u2029b","result":{"method":"echo"}}`,
+	}, {
+		name: "a script tag cannot escape the id",
+		body: `{"jsonrpc":"2.0","id":"</script><script>alert(1)</script>","method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":"\u003c/script\u003e\u003cscript\u003e` +
+			`alert(1)\u003c/script\u003e","result":{"method":"echo"}}`,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, header, got := post(t, h, tc.body)
+			assert.Equal(t, http.StatusOK, status)
+			assert.Equal(t, tc.want, got)
+			// The capacity hint must account for the escape, or the frame is
+			// built with a reallocation.
+			assert.Equal(t, strconv.Itoa(len(tc.want)), header.Get("Content-Length"))
+		})
+	}
+}
+
+func TestWire_ErrorMapping(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	for _, tc := range []struct{ name, body, want string }{{
+		name: "a *jrpc2.Error passes through verbatim, data included",
+		body: `{"jsonrpc":"2.0","id":1,"method":"jrpcError"}`,
+		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32123,"message":"custom failure","data":["a","b"]}}`,
+	}, {
+		// jrpc2 asserts, it does not unwrap: a wrapped *Error keeps its code
+		// but takes the wrapper's message. Pinned because it looks like a bug.
+		name: "a WRAPPED *jrpc2.Error keeps the code and takes the wrapper message",
+		body: `{"jsonrpc":"2.0","id":1,"method":"wrappedJRPCError"}`,
+		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32123,` +
+			`"message":"while doing the thing: [-32123] custom failure"}}`,
+	}, {
+		// The repo's limiter sentinels take this path; the doubled "[-32001] "
+		// is today's wire text and is reproduced, not fixed, in this commit.
+		name: "a jrpc2.Error VALUE keeps its code and doubles its code into the message",
+		body: `{"jsonrpc":"2.0","id":1,"method":"valueJRPCError"}`,
+		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32001,` +
+			`"message":"[-32001] request exceeded processing limit threshold"}}`,
+	}, {
+		name: "a plain error becomes SystemError",
+		body: `{"jsonrpc":"2.0","id":1,"method":"plainError"}`,
+		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32098,"message":"something went wrong"}}`,
+	}, {
+		name: "a wrapped context.Canceled maps to jrpc2's -32097",
+		body: `{"jsonrpc":"2.0","id":1,"method":"contextCanceled"}`,
+		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32097,"message":"gave up: context canceled"}}`,
+	}, {
+		name: "an unmarshalable result becomes an internal error, not a truncated body",
+		body: `{"jsonrpc":"2.0","id":1,"method":"unmarshalable"}`,
+		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32603,` +
+			`"message":"json: unsupported type: chan int"}}`,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _, got := post(t, h, tc.body)
+			assert.Equal(t, http.StatusOK, status)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWire_UnknownMethod(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	t.Run("a call gets jrpc2's own method-not-found frame", func(t *testing.T) {
+		status, _, got := post(t, h, `{"jsonrpc":"2.0","id":1,"method":"noSuchMethod"}`)
+		assert.Equal(t, http.StatusOK, status)
+		//nolint:testifylint // byte-exact wire pin; JSONEq would ignore key order and escaping
+		assert.Equal(t,
+			`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found","data":"noSuchMethod"}}`,
+			got)
+	})
+
+	t.Run("a notification is silent", func(t *testing.T) {
+		status, _, got := post(t, h, `{"jsonrpc":"2.0","method":"noSuchMethod"}`)
+		assert.Equal(t, http.StatusNoContent, status)
+		assert.Empty(t, got)
+	})
+}
+
+func TestWire_RequestLevelProtocolErrors(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	for _, tc := range []struct {
+		name   string
+		body   string
+		status int
+		want   string
+	}{{
+		// DELTA (a): the bridge answers 500 + the plaintext
+		// "[-32700] invalid request value". This is the spec's answer.
+		name:   "a malformed body is a -32700 frame over HTTP 200",
+		body:   `{`,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"invalid request value"}}`,
+	}, {
+		name:   "a body that is not JSON at all is the same -32700 frame",
+		body:   `not json`,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"invalid request value"}}`,
+	}, {
+		name:   "an empty body is the same -32700 frame",
+		body:   `   `,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"invalid request value"}}`,
+	}, {
+		// DELTA (b): the bridge answers `[]` with 204.
+		name:   "an empty batch is a single -32600 frame, not an array and not a 204",
+		body:   `[]`,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"empty request batch"}}`,
+	}, {
+		name:   "an empty method name on a call is -32600",
+		body:   `{"jsonrpc":"2.0","id":1,"method":""}`,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"empty method name"}}`,
+	}, {
+		// DELTA (e): the bridge answers 204 here, and only by accident — its
+		// in-process client discards the server's frame because the id is
+		// empty. An empty method name is a request-level error and is
+		// reportable even for a notification.
+		name:   "an empty method name on a NOTIFICATION is a -32600 frame with a null id",
+		body:   `{"jsonrpc":"2.0","method":""}`,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"empty method name"}}`,
+	}, {
+		// Parity, not a delta: a response-shaped message has no method, so it
+		// degrades to the empty-method error rather than being "understood".
+		name:   "a response-shaped message with a version marker degrades to empty method",
+		body:   `{"jsonrpc":"2.0","id":1,"result":5}`,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"empty method name"}}`,
+	}, {
+		name:   "a response-shaped message with no version marker fails on the version",
+		body:   `{"result":5}`,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid version marker"}}`,
+	}, {
+		name:   "a wrong version marker is -32600 and still echoes the id",
+		body:   `{"jsonrpc":"1.0","id":2,"method":"echo"}`,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"invalid version marker"}}`,
+	}, {
+		// Parity: a parse/shape error is reported even for a notification.
+		// This is what the bridge does today and what the spec requires.
+		name:   "a parse error on a notification still answers",
+		body:   `{"jsonrpc":"1.0","method":"echo"}`,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid version marker"}}`,
+	}, {
+		name:   "extra fields are rejected and named",
+		body:   `{"jsonrpc":"2.0","id":1,"method":"echo","bogus":1}`,
+		status: http.StatusOK,
+		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32600,` +
+			`"message":"extra fields in request","data":["bogus"]}}`,
+	}, {
+		name:   "params must be an array or an object",
+		body:   `{"jsonrpc":"2.0","id":1,"method":"echo","params":5}`,
+		status: http.StatusOK,
+		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32600,` +
+			`"message":"parameters must be array or object"}}`,
+	}, {
+		name:   "an unusable id answers with a null id",
+		body:   `{"jsonrpc":"2.0","id":{"a":1},"method":"echo"}`,
+		status: http.StatusOK,
+		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid request ID"}}`,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _, got := post(t, h, tc.body)
+			assert.Equal(t, tc.status, status)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWire_Notifications(t *testing.T) {
+	t.Run("an absent id is a notification and runs to completion before the 204", func(t *testing.T) {
+		h, notified := newTestHandler(t)
+		status, _, got := post(t, h, `{"jsonrpc":"2.0","method":"note"}`)
+		assert.Equal(t, http.StatusNoContent, status)
+		assert.Empty(t, got)
+		assert.Equal(t, int64(1), notified.Load(),
+			"DELTA (c): the work must be finished when the 204 is written")
+	})
+
+	t.Run("an explicit null id is a notification too", func(t *testing.T) {
+		h, notified := newTestHandler(t)
+		status, _, got := post(t, h, `{"jsonrpc":"2.0","id":null,"method":"note"}`)
+		assert.Equal(t, http.StatusNoContent, status)
+		assert.Empty(t, got)
+		assert.Equal(t, int64(1), notified.Load())
+	})
+
+	t.Run("an all-notification batch 204s after every element has run", func(t *testing.T) {
+		h, notified := newTestHandler(t)
+		status, _, got := post(t, h,
+			`[{"jsonrpc":"2.0","method":"note"},{"jsonrpc":"2.0","method":"note"},{"jsonrpc":"2.0","method":"note"}]`)
+		assert.Equal(t, http.StatusNoContent, status)
+		assert.Empty(t, got)
+		assert.Equal(t, int64(3), notified.Load())
+	})
+
+	t.Run("a notification inside a batch produces no entry but still runs", func(t *testing.T) {
+		h, notified := newTestHandler(t)
+		status, _, got := post(t, h,
+			`[{"jsonrpc":"2.0","method":"note"},{"jsonrpc":"2.0","id":9,"method":"echo"}]`)
+		assert.Equal(t, http.StatusOK, status)
+		//nolint:testifylint // byte-exact wire pin; JSONEq would ignore key order and escaping
+		assert.Equal(t, `[{"jsonrpc":"2.0","id":9,"result":{"method":"echo"}}]`, got)
+		assert.Equal(t, int64(1), notified.Load())
+	})
+
+	t.Run("a notification whose handler fails is silent", func(t *testing.T) {
+		h, _ := newTestHandler(t)
+		status, _, got := post(t, h, `{"jsonrpc":"2.0","method":"plainError"}`)
+		assert.Equal(t, http.StatusNoContent, status)
+		assert.Empty(t, got)
+	})
+}
+
+func TestWire_Batches(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	for _, tc := range []struct{ name, body, want string }{{
+		name: "a one-element batch stays an array",
+		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"}]`,
+		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}}]`,
+	}, {
+		// DELTA (f): the bridge answers this
+		// [invalid(id 2), valid(id 1), valid(id 3)].
+		name: "invalid elements answer in place, not first",
+		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"},` +
+			`{"jsonrpc":"1.0","id":2,"method":"echo"},` +
+			`{"jsonrpc":"2.0","id":3,"method":"echo"}]`,
+		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}},` +
+			`{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"invalid version marker"}},` +
+			`{"jsonrpc":"2.0","id":3,"result":{"method":"echo"}}]`,
+	}, {
+		name: "a non-object element answers in place with a null id",
+		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"},5]`,
+		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}},` +
+			`{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}]`,
+	}, {
+		// Parity: the bridge virtualizes ids, so jrpc2's duplicate-id check is
+		// unreachable today. Owning the framing must not make it reachable.
+		name: "duplicate ids inside one batch are allowed",
+		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"},{"jsonrpc":"2.0","id":1,"method":"nilResult"}]`,
+		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}},` +
+			`{"jsonrpc":"2.0","id":1,"result":null}]`,
+	}, {
+		name: "mixed methods, errors and unknown names all answer in order",
+		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"},` +
+			`{"jsonrpc":"2.0","id":2,"method":"nope"},` +
+			`{"jsonrpc":"2.0","id":3,"method":"plainError"}]`,
+		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}},` +
+			`{"jsonrpc":"2.0","id":2,"error":{"code":-32601,"message":"method not found","data":"nope"}},` +
+			`{"jsonrpc":"2.0","id":3,"error":{"code":-32098,"message":"something went wrong"}}]`,
+	}, {
+		name: "a nested array element is a parse error, still wrapped as a batch",
+		body: `[[]]`,
+		want: `[{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}]`,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, header, got := post(t, h, tc.body)
+			assert.Equal(t, http.StatusOK, status)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, strconv.Itoa(len(tc.want)), header.Get("Content-Length"))
+		})
+	}
+}
+
+func TestWire_HTTPShell(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	do := func(method, contentType, body string) *http.Response {
+		req := httptest.NewRequestWithContext(t.Context(), method, "/", strings.NewReader(body))
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec.Result()
+	}
+
+	t.Run("Accept-Post is advertised on a successful POST too", func(t *testing.T) {
+		res := do(http.MethodPost, "application/json", `{"jsonrpc":"2.0","id":1,"method":"echo"}`)
+		defer res.Body.Close()
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		assert.Equal(t, "application/json", res.Header.Get("Accept-Post"))
+	})
+
+	t.Run("GET is 405 with Accept-Post and no body", func(t *testing.T) {
+		res := do(http.MethodGet, "", "")
+		defer res.Body.Close()
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+		assert.Equal(t, "application/json", res.Header.Get("Accept-Post"))
+		assert.Empty(t, body)
+	})
+
+	for _, tc := range []struct {
+		name, contentType, want string
+	}{
+		{"no content type", "", "content-type must be application/json\n"},
+		{"wrong media type", "text/plain", "content-type must be application/json\n"},
+		{"wrong charset", "application/json; charset=iso-8859-1", "invalid content-type charset\n"},
+	} {
+		t.Run(tc.name+" is 415", func(t *testing.T) {
+			res := do(http.MethodPost, tc.contentType, `{"jsonrpc":"2.0","id":1,"method":"echo"}`)
+			defer res.Body.Close()
+			body, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusUnsupportedMediaType, res.StatusCode)
+			assert.Equal(t, tc.want, string(body))
+		})
+	}
+
+	t.Run("an explicit utf-8 charset is accepted", func(t *testing.T) {
+		res := do(http.MethodPost, "application/json; charset=utf-8", `{"jsonrpc":"2.0","id":1,"method":"echo"}`)
+		defer res.Body.Close()
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("an unreadable body is 500 plus plaintext, not a JSON-RPC frame", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", errReader{})
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		res := rec.Result()
+		defer res.Body.Close()
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
+		assert.Equal(t, "connection reset\n", string(body))
+	})
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("connection reset") }
+
+// A fat response must survive the envelope byte for byte. There is no way to
+// assert "exactly one copy" from a test, so this asserts the two things that
+// would break if the copy count changed for the wrong reason: the body still
+// parses, and its result is byte-identical to an independent json.Marshal of
+// the same value (so nothing re-compacted, re-escaped, or truncated it).
+//
+//nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
+func TestWire_BigResponseIntegrity(t *testing.T) {
+	const payloadBytes = 4 << 20
+	payload := strings.Repeat("abcdefgh", payloadBytes/8)
+	value := map[string]any{"blob": payload, "n": 12345}
+
+	h := NewHandler(map[string]jrpc2.Handler{
+		"fat": func(context.Context, *jrpc2.Request) (any, error) { return value, nil },
+	})
+
+	status, header, got := post(t, h, `{"jsonrpc":"2.0","id":"big","method":"fat"}`)
+	require.Equal(t, http.StatusOK, status)
+
+	oracle, err := json.Marshal(value)
+	require.NoError(t, err)
+	want := `{"jsonrpc":"2.0","id":"big","result":` + string(oracle) + `}`
+
+	//nolint:testifylint // compare lengths, not values: assert.Len would dump megabytes on failure
+	assert.Equal(t, len(want), len(got), "the framed body must be exactly the envelope plus the marshaled value")
+	assert.Equal(t, want, got)
+	assert.Equal(t, strconv.Itoa(len(want)), header.Get("Content-Length"))
+
+	var envelope struct {
+		Version string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  json.RawMessage `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(got), &envelope))
+	assert.Equal(t, "2.0", envelope.Version)
+	assert.JSONEq(t, `"big"`, string(envelope.ID))
+	assert.Equal(t, oracle, []byte(envelope.Result))
+}
+
+// The concurrency bound is the design's own #1 hazard: without it, the number
+// of fat marshals in flight is the HTTP backlog limit (5000), not the core
+// count. jrpc2's Server held a semaphore of runtime.NumCPU() across handler and
+// result marshal; this reproduces it, and this test fails if it is removed.
+//
+//nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
+func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
+	limit := runtime.NumCPU()
+	entered := make(chan struct{}, 4*limit)
+	release := make(chan struct{})
+
+	var inflight, peak atomic.Int64
+	h := NewHandler(map[string]jrpc2.Handler{
+		"hold": func(context.Context, *jrpc2.Request) (any, error) {
+			now := inflight.Add(1)
+			for {
+				old := peak.Load()
+				if now <= old || peak.CompareAndSwap(old, now) {
+					break
+				}
+			}
+			entered <- struct{}{}
+			<-release
+			inflight.Add(-1)
+			return "done", nil
+		},
+	})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	callers := 2 * limit
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL,
+				strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"hold"}`))
+			if err != nil {
+				return
+			}
+			req.Header.Set("Content-Type", "application/json")
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return
+			}
+			_, _ = io.Copy(io.Discard, res.Body)
+			res.Body.Close()
+		}()
+	}
+
+	// Wait for the bound to be saturated, then give the unbounded case ample
+	// room to exceed it before looking.
+	for range limit {
+		select {
+		case <-entered:
+		case <-time.After(10 * time.Second):
+			close(release)
+			wg.Wait()
+			t.Fatalf("only %d of %d handlers started", peak.Load(), limit)
+		}
+	}
+	time.Sleep(250 * time.Millisecond)
+	observed := peak.Load()
+	close(release)
+	wg.Wait()
+
+	assert.LessOrEqual(t, observed, int64(limit),
+		"more than runtime.NumCPU() handlers ran at once: the semaphore is gone or its weight is wrong")
+	assert.Equal(t, int64(limit), observed,
+		"the bound was never reached, so this test would not notice its removal")
+}
+
+// The permit must be gone before any byte is handed to the ResponseWriter, or a
+// slow reader holds a slot in a bound sized for CPUs. Proved structurally: the
+// handler that writes is the one that has already released, so a request whose
+// write blocks cannot stop the next request's handler from starting.
+//
+//nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
+func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
+	started := make(chan struct{}, 1)
+	h := NewHandler(map[string]jrpc2.Handler{
+		"echo": func(context.Context, *jrpc2.Request) (any, error) {
+			started <- struct{}{}
+			return "ok", nil
+		},
+	})
+
+	// Saturate the bound with writers that never drain, then prove a fresh
+	// request still reaches its handler.
+	blocked := make(chan struct{})
+	var wg sync.WaitGroup
+	for range runtime.NumCPU() {
+		wg.Go(func() {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/",
+				strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"echo"}`))
+			req.Header.Set("Content-Type", "application/json")
+			h.ServeHTTP(blockingWriter{blocked: blocked}, req)
+		})
+	}
+	for range runtime.NumCPU() {
+		select {
+		case <-started:
+		case <-time.After(10 * time.Second):
+			close(blocked)
+			wg.Wait()
+			t.Fatal("the saturating requests never reached their handlers")
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		status, _, body := post(t, h, `{"jsonrpc":"2.0","id":2,"method":"echo"}`)
+		assert.Equal(t, http.StatusOK, status)
+		//nolint:testifylint // byte-exact wire pin; JSONEq would ignore key order and escaping
+		assert.Equal(t, `{"jsonrpc":"2.0","id":2,"result":"ok"}`, body)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Error("a request could not be served while NumCPU writers were stalled: " +
+			"the semaphore is being held across the write")
+	}
+	<-started
+	close(blocked)
+	wg.Wait()
+}
+
+// blockingWriter is a ResponseWriter whose Write never returns until blocked is
+// closed, standing in for a client that stopped reading.
+type blockingWriter struct {
+	blocked chan struct{}
+	header  http.Header
+}
+
+func (b blockingWriter) Header() http.Header {
+	if b.header == nil {
+		return http.Header{}
+	}
+	return b.header
+}
+func (b blockingWriter) Write(p []byte) (int, error) { <-b.blocked; return len(p), nil }
+func (blockingWriter) WriteHeader(int)               {}
+
+func TestAppendHTMLEscaped(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{`"plain"`, `"plain"`},
+		{`123`, `123`},
+		{`"a<b"`, `"a\u003cb"`},
+		{`"a>b"`, `"a\u003eb"`},
+		{`"a&b"`, `"a\u0026b"`},
+		{`"<>&"`, `"\u003c\u003e\u0026"`},
+		{"\"\u2028\"", `"\u2028"`},
+		{"\"\u2029\"", `"\u2029"`},
+		{`"already \u003c escaped"`, `"already \u003c escaped"`},
+	} {
+		got := string(appendHTMLEscaped(nil, tc.in))
+		assert.Equal(t, tc.want, got, "input %q", tc.in)
+		assert.Equal(t, len(tc.want), idLen(tc.in), "idLen must predict the escaped length of %q", tc.in)
+	}
+	assert.Equal(t, len("null"), idLen(""))
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -1156,3 +1156,85 @@ func TestWire_ParamsReachTheHandlerVerbatim(t *testing.T) {
 		})
 	}
 }
+
+// DELTA (g), the half that stops: once the request is dead — the duration
+// limiter has written its 504, or the client is gone — the serving goroutine
+// stops feeding the bound. Before this it kept taking permits and starting
+// elements for ceil(elements/weight) x the per-element time AFTER the answer
+// had gone out, with the global backlog slot held inside that abandoned
+// goroutine; a 3,200-element batch measured 4.73s of it past a 300ms deadline.
+//
+// The half that does NOT stop — an element already inside its handler runs to
+// completion — is asserted here on the elements that held permits, and at the
+// mount in TestMount_AStartedElementSurvivesTheDeadline.
+//
+//nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
+func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
+	weight := runtime.GOMAXPROCS(0)
+	elements := max(512, 4*weight)
+
+	entered := make(chan struct{}, elements)
+	release := make(chan struct{})
+	var started, completed atomic.Int64
+
+	h := NewHandler(map[string]jrpc2.Handler{
+		"hold": func(context.Context, *jrpc2.Request) (any, error) {
+			started.Add(1)
+			entered <- struct{}{}
+			<-release
+			completed.Add(1)
+			return held, nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/", strings.NewReader(batchOf(elements, "hold")))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.ServeHTTP(rec, req)
+	}()
+
+	// Saturate the bound. Every permit is now held, so the dispatch loop is
+	// parked in Acquire with the great majority of the batch still to go.
+	for k := range weight {
+		select {
+		case <-entered:
+		case <-time.After(10 * time.Second):
+			cancel()
+			close(release)
+			<-done
+			t.Fatalf("only %d of %d permits were taken", k, weight)
+		}
+	}
+
+	// Kill the request, exactly as the limiter's 504 branch does.
+	cancel()
+	time.Sleep(250 * time.Millisecond) // ample room for the loop to notice
+	atCancel := started.Load()
+
+	// Release the in-flight elements and time the unwind from there: the
+	// serving goroutine joins the work it started, so it cannot return before
+	// that work does. What it must NOT do is start any more.
+	close(release)
+	unwindStart := time.Now()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the serving goroutine never unwound: the dispatch loop is not watching the request")
+	}
+	unwind := time.Since(unwindStart)
+	t.Logf("started %d of %d elements at a bound of %d; unwound %v after the last one returned",
+		started.Load(), elements, weight, unwind)
+
+	assert.Equal(t, atCancel, started.Load(), "elements started after the request was already dead")
+	assert.LessOrEqual(t, atCancel, int64(weight+1),
+		"a dead request started more than the elements already holding permits (+1 for the Acquire race)")
+	assert.Equal(t, atCancel, completed.Load(), "an element that had started did not run to completion")
+	assert.Less(t, unwind, 5*time.Second, "the unwind waited on more than the work it had started")
+	assert.Empty(t, rec.Body.String(),
+		"a dead request is answered by the layer that killed it; the framing writes nothing")
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -137,6 +137,11 @@ func TestWire_SingleRequests(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id":1e2,"method":"echo"}`,
 		want: `{"jsonrpc":"2.0","id":1e2,"result":{"method":"echo"}}`,
 	}, {
+		// The only branch of jrpc2's isValidID that no other case reaches.
+		name: "a negative id keeps its sign",
+		body: `{"jsonrpc":"2.0","id":-1,"method":"echo"}`,
+		want: `{"jsonrpc":"2.0","id":-1,"result":{"method":"echo"}}`,
+	}, {
 		name: "escapes inside a string id are passed through untouched",
 		body: `{"jsonrpc":"2.0","id":"a\"b\nc\u00e9","method":"echo"}`,
 		want: `{"jsonrpc":"2.0","id":"a\"b\nc\u00e9","result":{"method":"echo"}}`,
@@ -213,6 +218,24 @@ func TestWire_IDIsHTMLEscapedExactlyAsTheBridgeEscapedIt(t *testing.T) {
 	}
 }
 
+// idLen's capacity arithmetic is only load-bearing at scale: a hint one byte
+// short makes the frame reallocate and re-copy its whole payload, which is the
+// cost this package exists to delete. This is the worst case the 512KB body cap
+// allows — an id in which every single byte escapes to six.
+func TestWire_ALargeEscapingIDIsFramedAtItsExactLength(t *testing.T) {
+	h, _ := newTestHandler(t)
+	const n = 128 * 1024
+	body := `{"jsonrpc":"2.0","id":"` + strings.Repeat("<", n) + `","method":"echo"}`
+	want := `{"jsonrpc":"2.0","id":"` + strings.Repeat(`\u003c`, n) + `","result":{"method":"echo"}}`
+
+	status, header, got := post(t, h, body)
+	require.Equal(t, http.StatusOK, status)
+	//nolint:testifylint // compare lengths first: an Equal on the values would dump a megabyte
+	require.Equal(t, len(want), len(got), "the frame is not the envelope plus the escaped id")
+	assert.Equal(t, want, got)
+	assert.Equal(t, strconv.Itoa(len(want)), header.Get("Content-Length"))
+}
+
 func TestWire_ErrorMapping(t *testing.T) {
 	h, _ := newTestHandler(t)
 
@@ -243,9 +266,12 @@ func TestWire_ErrorMapping(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id":1,"method":"contextCanceled"}`,
 		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32097,"message":"gave up: context canceled"}}`,
 	}, {
-		name: "an unmarshalable result becomes an internal error, not a truncated body",
+		// -32098, not -32603: jrpc2's invoke returns the marshal failure as
+		// the task's error, so responses() maps it down the same ladder a
+		// handler error takes. Captured from the live bridge.
+		name: "a result that cannot be marshaled is a system error, not a truncated body",
 		body: `{"jsonrpc":"2.0","id":1,"method":"unmarshalable"}`,
-		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32603,` +
+		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32098,` +
 			`"message":"json: unsupported type: chan int"}}`,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -317,7 +343,7 @@ func TestWire_RequestLevelProtocolErrors(t *testing.T) {
 		status: http.StatusOK,
 		want:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"empty method name"}}`,
 	}, {
-		// DELTA (e): the bridge answers 204 here, and only by accident — its
+		// DELTA (d): the bridge answers 204 here, and only by accident — its
 		// in-process client discards the server's frame because the id is
 		// empty. An empty method name is a request-level error and is
 		// reportable even for a notification.
@@ -428,7 +454,7 @@ func TestWire_Batches(t *testing.T) {
 		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"}]`,
 		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}}]`,
 	}, {
-		// DELTA (f): the bridge answers this
+		// DELTA (e): the bridge answers this
 		// [invalid(id 2), valid(id 1), valid(id 3)].
 		name: "invalid elements answer in place, not first",
 		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"},` +
@@ -438,6 +464,7 @@ func TestWire_Batches(t *testing.T) {
 			`{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"invalid version marker"}},` +
 			`{"jsonrpc":"2.0","id":3,"result":{"method":"echo"}}]`,
 	}, {
+		// DELTA (e) again: the bridge answers [invalid(null id), valid(id 1)].
 		name: "a non-object element answers in place with a null id",
 		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"},5]`,
 		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}},` +
@@ -583,12 +610,13 @@ func TestWire_BigResponseIntegrity(t *testing.T) {
 
 // The concurrency bound is the design's own #1 hazard: without it, the number
 // of fat marshals in flight is the HTTP backlog limit (5000), not the core
-// count. jrpc2's Server held a semaphore of runtime.NumCPU() across handler and
-// result marshal; this reproduces it, and this test fails if it is removed.
+// count. jrpc2's Server held a semaphore across handler and result marshal;
+// this reproduces it (at GOMAXPROCS rather than NumCPU — see the sem field's
+// comment), and this test fails if it is removed.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
-	limit := runtime.NumCPU()
+	limit := runtime.GOMAXPROCS(0)
 	entered := make(chan struct{}, 4*limit)
 	release := make(chan struct{})
 
@@ -643,7 +671,7 @@ func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
 	wg.Wait()
 
 	assert.LessOrEqual(t, observed, int64(limit),
-		"more than runtime.NumCPU() handlers ran at once: the semaphore is gone or its weight is wrong")
+		"more handlers ran at once than the bound allows: the semaphore is gone or its weight is wrong")
 	assert.Equal(t, int64(limit), observed,
 		"the bound was never reached, so this test would not notice its removal")
 }
@@ -655,7 +683,7 @@ func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
-	started := make(chan struct{}, 1)
+	started := make(chan struct{}, runtime.GOMAXPROCS(0)+1)
 	h := NewHandler(map[string]jrpc2.Handler{
 		"echo": func(context.Context, *jrpc2.Request) (any, error) {
 			started <- struct{}{}
@@ -667,15 +695,15 @@ func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
 	// request still reaches its handler.
 	blocked := make(chan struct{})
 	var wg sync.WaitGroup
-	for range runtime.NumCPU() {
+	for range runtime.GOMAXPROCS(0) {
 		wg.Go(func() {
 			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/",
 				strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"echo"}`))
 			req.Header.Set("Content-Type", "application/json")
-			h.ServeHTTP(blockingWriter{blocked: blocked}, req)
+			h.ServeHTTP(&blockingWriter{blocked: blocked}, req)
 		})
 	}
-	for range runtime.NumCPU() {
+	for range runtime.GOMAXPROCS(0) {
 		select {
 		case <-started:
 		case <-time.After(10 * time.Second):
@@ -696,7 +724,7 @@ func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(10 * time.Second):
-		t.Error("a request could not be served while NumCPU writers were stalled: " +
+		t.Error("a request could not be served while the bound's worth of writers were stalled: " +
 			"the semaphore is being held across the write")
 	}
 	<-started
@@ -705,20 +733,21 @@ func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
 }
 
 // blockingWriter is a ResponseWriter whose Write never returns until blocked is
-// closed, standing in for a client that stopped reading.
+// closed, standing in for a client that stopped reading. Header must keep the
+// map it hands out, or the writer silently swallows every header set on it.
 type blockingWriter struct {
 	blocked chan struct{}
 	header  http.Header
 }
 
-func (b blockingWriter) Header() http.Header {
+func (b *blockingWriter) Header() http.Header {
 	if b.header == nil {
-		return http.Header{}
+		b.header = http.Header{}
 	}
 	return b.header
 }
-func (b blockingWriter) Write(p []byte) (int, error) { <-b.blocked; return len(p), nil }
-func (blockingWriter) WriteHeader(int)               {}
+func (b *blockingWriter) Write(p []byte) (int, error) { <-b.blocked; return len(p), nil }
+func (*blockingWriter) WriteHeader(int)               {}
 
 func TestAppendHTMLEscaped(t *testing.T) {
 	for _, tc := range []struct{ in, want string }{
@@ -781,7 +810,7 @@ func serveAsync(t *testing.T, h http.Handler, body string) (*httptest.ResponseRe
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_BatchElementsRunConcurrently(t *testing.T) {
-	n := min(runtime.NumCPU(), 8)
+	n := min(runtime.GOMAXPROCS(0), 8)
 	if n < 2 {
 		t.Skip("a one-permit bound cannot show concurrency")
 	}
@@ -829,7 +858,7 @@ func TestWire_BatchElementsRunConcurrently(t *testing.T) {
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_ABatchOfSlowCallsTakesAboutOneCallsTime(t *testing.T) {
-	n := min(runtime.NumCPU(), 4)
+	n := min(runtime.GOMAXPROCS(0), 4)
 	if n < 4 {
 		t.Skip("needs at least 4 permits for the serial and concurrent times to separate")
 	}
@@ -854,7 +883,7 @@ func TestWire_ABatchOfSlowCallsTakesAboutOneCallsTime(t *testing.T) {
 // A batch borrows from the process-wide bound; it does not multiply it. Two
 // separate things are pinned, because they fail separately:
 //
-//  1. no more than runtime.NumCPU() of a batch's handlers run at once, and
+//  1. no more than the semaphore's weight of a batch's handlers run at once, and
 //  2. no more than that many GOROUTINES exist for them, which is only true
 //     because the permit is taken on the serving goroutine BEFORE the worker
 //     is started. Acquire inside the worker instead and this batch parks one
@@ -862,7 +891,7 @@ func TestWire_ABatchOfSlowCallsTakesAboutOneCallsTime(t *testing.T) {
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
-	limit := runtime.NumCPU()
+	limit := runtime.GOMAXPROCS(0)
 	if limit < 2 {
 		t.Skip("a one-permit bound cannot separate the two failure modes")
 	}
@@ -913,7 +942,7 @@ func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-// Input order (DELTA (f)) and notification compaction are properties of the
+// Input order (DELTA (e)) and notification compaction are properties of the
 // response, not of the completion order. This batch finishes back to front.
 //
 //nolint:unparam // the handler literals must match the fixed jrpc2.Handler signature
@@ -997,7 +1026,7 @@ func TestWire_APanicInABatchElementFailsTheRequestAndReleasesItsPermit(t *testin
 	})
 
 	// Enough panics to exhaust the bound if any of them leaked its permit.
-	for range runtime.NumCPU() + 1 {
+	for range runtime.GOMAXPROCS(0) + 1 {
 		serve(`[{"jsonrpc":"2.0","id":1,"method":"boom"},{"jsonrpc":"2.0","id":2,"method":"boom"}]`)
 	}
 
@@ -1050,18 +1079,30 @@ func TestWire_ValidJSONThatIsNotARequest(t *testing.T) {
 	}
 }
 
-// Handlers used to run on a context jrpc2's Server built, carrying the inbound
-// request and the server itself. They now run on a context.Background-derived
-// one carrying neither, so jrpc2.InboundRequest returns nil and
-// jrpc2.ServerFromContext PANICS. Neither value is fabricated here (see the
-// package doc), which is only safe while nothing calls them — so this test
-// fails the moment production code does.
+// Three jrpc2 accessors stopped working when the jrpc2.Server left the serving
+// path, and none of them is fabricated back (see the package doc):
+// jrpc2.InboundRequest returns nil, jrpc2.ServerFromContext PANICS, and
+// (*jrpc2.Request).IsNotification reports false for every request — the last
+// one silently, which is why it is banned here alongside the other two. That is
+// only safe while nothing calls them, so this test fails the moment production
+// code does.
 func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
-	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
-	require.NoError(t, err)
+	// Anchored on this file's own compiled-in path, not the working directory,
+	// so the walk is the same whether `go test` runs it from the package dir
+	// or something runs the built binary from elsewhere.
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "cannot locate this test's own source file")
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", "..", ".."))
 	require.Equal(t, "cmd", filepath.Base(root), "this test walks cmd/; the package moved")
 
-	banned := map[string]bool{"InboundRequest": true, "ServerFromContext": true}
+	// The accessor name, and the receiver that makes a hit a real call: the
+	// two context accessors are package functions of jrpc2, and
+	// IsNotification is a method on a *jrpc2.Request under any name.
+	banned := map[string]string{
+		"InboundRequest":    "jrpc2",
+		"ServerFromContext": "jrpc2",
+		"IsNotification":    "",
+	}
 	fset := token.NewFileSet()
 	var callers []string
 
@@ -1077,24 +1118,32 @@ func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
 		// a comment is not a caller.
 		ast.Inspect(file, func(n ast.Node) bool {
 			sel, ok := n.(*ast.SelectorExpr)
-			if !ok || !banned[sel.Sel.Name] {
+			if !ok {
 				return true
 			}
-			if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "jrpc2" {
-				callers = append(callers, fmt.Sprintf("%s: jrpc2.%s", fset.Position(sel.Pos()), sel.Sel.Name))
+			recv, banned := banned[sel.Sel.Name]
+			if !banned {
+				return true
 			}
+			if recv != "" {
+				pkg, isIdent := sel.X.(*ast.Ident)
+				if !isIdent || pkg.Name != recv {
+					return true
+				}
+			}
+			callers = append(callers, fmt.Sprintf("%s: %s", fset.Position(sel.Pos()), sel.Sel.Name))
 			return true
 		})
 		return nil
 	}))
 
-	assert.Empty(t, callers, "wire runs handlers on a context with none of jrpc2's server values: "+
-		"InboundRequest returns nil and ServerFromContext panics. Take the request from the handler's "+
-		"second argument instead")
+	assert.Empty(t, callers, "no jrpc2.Server sits under these handlers any more, so InboundRequest "+
+		"returns nil, ServerFromContext panics, and IsNotification is false even for a notification. "+
+		"Take the request from the handler's second argument, and its notification-ness from an empty ID()")
 }
 
 // Params reach the handler as the exact bytes the body carried, by position or
-// by name. DELTA (g): the bridge re-marshaled every params value through
+// by name. DELTA (f): the bridge re-marshaled every params value through
 // json.Marshal of a json.RawMessage, which compacted it and HTML-escaped it.
 // Both forms decode to the same value and every handler here decodes, so the
 // delta is invisible in behavior — but rpcv2's getEventsV2 reads

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/creachadair/jrpc2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/network"
 )
 
 // Every `want` is a byte string captured from jrpc2 v1.3.3's jhttp.Bridge,
@@ -95,7 +97,7 @@ func post(t *testing.T, h http.Handler, body string) (int, http.Header, string) 
 func newTestHandler(t *testing.T) (*Handler, *atomic.Int64) {
 	t.Helper()
 	var notified atomic.Int64
-	return NewHandler(testMethods(&notified), nil), &notified
+	return NewHandler(testMethods(&notified), new(network.LiveHandlers)), &notified
 }
 
 func TestWire_SingleRequests(t *testing.T) {
@@ -546,7 +548,7 @@ func TestWire_BigResponseIntegrity(t *testing.T) {
 
 	h := NewHandler(map[string]jrpc2.Handler{
 		"fat": func(context.Context, *jrpc2.Request) (any, error) { return value, nil },
-	}, nil)
+	}, new(network.LiveHandlers))
 
 	status, header, got := post(t, h, `{"jsonrpc":"2.0","id":"big","method":"fat"}`)
 	require.Equal(t, http.StatusOK, status)
@@ -588,7 +590,7 @@ func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
 			inflight.Add(-1)
 			return held, nil
 		},
-	}, nil)
+	}, new(network.LiveHandlers))
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -644,7 +646,7 @@ func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
 			started <- struct{}{}
 			return "ok", nil
 		},
-	}, nil)
+	}, new(network.LiveHandlers))
 
 	// Saturate with writers that never drain, then serve a fresh request.
 	blocked := make(chan struct{})
@@ -764,7 +766,7 @@ func TestWire_BatchElementsRunConcurrently(t *testing.T) {
 			<-release
 			return held, nil
 		},
-	}, nil)
+	}, new(network.LiveHandlers))
 	rec, done := serveAsync(t, h, batchOf(n, "hold"))
 
 	for k := range n {
@@ -813,7 +815,7 @@ func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
 			inflight.Add(-1)
 			return held, nil
 		},
-	}, nil)
+	}, new(network.LiveHandlers))
 
 	runtime.GC() // settle the goroutine count before sampling it
 	before := runtime.NumGoroutine()
@@ -865,7 +867,7 @@ func TestWire_BatchOrderAndCompactionSurviveOutOfOrderCompletion(t *testing.T) {
 			return "noted", nil
 		},
 		"fast": func(context.Context, *jrpc2.Request) (any, error) { return "fast", nil },
-	}, nil)
+	}, new(network.LiveHandlers))
 
 	status, header, got := post(t, h, `[{"jsonrpc":"2.0","id":1,"method":"slowest"},`+
 		`{"jsonrpc":"2.0","method":"note"},`+
@@ -895,7 +897,7 @@ func TestWire_APanicInABatchElementFailsTheRequestAndReleasesItsPermit(t *testin
 		"echo": func(_ context.Context, r *jrpc2.Request) (any, error) {
 			return map[string]any{"method": r.Method()}, nil
 		},
-	}, nil)
+	}, new(network.LiveHandlers))
 
 	serve := func(body string) any {
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
@@ -1031,7 +1033,7 @@ func TestWire_ParamsReachTheHandlerVerbatim(t *testing.T) {
 			seen = r.ParamString()
 			return nil, nil
 		},
-	}, nil)
+	}, new(network.LiveHandlers))
 
 	for _, tc := range []struct{ name, body, want string }{{
 		name: "by position",
@@ -1083,7 +1085,7 @@ func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
 			completed.Add(1)
 			return held, nil
 		},
-	}, nil)
+	}, new(network.LiveHandlers))
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -1221,7 +1223,7 @@ func TestWire_Shutdown(t *testing.T) {
 				observed <- ctx.Err()
 				return held, nil
 			},
-		}, nil)
+		}, new(network.LiveHandlers))
 		rec, done := serveAsync(t, h, `{"jsonrpc":"2.0","id":1,"method":"watch"}`)
 		<-entered
 
@@ -1253,7 +1255,7 @@ func TestWire_Shutdown(t *testing.T) {
 				<-release // ignores cancellation, as a scan loop between checks does
 				return held, nil
 			},
-		}, nil)
+		}, new(network.LiveHandlers))
 		_, done := serveAsync(t, h, `{"jsonrpc":"2.0","id":1,"method":"stuck"}`)
 		<-entered
 
@@ -1278,7 +1280,7 @@ func TestWire_Shutdown(t *testing.T) {
 				ran.Add(1)
 				return held, nil
 			},
-		}, nil)
+		}, new(network.LiveHandlers))
 		require.NoError(t, h.Shutdown(t.Context()))
 
 		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
@@ -1312,7 +1314,7 @@ func TestWire_StaticErrorFramesAreBuiltInsideTheBound(t *testing.T) {
 			<-release
 			return held, nil
 		},
-	}, nil)
+	}, new(network.LiveHandlers))
 
 	var wg sync.WaitGroup
 	for range weight {
@@ -1349,4 +1351,14 @@ func TestWire_StaticErrorFramesAreBuiltInsideTheBound(t *testing.T) {
 	one := `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}`
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "["+one+","+one+","+one+"]", rec.Body.String())
+}
+
+// Both ends of the drain must be wired to the SAME group. A nil one used to
+// default silently to a private group, producing a Shutdown that reports
+// success while abandoned handlers run into a closing store — no error, no log
+// line, nothing observable until a shutdown races a teardown in production.
+func TestWire_NewHandlerRefusesAMissingLiveHandlersGroup(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"wire: NewHandler needs the mount's LiveHandlers; jsonrpc.NewHandler is the one place that builds it",
+		func() { NewHandler(map[string]jrpc2.Handler{}, nil) })
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -1347,3 +1347,92 @@ func TestWire_NewHandlerRefusesAMissingLiveHandlersGroup(t *testing.T) {
 		"wire: NewHandler needs the mount's LiveHandlers; jsonrpc.NewHandler is the one place that builds it",
 		func() { NewHandler(map[string]jrpc2.Handler{}, nil) })
 }
+
+// The single-request path frames static errors under the bound too: an
+// unknown-method flood carries client-controlled ids that escape to megabytes.
+//
+//nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
+func TestWire_ASingleStaticErrorFrameIsBuiltInsideTheBound(t *testing.T) {
+	weight := runtime.GOMAXPROCS(0)
+	entered := make(chan struct{}, weight)
+	release := make(chan struct{})
+
+	h := NewHandler(map[string]jrpc2.Handler{
+		"hold": func(context.Context, *jrpc2.Request) (any, error) {
+			entered <- struct{}{}
+			<-release
+			return held, nil
+		},
+	}, new(network.LiveHandlers))
+
+	var wg sync.WaitGroup
+	for range weight {
+		wg.Go(func() {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/",
+				strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"hold"}`))
+			req.Header.Set("Content-Type", "application/json")
+			h.ServeHTTP(httptest.NewRecorder(), req)
+		})
+	}
+	for range weight {
+		<-entered
+	}
+
+	// Every permit held; this call runs no handler at all.
+	rec, done := serveAsync(t, h, `{"jsonrpc":"2.0","id":1,"method":"nope"}`)
+	select {
+	case <-done:
+		close(release)
+		wg.Wait()
+		t.Fatal("a static-error frame was built while every permit was held")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the static-error frame never completed after a permit came back")
+	}
+	wg.Wait()
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	//nolint:testifylint // byte-exact wire pin; JSONEq would ignore key order and escaping
+	assert.Equal(t,
+		`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found","data":"nope"}}`,
+		rec.Body.String())
+}
+
+// A dead single request builds no frame at all. The id here escapes six to one,
+// so the frame it would have built is megabytes.
+func TestWire_ADeadSingleRequestBuildsNoStaticFrame(t *testing.T) {
+	h, _ := newTestHandler(t)
+	body := `{"jsonrpc":"2.0","id":"` + strings.Repeat("<", 256*1024) + `","method":"nope"}`
+
+	serve := func(ctx context.Context) (uint64, int) {
+		req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		h.ServeHTTP(rec, req)
+		runtime.ReadMemStats(&after)
+		return after.TotalAlloc - before.TotalAlloc, rec.Body.Len()
+	}
+
+	liveAlloc, liveLen := serve(t.Context())
+	dead, cancel := context.WithCancel(t.Context())
+	cancel()
+	deadAlloc, deadLen := serve(dead)
+
+	t.Logf("live %.1fMB -> %d body bytes; dead %.1fMB -> %d body bytes",
+		float64(liveAlloc)/(1<<20), liveLen, float64(deadAlloc)/(1<<20), deadLen)
+
+	require.Positive(t, liveLen, "the control run must answer, or this proves nothing")
+	assert.Zero(t, deadLen)
+	assert.Less(t, deadAlloc, liveAlloc/2,
+		"a dead request allocated %.1fMB against a %.1fMB control: it is still framing",
+		float64(deadAlloc)/(1<<20), float64(liveAlloc)/(1<<20))
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -26,15 +26,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Every `want` here is a byte string captured from jrpc2 v1.3.3's jhttp.Bridge
-// except where annotated with a delta. The error vocabulary is unexported and
-// transcribed into wire.go: only an exact-byte pin notices a bump moving one.
+// Every `want` is a byte string captured from jrpc2 v1.3.3's jhttp.Bridge,
+// except where annotated with a delta. Only an exact-byte pin notices a bump
+// moving one of wire.go's transcribed error strings.
 
 // held is what the parked handlers return once released.
 const held = "done"
 
-// recordPeak raises peak to now, for handlers counting how many of them ran at
-// the same time.
+// recordPeak raises peak to now.
 func recordPeak(peak *atomic.Int64, now int64) {
 	for {
 		old := peak.Load()
@@ -44,8 +43,7 @@ func recordPeak(peak *atomic.Int64, now int64) {
 	}
 }
 
-// testMethods is the table under test; notified makes a notification's
-// completion observable.
+// testMethods is the table under test; notified observes a notification.
 //
 //nolint:unparam // every literal here must match the fixed jrpc2.Handler signature
 func testMethods(notified *atomic.Int64) map[string]jrpc2.Handler {
@@ -68,8 +66,7 @@ func testMethods(notified *atomic.Int64) map[string]jrpc2.Handler {
 			return nil, fmt.Errorf("while doing the thing: %w", &jrpc2.Error{Code: -32123, Message: "custom failure"})
 		},
 		"valueJRPCError": func(context.Context, *jrpc2.Request) (any, error) {
-			// The repo's limiter sentinels are jrpc2.Error VALUES; see
-			// handlerError.
+			// The limiter sentinels are jrpc2.Error VALUES; see handlerError.
 			return nil, jrpc2.Error{Code: -32001, Message: "request exceeded processing limit threshold"}
 		},
 		"contextCanceled": func(context.Context, *jrpc2.Request) (any, error) {
@@ -232,8 +229,7 @@ func TestWire_ErrorMapping(t *testing.T) {
 		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32123,` +
 			`"message":"while doing the thing: [-32123] custom failure"}}`,
 	}, {
-		// The repo's limiter sentinels take this path; the doubled
-		// "[-32001] " is reproduced, not fixed.
+		// The doubled "[-32001] " is reproduced, not fixed.
 		name: "a jrpc2.Error VALUE keeps its code and doubles its code into the message",
 		body: `{"jsonrpc":"2.0","id":1,"method":"valueJRPCError"}`,
 		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32001,` +
@@ -247,8 +243,7 @@ func TestWire_ErrorMapping(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id":1,"method":"contextCanceled"}`,
 		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32097,"message":"gave up: context canceled"}}`,
 	}, {
-		// -32098, not -32603: jrpc2 maps a marshal failure down the same
-		// ladder a handler error takes. Captured from the live bridge.
+		// -32098, not -32603: a marshal failure takes the handler ladder.
 		name: "a result that cannot be marshaled is a system error, not a truncated body",
 		body: `{"jsonrpc":"2.0","id":1,"method":"unmarshalable"}`,
 		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32098,` +
@@ -322,15 +317,13 @@ func TestWire_RequestLevelProtocolErrors(t *testing.T) {
 		status: http.StatusOK,
 		want:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"empty method name"}}`,
 	}, {
-		// DELTA (d). An empty method name is a request-level error and is
-		// reportable even for a notification.
+		// DELTA (d). Reportable even for a notification.
 		name:   "an empty method name on a NOTIFICATION is a -32600 frame with a null id",
 		body:   `{"jsonrpc":"2.0","method":""}`,
 		status: http.StatusOK,
 		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"empty method name"}}`,
 	}, {
-		// A response-shaped message has no method, so it degrades to the
-		// empty-method error rather than being "understood".
+		// No method, so it degrades rather than being "understood".
 		name:   "a response-shaped message with a version marker degrades to empty method",
 		body:   `{"jsonrpc":"2.0","id":1,"result":5}`,
 		status: http.StatusOK,
@@ -445,8 +438,7 @@ func TestWire_Batches(t *testing.T) {
 		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}},` +
 			`{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}]`,
 	}, {
-		// jrpc2's duplicate-id check was unreachable under the bridge, and
-		// owning the framing must not make it reachable.
+		// Owning the framing must not make jrpc2's duplicate-id check reachable.
 		name: "duplicate ids inside one batch are allowed",
 		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"},{"jsonrpc":"2.0","id":1,"method":"nilResult"}]`,
 		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}},` +
@@ -579,8 +571,7 @@ func TestWire_BigResponseIntegrity(t *testing.T) {
 	assert.Equal(t, oracle, []byte(envelope.Result))
 }
 
-// Without the bound, the fat marshals in flight are the HTTP backlog limit
-// (5000), not the core count.
+// Without the bound, fat marshals in flight are the backlog limit, not cores.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
@@ -643,8 +634,7 @@ func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
 		"the bound was never reached, so this test would not notice its removal")
 }
 
-// The permit must be gone before any byte reaches the ResponseWriter, or a
-// slow reader holds a slot in a bound sized for CPUs.
+// The permit must be gone before any byte reaches the ResponseWriter.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
@@ -656,8 +646,7 @@ func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
 		},
 	})
 
-	// Saturate with writers that never drain, then prove a fresh request
-	// reaches its handler.
+	// Saturate with writers that never drain, then serve a fresh request.
 	blocked := make(chan struct{})
 	var wg sync.WaitGroup
 	for range runtime.GOMAXPROCS(0) {
@@ -744,8 +733,7 @@ func jsonArray(n int, element func(id int) string) string {
 	return "[" + strings.Join(elems, ",") + "]"
 }
 
-// serveAsync runs one body on its own goroutine, so a test can look at a batch
-// in flight; post()'s require calls would be on the wrong one.
+// serveAsync runs one body on its own goroutine, to watch a batch in flight.
 func serveAsync(t *testing.T, h http.Handler, body string) (*httptest.ResponseRecorder, <-chan struct{}) {
 	t.Helper()
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
@@ -759,8 +747,7 @@ func serveAsync(t *testing.T, h http.Handler, body string) (*httptest.ResponseRe
 	return rec, done
 }
 
-// The proof is a barrier: every element must be inside its handler before any
-// of them returns. Serial dispatch delivers one.
+// A barrier, not a stopwatch: serial dispatch gets one element in flight.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_BatchElementsRunConcurrently(t *testing.T) {
@@ -857,8 +844,8 @@ func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-// Input order (DELTA (e)) and compaction are properties of the response, not
-// the completion order. This batch finishes back to front.
+// DELTA (e) and compaction hold however the batch completes; this one
+// finishes back to front.
 //
 //nolint:unparam // the handler literals must match the fixed jrpc2.Handler signature
 func TestWire_BatchOrderAndCompactionSurviveOutOfOrderCompletion(t *testing.T) {
@@ -899,8 +886,7 @@ func TestWire_BatchOrderAndCompactionSurviveOutOfOrderCompletion(t *testing.T) {
 	assert.Equal(t, int64(1), notified.Load(), "the notification must have run before the response was written")
 }
 
-// A batch worker's panic must be RE-RAISED on the serving goroutine rather
-// than escaping its own, and its permit must be gone either way.
+// A worker's panic must be RE-RAISED, not escape, and free its permit.
 //
 //nolint:unparam // the handler literals must match the fixed jrpc2.Handler signature
 func TestWire_APanicInABatchElementFailsTheRequestAndReleasesItsPermit(t *testing.T) {
@@ -951,8 +937,7 @@ func TestWire_APanicInABatchElementFailsTheRequestAndReleasesItsPermit(t *testin
 	}
 }
 
-// Valid JSON that is not a request object answers one bare frame, never an
-// array.
+// Valid JSON that is not a request object answers one bare frame.
 func TestWire_ValidJSONThatIsNotARequest(t *testing.T) {
 	h, _ := newTestHandler(t)
 
@@ -984,8 +969,7 @@ func TestWire_ValidJSONThatIsNotARequest(t *testing.T) {
 	}
 }
 
-// Three jrpc2 accessors stopped working with the jrpc2.Server (see the package
-// doc), which is only safe while nothing calls them.
+// Three jrpc2 accessors stopped working with the jrpc2.Server; see the doc.
 func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
 	// Anchored on this file's compiled-in path, not the working directory.
 	_, thisFile, _, ok := runtime.Caller(0)
@@ -1037,8 +1021,7 @@ func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
 		"Take the request from the handler's second argument, and its notification-ness from an empty ID()")
 }
 
-// DELTA (f): params reach the handler as the exact bytes the body carried.
-// rpcv2's getEventsV2 reads ParamString, so those bytes are contract.
+// DELTA (f). rpcv2's getEventsV2 reads ParamString, so the bytes are contract.
 //
 //nolint:nilnil,unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_ParamsReachTheHandlerVerbatim(t *testing.T) {
@@ -1067,8 +1050,7 @@ func TestWire_ParamsReachTheHandlerVerbatim(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id":1,"method":"params"}`,
 		want: ``,
 	}, {
-		// jrpc2 reduces "null" params to nil, so a handler cannot tell an
-		// explicit null from an absent one.
+		// jrpc2 reduces "null" params to nil, indistinguishable from absent.
 		name: "an explicit null is reduced to absent",
 		body: `{"jsonrpc":"2.0","id":1,"method":"params","params":null}`,
 		want: ``,
@@ -1082,8 +1064,7 @@ func TestWire_ParamsReachTheHandlerVerbatim(t *testing.T) {
 	}
 }
 
-// DELTA (g): once the request is dead the serving goroutine stops feeding the
-// bound. What HAD started still finishes.
+// DELTA (g): a dead request stops feeding the bound; what started finishes.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
@@ -1154,7 +1135,7 @@ func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
 }
 
 // adversarialBatch fills the body cap with the cheapest element that still
-// demands an answer: the worst response amplification the cap allows.
+// demands an answer.
 func adversarialBatch(t *testing.T) (string, int) {
 	t.Helper()
 	const bodyCap = 512 * 1024
@@ -1168,9 +1149,9 @@ func adversarialBatch(t *testing.T) (string, int) {
 	return body, n
 }
 
-// DELTA (g) for the elements that never reach acquirePermit. The signal is
-// allocation ABOVE the parse — the frames are discarded either way, so all
-// that changes is whether they were built.
+// DELTA (g) for the elements that never reach acquirePermit. Measured ABOVE
+// the parse: the frames are discarded either way, so all that changes is
+// whether they were built.
 func TestWire_ADeadRequestStopsBuildingStaticErrorFrames(t *testing.T) {
 	h, _ := newTestHandler(t)
 	body, elements := adversarialBatch(t)
@@ -1288,8 +1269,8 @@ func TestWire_Shutdown(t *testing.T) {
 		<-done
 	})
 
-	// The two sources compose: Shutdown holds the bound, so a later request
-	// unwinds at its own deadline instead (DELTA (g)).
+	// Shutdown holds the bound, so a later request unwinds at its own
+	// deadline (DELTA (g)) rather than hanging.
 	t.Run("nothing new starts after a completed drain", func(t *testing.T) {
 		var ran atomic.Int64
 		h := NewHandler(map[string]jrpc2.Handler{

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -1293,3 +1293,60 @@ func TestWire_Shutdown(t *testing.T) {
 		assert.Empty(t, rec.Body.String())
 	})
 }
+
+// Static-error frames are the one answer that needs no handler, and a hostile
+// body carries ~260,000 of them at ~23MB. Building them outside the bound let
+// concurrent hostile bodies materialize that much each, so the deferred build
+// takes a permit — proved here by holding every permit and showing a
+// static-only batch cannot finish until one comes back.
+//
+//nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
+func TestWire_StaticErrorFramesAreBuiltInsideTheBound(t *testing.T) {
+	weight := runtime.GOMAXPROCS(0)
+	entered := make(chan struct{}, weight)
+	release := make(chan struct{})
+
+	h := NewHandler(map[string]jrpc2.Handler{
+		"hold": func(context.Context, *jrpc2.Request) (any, error) {
+			entered <- struct{}{}
+			<-release
+			return held, nil
+		},
+	}, nil)
+
+	var wg sync.WaitGroup
+	for range weight {
+		wg.Go(func() {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/",
+				strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"hold"}`))
+			req.Header.Set("Content-Type", "application/json")
+			h.ServeHTTP(httptest.NewRecorder(), req)
+		})
+	}
+	for range weight {
+		<-entered
+	}
+
+	// Every permit is held. This batch runs no handler at all, so before the
+	// deferred build it answered immediately.
+	rec, done := serveAsync(t, h, `[5,5,5]`)
+	select {
+	case <-done:
+		close(release)
+		wg.Wait()
+		t.Fatal("a static-error batch was framed while every permit was held")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the static-error batch never completed after a permit came back")
+	}
+	wg.Wait()
+
+	one := `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}`
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "["+one+","+one+","+one+"]", rec.Body.String())
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -5,9 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1022,4 +1027,47 @@ func TestWire_ValidJSONThatIsNotARequest(t *testing.T) {
 			assert.Equal(t, strconv.Itoa(len(tc.want)), header.Get("Content-Length"))
 		})
 	}
+}
+
+// Handlers used to run on a context jrpc2's Server built, carrying the inbound
+// request and the server itself. They now run on a context.Background-derived
+// one carrying neither, so jrpc2.InboundRequest returns nil and
+// jrpc2.ServerFromContext PANICS. Neither value is fabricated here (see the
+// package doc), which is only safe while nothing calls them — so this test
+// fails the moment production code does.
+func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	require.NoError(t, err)
+	require.Equal(t, "cmd", filepath.Base(root), "this test walks cmd/; the package moved")
+
+	banned := map[string]bool{"InboundRequest": true, "ServerFromContext": true}
+	fset := token.NewFileSet()
+	var callers []string
+
+	require.NoError(t, filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		file, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return perr
+		}
+		// Selector expressions only: the package doc names both accessors, and
+		// a comment is not a caller.
+		ast.Inspect(file, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok || !banned[sel.Sel.Name] {
+				return true
+			}
+			if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "jrpc2" {
+				callers = append(callers, fmt.Sprintf("%s: jrpc2.%s", fset.Position(sel.Pos()), sel.Sel.Name))
+			}
+			return true
+		})
+		return nil
+	}))
+
+	assert.Empty(t, callers, "wire runs handlers on a context with none of jrpc2's server values: "+
+		"InboundRequest returns nil and ServerFromContext panics. Take the request from the handler's "+
+		"second argument instead")
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -30,6 +30,10 @@ import (
 // fields in request", ...) is unexported in jrpc2 and transcribed here: only an
 // exact-byte pin will notice if a library bump or a refactor moves one.
 
+// held is what the handlers that park under the concurrency bound return once
+// they are released.
+const held = "done"
+
 // testMethods is the table under test. notified counts calls to "note" so a
 // notification's completion is observable.
 //
@@ -563,7 +567,7 @@ func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
 			entered <- struct{}{}
 			<-release
 			inflight.Add(-1)
-			return "done", nil
+			return held, nil
 		},
 	})
 	srv := httptest.NewServer(h)
@@ -701,4 +705,321 @@ func TestAppendHTMLEscaped(t *testing.T) {
 		assert.Equal(t, len(tc.want), idLen(tc.in), "idLen must predict the escaped length of %q", tc.in)
 	}
 	assert.Equal(t, len("null"), idLen(""))
+}
+
+// batchOf builds a batch body of n calls to method, with ids 1..n.
+func batchOf(n int, method string) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"jsonrpc":"2.0","id":%d,"method":%q}`, i, method)
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+// serveAsync runs one body through h on its own goroutine and returns the
+// recorder plus a channel closed when ServeHTTP has returned. It exists so a
+// test can look at a batch while it is still in flight; post() cannot, and its
+// require calls would be on the wrong goroutine anyway.
+func serveAsync(t *testing.T, h http.Handler, body string) (*httptest.ResponseRecorder, <-chan struct{}) {
+	t.Helper()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.ServeHTTP(rec, req)
+	}()
+	return rec, done
+}
+
+// Batch elements run concurrently, as jrpc2's dispatchLocked ran them. Serial
+// dispatch sums a batch's latencies under the one HTTP deadline the mount
+// enforces, so a batch of individually-fine calls 504s where each of them alone
+// succeeds — the regression this test exists to catch.
+//
+// The proof is a barrier, not a stopwatch: every element must be inside its
+// handler before any of them is allowed to return. Serial dispatch delivers
+// exactly one.
+//
+//nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
+func TestWire_BatchElementsRunConcurrently(t *testing.T) {
+	n := min(runtime.NumCPU(), 8)
+	if n < 2 {
+		t.Skip("a one-permit bound cannot show concurrency")
+	}
+	entered := make(chan struct{}, n)
+	release := make(chan struct{})
+
+	h := NewHandler(map[string]jrpc2.Handler{
+		"hold": func(context.Context, *jrpc2.Request) (any, error) {
+			entered <- struct{}{}
+			<-release
+			return held, nil
+		},
+	})
+	rec, done := serveAsync(t, h, batchOf(n, "hold"))
+
+	for k := range n {
+		select {
+		case <-entered:
+		case <-time.After(10 * time.Second):
+			close(release)
+			<-done
+			t.Fatalf("only %d of %d batch elements were in flight at once: batch dispatch is serial", k, n)
+		}
+	}
+	close(release)
+	<-done
+
+	var want strings.Builder
+	want.WriteByte('[')
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			want.WriteByte(',')
+		}
+		fmt.Fprintf(&want, `{"jsonrpc":"2.0","id":%d,"result":%q}`, i, held)
+	}
+	want.WriteByte(']')
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, want.String(), rec.Body.String())
+	assert.Equal(t, strconv.Itoa(want.Len()), rec.Header().Get("Content-Length"))
+}
+
+// The stopwatch form of the test above, because "the batch took N times one
+// call" is the user-visible symptom and is worth asserting in its own units.
+//
+//nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
+func TestWire_ABatchOfSlowCallsTakesAboutOneCallsTime(t *testing.T) {
+	n := min(runtime.NumCPU(), 4)
+	if n < 4 {
+		t.Skip("needs at least 4 permits for the serial and concurrent times to separate")
+	}
+	const delay = 200 * time.Millisecond
+
+	h := NewHandler(map[string]jrpc2.Handler{
+		"slow": func(context.Context, *jrpc2.Request) (any, error) {
+			time.Sleep(delay)
+			return held, nil
+		},
+	})
+
+	start := time.Now()
+	status, _, _ := post(t, h, batchOf(n, "slow"))
+	elapsed := time.Since(start)
+
+	assert.Equal(t, http.StatusOK, status)
+	assert.Less(t, elapsed, time.Duration(n)*delay/2,
+		"a batch of %d %v calls took %v; serial dispatch would need %v", n, delay, elapsed, time.Duration(n)*delay)
+}
+
+// A batch borrows from the process-wide bound; it does not multiply it. Two
+// separate things are pinned, because they fail separately:
+//
+//  1. no more than runtime.NumCPU() of a batch's handlers run at once, and
+//  2. no more than that many GOROUTINES exist for them, which is only true
+//     because the permit is taken on the serving goroutine BEFORE the worker
+//     is started. Acquire inside the worker instead and this batch parks one
+//     goroutine per element — which the 512KB body cap bounds at ~260,000.
+//
+//nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
+func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
+	limit := runtime.NumCPU()
+	if limit < 2 {
+		t.Skip("a one-permit bound cannot separate the two failure modes")
+	}
+	const oversubscribe = 16
+	elements := oversubscribe * limit
+
+	entered := make(chan struct{}, elements)
+	release := make(chan struct{})
+	var inflight, peak atomic.Int64
+
+	h := NewHandler(map[string]jrpc2.Handler{
+		"hold": func(context.Context, *jrpc2.Request) (any, error) {
+			now := inflight.Add(1)
+			for {
+				old := peak.Load()
+				if now <= old || peak.CompareAndSwap(old, now) {
+					break
+				}
+			}
+			entered <- struct{}{}
+			<-release
+			inflight.Add(-1)
+			return held, nil
+		},
+	})
+
+	runtime.GC() // settle the goroutine count before sampling it
+	before := runtime.NumGoroutine()
+	rec, done := serveAsync(t, h, batchOf(elements, "hold"))
+
+	for k := range limit {
+		select {
+		case <-entered:
+		case <-time.After(10 * time.Second):
+			close(release)
+			<-done
+			t.Fatalf("only %d of %d permits were taken", k, limit)
+		}
+	}
+	// Saturated: give an unbounded implementation ample room to overshoot.
+	time.Sleep(250 * time.Millisecond)
+	observedPeak := peak.Load()
+	observedGoroutines := runtime.NumGoroutine()
+	close(release)
+	<-done
+
+	assert.Equal(t, int64(limit), observedPeak,
+		"a batch of %d elements ran %d handlers at once against a bound of %d", elements, observedPeak, limit)
+	// The serving goroutine, this test's goroutine and the runtime's own make
+	// up the slack; what must not appear is one goroutine per element.
+	assert.Less(t, observedGoroutines, before+limit+16,
+		"a batch of %d elements parked %d goroutines: the permit is being acquired inside the worker",
+		elements, observedGoroutines-before)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// Input order (DELTA (f)) and notification compaction are properties of the
+// response, not of the completion order. This batch finishes back to front.
+//
+//nolint:unparam // the handler literals must match the fixed jrpc2.Handler signature
+func TestWire_BatchOrderAndCompactionSurviveOutOfOrderCompletion(t *testing.T) {
+	var notified atomic.Int64
+	h := NewHandler(map[string]jrpc2.Handler{
+		"slowest": func(context.Context, *jrpc2.Request) (any, error) {
+			time.Sleep(120 * time.Millisecond)
+			return "slowest", nil
+		},
+		"slower": func(context.Context, *jrpc2.Request) (any, error) {
+			time.Sleep(60 * time.Millisecond)
+			return "slower", nil
+		},
+		"note": func(context.Context, *jrpc2.Request) (any, error) {
+			time.Sleep(30 * time.Millisecond)
+			notified.Add(1)
+			return "noted", nil
+		},
+		"fast": func(context.Context, *jrpc2.Request) (any, error) { return "fast", nil },
+	})
+
+	status, header, got := post(t, h, `[{"jsonrpc":"2.0","id":1,"method":"slowest"},`+
+		`{"jsonrpc":"2.0","method":"note"},`+
+		`{"jsonrpc":"2.0","id":2,"method":"slower"},`+
+		`{"jsonrpc":"1.0","id":3,"method":"fast"},`+
+		`{"jsonrpc":"2.0","id":4,"method":"fast"},`+
+		`{"jsonrpc":"2.0","id":4,"method":"nope"}]`)
+
+	want := `[{"jsonrpc":"2.0","id":1,"result":"slowest"},` +
+		`{"jsonrpc":"2.0","id":2,"result":"slower"},` +
+		`{"jsonrpc":"2.0","id":3,"error":{"code":-32600,"message":"invalid version marker"}},` +
+		`{"jsonrpc":"2.0","id":4,"result":"fast"},` +
+		`{"jsonrpc":"2.0","id":4,"error":{"code":-32601,"message":"method not found","data":"nope"}}]`
+
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, want, got)
+	assert.Equal(t, strconv.Itoa(len(want)), header.Get("Content-Length"))
+	assert.Equal(t, int64(1), notified.Load(), "the notification must have run before the response was written")
+}
+
+// jrpc2 never recovered a handler panic: under the bridge it unwound on a
+// goroutine the server owned, and took the process with it. Here a panic
+// unwinds out of ServeHTTP into httpRequestDurationLimiter's recover, which
+// answers 500 — so a batch worker's panic must be RE-RAISED on the serving
+// goroutine rather than escaping its own, and the permit it held must be gone
+// either way.
+//
+//nolint:unparam // the handler literals must match the fixed jrpc2.Handler signature
+func TestWire_APanicInABatchElementFailsTheRequestAndReleasesItsPermit(t *testing.T) {
+	h := NewHandler(map[string]jrpc2.Handler{
+		"boom": func(context.Context, *jrpc2.Request) (any, error) { panic("handler exploded") },
+		"echo": func(_ context.Context, r *jrpc2.Request) (any, error) {
+			return map[string]any{"method": r.Method()}, nil
+		},
+	})
+
+	serve := func(body string) any {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		var recovered any
+		func() {
+			defer func() { recovered = recover() }()
+			h.ServeHTTP(httptest.NewRecorder(), req)
+		}()
+		return recovered
+	}
+
+	t.Run("a single request's panic propagates unchanged", func(t *testing.T) {
+		assert.Equal(t, "handler exploded", serve(`{"jsonrpc":"2.0","id":1,"method":"boom"}`))
+	})
+
+	t.Run("a batch element's panic is re-raised with its own stack", func(t *testing.T) {
+		got := serve(`[{"jsonrpc":"2.0","id":1,"method":"echo"},{"jsonrpc":"2.0","id":2,"method":"boom"}]`)
+		require.NotNil(t, got, "the batch must fail the request, not swallow the panic")
+		rendered := fmt.Sprintf("%v", got)
+		assert.Contains(t, rendered, "handler exploded")
+		assert.Contains(t, rendered, "panicked on a batch worker goroutine")
+		assert.Contains(t, rendered, "wire.TestWire_APanicInABatchElementFailsTheRequestAndReleasesItsPermit",
+			"the relayed value must carry the stack the handler panicked on, not the relay's")
+	})
+
+	// Enough panics to exhaust the bound if any of them leaked its permit.
+	for range runtime.NumCPU() + 1 {
+		serve(`[{"jsonrpc":"2.0","id":1,"method":"boom"},{"jsonrpc":"2.0","id":2,"method":"boom"}]`)
+	}
+
+	served := make(chan string, 1)
+	go func() {
+		_, _, body := post(t, h, `{"jsonrpc":"2.0","id":9,"method":"echo"}`)
+		served <- body
+	}()
+	select {
+	case body := <-served:
+		//nolint:testifylint // byte-exact wire pin; JSONEq would ignore key order and escaping
+		assert.Equal(t, `{"jsonrpc":"2.0","id":9,"result":{"method":"echo"}}`, body)
+	case <-time.After(10 * time.Second):
+		t.Error("the handler stopped serving after panicking batches: every panic leaked its permit")
+	}
+}
+
+// A body that is valid JSON but is not a request object or an array of them.
+// jrpc2 parses it as a single element whose validation failed, so it answers
+// with one bare frame — never an array — which is what the bridge did too.
+func TestWire_ValidJSONThatIsNotARequest(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	for _, tc := range []struct{ name, body, want string }{{
+		name: "a bare number",
+		body: `5`,
+		want: `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}`,
+	}, {
+		name: "a bare string",
+		body: `"hello"`,
+		want: `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}`,
+	}, {
+		name: "a bare boolean",
+		body: `true`,
+		want: `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}`,
+	}, {
+		// null decodes into a nil map rather than failing, so it gets as far as
+		// the version check. Pinned because it is the one scalar that does not
+		// answer -32700.
+		name: "a bare null",
+		body: `null`,
+		want: `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid version marker"}}`,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, header, got := post(t, h, tc.body)
+			assert.Equal(t, http.StatusOK, status)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, strconv.Itoa(len(tc.want)), header.Get("Content-Length"))
+		})
+	}
 }

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -39,6 +39,17 @@ import (
 // they are released.
 const held = "done"
 
+// recordPeak raises peak to now, for handlers counting how many of them ran at
+// the same time.
+func recordPeak(peak *atomic.Int64, now int64) {
+	for {
+		old := peak.Load()
+		if now <= old || peak.CompareAndSwap(old, now) {
+			return
+		}
+	}
+}
+
 // testMethods is the table under test. notified counts calls to "note" so a
 // notification's completion is observable.
 //
@@ -584,13 +595,7 @@ func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
 	var inflight, peak atomic.Int64
 	h := NewHandler(map[string]jrpc2.Handler{
 		"hold": func(context.Context, *jrpc2.Request) (any, error) {
-			now := inflight.Add(1)
-			for {
-				old := peak.Load()
-				if now <= old || peak.CompareAndSwap(old, now) {
-					break
-				}
-			}
+			recordPeak(&peak, inflight.Add(1))
 			entered <- struct{}{}
 			<-release
 			inflight.Add(-1)
@@ -870,13 +875,7 @@ func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
 
 	h := NewHandler(map[string]jrpc2.Handler{
 		"hold": func(context.Context, *jrpc2.Request) (any, error) {
-			now := inflight.Add(1)
-			for {
-				old := peak.Load()
-				if now <= old || peak.CompareAndSwap(old, now) {
-					break
-				}
-			}
+			recordPeak(&peak, inflight.Add(1))
 			entered <- struct{}{}
 			<-release
 			inflight.Add(-1)

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -1238,3 +1238,87 @@ func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
 	assert.Empty(t, rec.Body.String(),
 		"a dead request is answered by the layer that killed it; the framing writes nothing")
 }
+
+// adversarialBatch fills the 512KB body cap with the cheapest element that
+// still demands an answer: a bare scalar, which is a -32700 "request is not a
+// JSON object" frame. It is the worst response amplification the cap allows —
+// ~260,000 elements in, ~22MB of frames out.
+func adversarialBatch(t *testing.T) (string, int) {
+	t.Helper()
+	const bodyCap = 512 * 1024
+	n := (bodyCap - 2) / 2 // "5," per element, inside the brackets
+	elems := make([]string, n)
+	for i := range elems {
+		elems[i] = "5"
+	}
+	body := "[" + strings.Join(elems, ",") + "]"
+	require.LessOrEqual(t, len(body), bodyCap)
+	return body, n
+}
+
+// DELTA (g), the half the permit does not cover. Elements that answer without
+// a handler never reach acquirePermit, so a batch of nothing BUT those — the
+// adversarial `[5,5,5,...]` — used to keep building frames after the request
+// was already dead, 22MB of them for a reader that had gone.
+//
+// The signal is allocation, and specifically allocation ABOVE the parse: the
+// frames are discarded either way, so the only thing that changes is whether
+// they were built at all, and ParseRequests' own ~175MB for a quarter-million
+// elements would otherwise drown that out. Measuring the parse separately
+// leaves the framing cost by subtraction, and calibrates to the machine.
+func TestWire_ADeadRequestStopsBuildingStaticErrorFrames(t *testing.T) {
+	h, _ := newTestHandler(t)
+	body, elements := adversarialBatch(t)
+
+	measure := func(f func()) uint64 {
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		f()
+		runtime.ReadMemStats(&after)
+		return after.TotalAlloc - before.TotalAlloc
+	}
+	serve := func(ctx context.Context) (uint64, time.Duration, int) {
+		req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		var elapsed time.Duration
+		alloc := measure(func() {
+			start := time.Now()
+			h.ServeHTTP(rec, req)
+			elapsed = time.Since(start)
+		})
+		return alloc, elapsed, rec.Body.Len()
+	}
+
+	// The floor both runs pay whatever happens.
+	parseAlloc := measure(func() {
+		parsed, err := jrpc2.ParseRequests([]byte(body))
+		require.NoError(t, err)
+		require.Len(t, parsed, elements)
+	})
+
+	liveAlloc, liveTime, liveLen := serve(t.Context())
+	dead, cancel := context.WithCancel(t.Context())
+	cancel()
+	deadAlloc, deadTime, deadLen := serve(dead)
+
+	mb := func(n float64) float64 { return n / (1 << 20) }
+	liveFraming := float64(liveAlloc) - float64(parseAlloc)
+	deadFraming := float64(deadAlloc) - float64(parseAlloc)
+	t.Logf("%d elements, parse floor %.1fMB: live %.1fMB (%.1fMB framing) in %v -> %d body bytes; "+
+		"dead %.1fMB (%.1fMB framing) in %v -> %d body bytes",
+		elements, mb(float64(parseAlloc)),
+		mb(float64(liveAlloc)), mb(liveFraming), liveTime, liveLen,
+		mb(float64(deadAlloc)), mb(deadFraming), deadTime, deadLen)
+
+	require.Positive(t, liveLen, "the control run must actually answer, or this proves nothing")
+	require.Positive(t, liveFraming, "the control run framed nothing; the measurement is broken")
+	assert.Zero(t, deadLen, "a dead request must not be answered by the framing")
+	// The dead run's residual is the one allocation it makes before it can
+	// know: dispatchAll's slot slice, 24 bytes x the element count. The bound
+	// sits well above that and well below a run that framed anything.
+	assert.Less(t, deadFraming, liveFraming/5,
+		"a dead request spent %.1fMB framing against a %.1fMB control: it is still answering its elements",
+		mb(deadFraming), mb(liveFraming))
+}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -211,29 +211,33 @@ func TestWire_IDIsHTMLEscapedExactlyAsTheBridgeEscapedIt(t *testing.T) {
 			status, header, got := post(t, h, tc.body)
 			assert.Equal(t, http.StatusOK, status)
 			assert.Equal(t, tc.want, got)
-			// The capacity hint must account for the escape, or the frame is
-			// built with a reallocation.
 			assert.Equal(t, strconv.Itoa(len(tc.want)), header.Get("Content-Length"))
 		})
 	}
 }
 
-// idLen's capacity arithmetic is only load-bearing at scale: a hint one byte
-// short makes the frame reallocate and re-copy its whole payload, which is the
-// cost this package exists to delete. This is the worst case the 512KB body cap
-// allows — an id in which every single byte escapes to six.
-func TestWire_ALargeEscapingIDIsFramedAtItsExactLength(t *testing.T) {
-	h, _ := newTestHandler(t)
-	const n = 128 * 1024
-	body := `{"jsonrpc":"2.0","id":"` + strings.Repeat("<", n) + `","method":"echo"}`
-	want := `{"jsonrpc":"2.0","id":"` + strings.Repeat(`\u003c`, n) + `","result":{"method":"echo"}}`
-
-	status, header, got := post(t, h, body)
-	require.Equal(t, http.StatusOK, status)
-	//nolint:testifylint // compare lengths first: an Equal on the values would dump a megabyte
-	require.Equal(t, len(want), len(got), "the frame is not the envelope plus the escaped id")
-	assert.Equal(t, want, got)
-	assert.Equal(t, strconv.Itoa(len(want)), header.Get("Content-Length"))
+// The frame builder's capacity is meant to be the frame's EXACT length, so a
+// frame is one allocation and one copy. No assertion on the response can see
+// that: append grows silently and the bytes come out identical either way. It
+// is observable on the slice, though — make([]byte, 0, n) yields cap == n, so
+// cap > len means the hint was short and the payload was re-copied.
+//
+// idLen is the half of the arithmetic that can be wrong, so the ids here are
+// the ones that escape, at both ends of the scale.
+func TestFrameIsExactlyOneAllocation(t *testing.T) {
+	payload := []byte(`{"a":[1,2,3]}`)
+	for _, id := range []string{
+		``, `1`, `12345678901234567890`, `-1`, `1.500`,
+		`"plain"`, `"a<b&c>d"`, `"</script>"`, "\"a\u2028b\"", "\"a\u2029b\"",
+		`"` + strings.Repeat("<", 64*1024) + `"`,
+		`"` + strings.Repeat("\u2028", 16*1024) + `"`,
+	} {
+		for _, key := range []string{resultKey, errorKey} {
+			f := frame(id, key, payload)
+			assert.Equal(t, len(f), cap(f),
+				"frame(%.20q, %q, ...) reallocated: idLen under-predicts by %d bytes", id, key, cap(f)-len(f))
+		}
+	}
 }
 
 func TestWire_ErrorMapping(t *testing.T) {
@@ -713,16 +717,12 @@ func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
 		}
 	}
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		status, _, body := post(t, h, `{"jsonrpc":"2.0","id":2,"method":"echo"}`)
-		assert.Equal(t, http.StatusOK, status)
-		//nolint:testifylint // byte-exact wire pin; JSONEq would ignore key order and escaping
-		assert.Equal(t, `{"jsonrpc":"2.0","id":2,"result":"ok"}`, body)
-	}()
+	rec, done := serveAsync(t, h, `{"jsonrpc":"2.0","id":2,"method":"echo"}`)
 	select {
 	case <-done:
+		assert.Equal(t, http.StatusOK, rec.Code)
+		//nolint:testifylint // byte-exact wire pin; JSONEq would ignore key order and escaping
+		assert.Equal(t, `{"jsonrpc":"2.0","id":2,"result":"ok"}`, rec.Body.String())
 	case <-time.After(10 * time.Second):
 		t.Error("a request could not be served while the bound's worth of writers were stalled: " +
 			"the semaphore is being held across the write")
@@ -847,33 +847,6 @@ func TestWire_BatchElementsRunConcurrently(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, want, rec.Body.String())
 	assert.Equal(t, strconv.Itoa(len(want)), rec.Header().Get("Content-Length"))
-}
-
-// The stopwatch form of the test above, because "the batch took N times one
-// call" is the user-visible symptom and is worth asserting in its own units.
-//
-//nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
-func TestWire_ABatchOfSlowCallsTakesAboutOneCallsTime(t *testing.T) {
-	n := min(runtime.GOMAXPROCS(0), 4)
-	if n < 4 {
-		t.Skip("needs at least 4 permits for the serial and concurrent times to separate")
-	}
-	const delay = 200 * time.Millisecond
-
-	h := NewHandler(map[string]jrpc2.Handler{
-		"slow": func(context.Context, *jrpc2.Request) (any, error) {
-			time.Sleep(delay)
-			return held, nil
-		},
-	})
-
-	start := time.Now()
-	status, _, _ := post(t, h, batchOf(n, "slow"))
-	elapsed := time.Since(start)
-
-	assert.Equal(t, http.StatusOK, status)
-	assert.Less(t, elapsed, time.Duration(n)*delay/2,
-		"a batch of %d %v calls took %v; serial dispatch would need %v", n, delay, elapsed, time.Duration(n)*delay)
 }
 
 // A batch borrows from the process-wide bound; it does not multiply it. Two
@@ -1026,15 +999,11 @@ func TestWire_APanicInABatchElementFailsTheRequestAndReleasesItsPermit(t *testin
 		serve(`[{"jsonrpc":"2.0","id":1,"method":"boom"},{"jsonrpc":"2.0","id":2,"method":"boom"}]`)
 	}
 
-	served := make(chan string, 1)
-	go func() {
-		_, _, body := post(t, h, `{"jsonrpc":"2.0","id":9,"method":"echo"}`)
-		served <- body
-	}()
+	rec, done := serveAsync(t, h, `{"jsonrpc":"2.0","id":9,"method":"echo"}`)
 	select {
-	case body := <-served:
+	case <-done:
 		//nolint:testifylint // byte-exact wire pin; JSONEq would ignore key order and escaping
-		assert.Equal(t, `{"jsonrpc":"2.0","id":9,"result":{"method":"echo"}}`, body)
+		assert.Equal(t, `{"jsonrpc":"2.0","id":9,"result":{"method":"echo"}}`, rec.Body.String())
 	case <-time.After(10 * time.Second):
 		t.Error("the handler stopped serving after panicking batches: every panic leaked its permit")
 	}

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -26,17 +26,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Every `want` in this file is a byte string, not a shape. They were captured
-// from jrpc2 v1.3.3's jhttp.Bridge — the framing this package replaces — on
-// 2026-08-30, except where a case is annotated with the delta that changes it
-// deliberately. The point of pinning bytes rather than structure is that the
-// error vocabulary these frames carry (errEmptyMethod, errNoSuchMethod,
-// errEmptyBatch, "invalid request value", "invalid version marker", "extra
-// fields in request", ...) is unexported in jrpc2 and transcribed here: only an
-// exact-byte pin will notice if a library bump or a refactor moves one.
+// Every `want` here is a byte string captured from jrpc2 v1.3.3's jhttp.Bridge
+// except where annotated with a delta. The error vocabulary is unexported and
+// transcribed into wire.go: only an exact-byte pin notices a bump moving one.
 
-// held is what the handlers that park under the concurrency bound return once
-// they are released.
+// held is what the parked handlers return once released.
 const held = "done"
 
 // recordPeak raises peak to now, for handlers counting how many of them ran at
@@ -50,8 +44,8 @@ func recordPeak(peak *atomic.Int64, now int64) {
 	}
 }
 
-// testMethods is the table under test. notified counts calls to "note" so a
-// notification's completion is observable.
+// testMethods is the table under test; notified makes a notification's
+// completion observable.
 //
 //nolint:unparam // every literal here must match the fixed jrpc2.Handler signature
 func testMethods(notified *atomic.Int64) map[string]jrpc2.Handler {
@@ -74,8 +68,8 @@ func testMethods(notified *atomic.Int64) map[string]jrpc2.Handler {
 			return nil, fmt.Errorf("while doing the thing: %w", &jrpc2.Error{Code: -32123, Message: "custom failure"})
 		},
 		"valueJRPCError": func(context.Context, *jrpc2.Request) (any, error) {
-			// The repo's own limiter sentinels are jrpc2.Error VALUES; see
-			// handlerError's comment for why that changes the wire message.
+			// The repo's limiter sentinels are jrpc2.Error VALUES; see
+			// handlerError.
 			return nil, jrpc2.Error{Code: -32001, Message: "request exceeded processing limit threshold"}
 		},
 		"contextCanceled": func(context.Context, *jrpc2.Request) (any, error) {
@@ -123,8 +117,7 @@ func TestWire_SingleRequests(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id":"abc","method":"echo"}`,
 		want: `{"jsonrpc":"2.0","id":"abc","result":{"method":"echo"}}`,
 	}, {
-		// The id is echoed as raw bytes, never decoded and re-encoded: a
-		// float64 round trip would render this 12345678901234567000.
+		// A float64 round trip would render this 12345678901234567000.
 		name: "integer id beyond float64 precision keeps every digit",
 		body: `{"jsonrpc":"2.0","id":12345678901234567890,"method":"echo"}`,
 		want: `{"jsonrpc":"2.0","id":12345678901234567890,"result":{"method":"echo"}}`,
@@ -137,7 +130,7 @@ func TestWire_SingleRequests(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id":1e2,"method":"echo"}`,
 		want: `{"jsonrpc":"2.0","id":1e2,"result":{"method":"echo"}}`,
 	}, {
-		// The only branch of jrpc2's isValidID that no other case reaches.
+		// The only isValidID branch no other case reaches.
 		name: "a negative id keeps its sign",
 		body: `{"jsonrpc":"2.0","id":-1,"method":"echo"}`,
 		want: `{"jsonrpc":"2.0","id":-1,"result":{"method":"echo"}}`,
@@ -150,8 +143,7 @@ func TestWire_SingleRequests(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id"  :  7  ,"method":"echo"}`,
 		want: `{"jsonrpc":"2.0","id":7,"result":{"method":"echo"}}`,
 	}, {
-		// Both the bridge and this package take the id from encoding/json's
-		// object decode, where a repeated key keeps the last value.
+		// encoding/json's object decode keeps the last value for a key.
 		name: "a repeated id key echoes the last one",
 		body: `{"jsonrpc":"2.0","id":1,"id":2,"method":"echo"}`,
 		want: `{"jsonrpc":"2.0","id":2,"result":{"method":"echo"}}`,
@@ -170,11 +162,8 @@ func TestWire_SingleRequests(t *testing.T) {
 	}
 }
 
-// The id is client-controlled and reflected. jrpc2 splices it into the response
-// unescaped; today's responses are escaped only as a side effect of the
-// compaction passes this package deletes. If this test ever fails because
-// someone "simplified" appendID to a plain append, the mount has started
-// reflecting arbitrary client bytes into a response with no nosniff header.
+// If this fails because appendID was "simplified" to a plain append, the mount
+// is reflecting arbitrary client bytes into a response with no nosniff header.
 func TestWire_IDIsHTMLEscapedExactlyAsTheBridgeEscapedIt(t *testing.T) {
 	h, _ := newTestHandler(t)
 
@@ -191,13 +180,8 @@ func TestWire_IDIsHTMLEscapedExactlyAsTheBridgeEscapedIt(t *testing.T) {
 		body: "{\"jsonrpc\":\"2.0\",\"id\":\"a\u2029b\",\"method\":\"echo\"}",
 		want: `{"jsonrpc":"2.0","id":"a\u2029b","result":{"method":"echo"}}`,
 	}, {
-		// The escape covers exactly five characters; every other byte of the
-		// id is spliced raw. That includes bytes that are not valid UTF-8:
-		// the bridge's compaction pass let them through too, because
-		// encoding/json's scanner checks JSON syntax and not encoding. A
-		// non-UTF-8 id therefore produces a non-UTF-8 response body, here and
-		// before. This is the boundary of the escaping guarantee, not an
-		// oversight in it.
+		// Every byte but the five is spliced raw, invalid UTF-8 included:
+		// the boundary of the guarantee, not an oversight in it.
 		name: "bytes that are not valid UTF-8 are spliced raw, as the bridge spliced them",
 		body: "{\"jsonrpc\":\"2.0\",\"id\":\"a\xffb\",\"method\":\"echo\"}",
 		want: "{\"jsonrpc\":\"2.0\",\"id\":\"a\xffb\",\"result\":{\"method\":\"echo\"}}",
@@ -216,14 +200,8 @@ func TestWire_IDIsHTMLEscapedExactlyAsTheBridgeEscapedIt(t *testing.T) {
 	}
 }
 
-// The frame builder's capacity is meant to be the frame's EXACT length, so a
-// frame is one allocation and one copy. No assertion on the response can see
-// that: append grows silently and the bytes come out identical either way. It
-// is observable on the slice, though — make([]byte, 0, n) yields cap == n, so
-// cap > len means the hint was short and the payload was re-copied.
-//
-// idLen is the half of the arithmetic that can be wrong, so the ids here are
-// the ones that escape, at both ends of the scale.
+// The frame's capacity must be its EXACT length: no assertion on the response
+// can see that, but cap > len means the payload was re-copied.
 func TestFrameIsExactlyOneAllocation(t *testing.T) {
 	payload := []byte(`{"a":[1,2,3]}`)
 	for _, id := range []string{
@@ -248,15 +226,14 @@ func TestWire_ErrorMapping(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id":1,"method":"jrpcError"}`,
 		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32123,"message":"custom failure","data":["a","b"]}}`,
 	}, {
-		// jrpc2 asserts, it does not unwrap: a wrapped *Error keeps its code
-		// but takes the wrapper's message. Pinned because it looks like a bug.
+		// jrpc2 asserts, it does not unwrap. Pinned: it looks like a bug.
 		name: "a WRAPPED *jrpc2.Error keeps the code and takes the wrapper message",
 		body: `{"jsonrpc":"2.0","id":1,"method":"wrappedJRPCError"}`,
 		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32123,` +
 			`"message":"while doing the thing: [-32123] custom failure"}}`,
 	}, {
-		// The repo's limiter sentinels take this path; the doubled "[-32001] "
-		// is today's wire text and is reproduced, not fixed, in this commit.
+		// The repo's limiter sentinels take this path; the doubled
+		// "[-32001] " is reproduced, not fixed.
 		name: "a jrpc2.Error VALUE keeps its code and doubles its code into the message",
 		body: `{"jsonrpc":"2.0","id":1,"method":"valueJRPCError"}`,
 		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32001,` +
@@ -270,9 +247,8 @@ func TestWire_ErrorMapping(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id":1,"method":"contextCanceled"}`,
 		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32097,"message":"gave up: context canceled"}}`,
 	}, {
-		// -32098, not -32603: jrpc2's invoke returns the marshal failure as
-		// the task's error, so responses() maps it down the same ladder a
-		// handler error takes. Captured from the live bridge.
+		// -32098, not -32603: jrpc2 maps a marshal failure down the same
+		// ladder a handler error takes. Captured from the live bridge.
 		name: "a result that cannot be marshaled is a system error, not a truncated body",
 		body: `{"jsonrpc":"2.0","id":1,"method":"unmarshalable"}`,
 		want: `{"jsonrpc":"2.0","id":1,"error":{"code":-32098,` +
@@ -314,8 +290,7 @@ func TestWire_RequestLevelProtocolErrors(t *testing.T) {
 		status int
 		want   string
 	}{{
-		// DELTA (a): the bridge answers 500 + the plaintext
-		// "[-32700] invalid request value". This is the spec's answer.
+		// DELTA (a).
 		name:   "a malformed body is a -32700 frame over HTTP 200",
 		body:   `{`,
 		status: http.StatusOK,
@@ -347,17 +322,15 @@ func TestWire_RequestLevelProtocolErrors(t *testing.T) {
 		status: http.StatusOK,
 		want:   `{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"empty method name"}}`,
 	}, {
-		// DELTA (d): the bridge answers 204 here, and only by accident — its
-		// in-process client discards the server's frame because the id is
-		// empty. An empty method name is a request-level error and is
+		// DELTA (d). An empty method name is a request-level error and is
 		// reportable even for a notification.
 		name:   "an empty method name on a NOTIFICATION is a -32600 frame with a null id",
 		body:   `{"jsonrpc":"2.0","method":""}`,
 		status: http.StatusOK,
 		want:   `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"empty method name"}}`,
 	}, {
-		// Parity, not a delta: a response-shaped message has no method, so it
-		// degrades to the empty-method error rather than being "understood".
+		// A response-shaped message has no method, so it degrades to the
+		// empty-method error rather than being "understood".
 		name:   "a response-shaped message with a version marker degrades to empty method",
 		body:   `{"jsonrpc":"2.0","id":1,"result":5}`,
 		status: http.StatusOK,
@@ -373,8 +346,7 @@ func TestWire_RequestLevelProtocolErrors(t *testing.T) {
 		status: http.StatusOK,
 		want:   `{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"invalid version marker"}}`,
 	}, {
-		// Parity: a parse/shape error is reported even for a notification.
-		// This is what the bridge does today and what the spec requires.
+		// A parse/shape error is reported even for a notification.
 		name:   "a parse error on a notification still answers",
 		body:   `{"jsonrpc":"1.0","method":"echo"}`,
 		status: http.StatusOK,
@@ -458,8 +430,7 @@ func TestWire_Batches(t *testing.T) {
 		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"}]`,
 		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}}]`,
 	}, {
-		// DELTA (e): the bridge answers this
-		// [invalid(id 2), valid(id 1), valid(id 3)].
+		// DELTA (e).
 		name: "invalid elements answer in place, not first",
 		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"},` +
 			`{"jsonrpc":"1.0","id":2,"method":"echo"},` +
@@ -468,14 +439,14 @@ func TestWire_Batches(t *testing.T) {
 			`{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"invalid version marker"}},` +
 			`{"jsonrpc":"2.0","id":3,"result":{"method":"echo"}}]`,
 	}, {
-		// DELTA (e) again: the bridge answers [invalid(null id), valid(id 1)].
+		// DELTA (e) again.
 		name: "a non-object element answers in place with a null id",
 		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"},5]`,
 		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}},` +
 			`{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}]`,
 	}, {
-		// Parity: the bridge virtualizes ids, so jrpc2's duplicate-id check is
-		// unreachable today. Owning the framing must not make it reachable.
+		// jrpc2's duplicate-id check was unreachable under the bridge, and
+		// owning the framing must not make it reachable.
 		name: "duplicate ids inside one batch are allowed",
 		body: `[{"jsonrpc":"2.0","id":1,"method":"echo"},{"jsonrpc":"2.0","id":1,"method":"nilResult"}]`,
 		want: `[{"jsonrpc":"2.0","id":1,"result":{"method":"echo"}},` +
@@ -573,11 +544,7 @@ type errReader struct{}
 
 func (errReader) Read([]byte) (int, error) { return 0, errors.New("connection reset") }
 
-// A fat response must survive the envelope byte for byte. There is no way to
-// assert "exactly one copy" from a test, so this asserts the two things that
-// would break if the copy count changed for the wrong reason: the body still
-// parses, and its result is byte-identical to an independent json.Marshal of
-// the same value (so nothing re-compacted, re-escaped, or truncated it).
+// A fat response must survive the envelope byte for byte.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_BigResponseIntegrity(t *testing.T) {
@@ -612,11 +579,8 @@ func TestWire_BigResponseIntegrity(t *testing.T) {
 	assert.Equal(t, oracle, []byte(envelope.Result))
 }
 
-// The concurrency bound is the design's own #1 hazard: without it, the number
-// of fat marshals in flight is the HTTP backlog limit (5000), not the core
-// count. jrpc2's Server held a semaphore across handler and result marshal;
-// this reproduces it (at GOMAXPROCS rather than NumCPU — see the sem field's
-// comment), and this test fails if it is removed.
+// Without the bound, the fat marshals in flight are the HTTP backlog limit
+// (5000), not the core count.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
@@ -658,8 +622,7 @@ func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
 		}()
 	}
 
-	// Wait for the bound to be saturated, then give the unbounded case ample
-	// room to exceed it before looking.
+	// Saturate the bound, then give an unbounded case room to exceed it.
 	for range limit {
 		select {
 		case <-entered:
@@ -680,10 +643,8 @@ func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
 		"the bound was never reached, so this test would not notice its removal")
 }
 
-// The permit must be gone before any byte is handed to the ResponseWriter, or a
-// slow reader holds a slot in a bound sized for CPUs. Proved structurally: the
-// handler that writes is the one that has already released, so a request whose
-// write blocks cannot stop the next request's handler from starting.
+// The permit must be gone before any byte reaches the ResponseWriter, or a
+// slow reader holds a slot in a bound sized for CPUs.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
@@ -695,8 +656,8 @@ func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
 		},
 	})
 
-	// Saturate the bound with writers that never drain, then prove a fresh
-	// request still reaches its handler.
+	// Saturate with writers that never drain, then prove a fresh request
+	// reaches its handler.
 	blocked := make(chan struct{})
 	var wg sync.WaitGroup
 	for range runtime.GOMAXPROCS(0) {
@@ -732,9 +693,8 @@ func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
 	wg.Wait()
 }
 
-// blockingWriter is a ResponseWriter whose Write never returns until blocked is
-// closed, standing in for a client that stopped reading. Header must keep the
-// map it hands out, or the writer silently swallows every header set on it.
+// blockingWriter stands in for a client that stopped reading. Header must keep
+// the map it hands out, or the writer swallows every header set on it.
 type blockingWriter struct {
 	blocked chan struct{}
 	header  http.Header
@@ -784,10 +744,8 @@ func jsonArray(n int, element func(id int) string) string {
 	return "[" + strings.Join(elems, ",") + "]"
 }
 
-// serveAsync runs one body through h on its own goroutine and returns the
-// recorder plus a channel closed when ServeHTTP has returned. It exists so a
-// test can look at a batch while it is still in flight; post() cannot, and its
-// require calls would be on the wrong goroutine anyway.
+// serveAsync runs one body on its own goroutine, so a test can look at a batch
+// in flight; post()'s require calls would be on the wrong one.
 func serveAsync(t *testing.T, h http.Handler, body string) (*httptest.ResponseRecorder, <-chan struct{}) {
 	t.Helper()
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
@@ -801,14 +759,8 @@ func serveAsync(t *testing.T, h http.Handler, body string) (*httptest.ResponseRe
 	return rec, done
 }
 
-// Batch elements run concurrently, as jrpc2's dispatchLocked ran them. Serial
-// dispatch sums a batch's latencies under the one HTTP deadline the mount
-// enforces, so a batch of individually-fine calls 504s where each of them alone
-// succeeds — the regression this test exists to catch.
-//
-// The proof is a barrier, not a stopwatch: every element must be inside its
-// handler before any of them is allowed to return. Serial dispatch delivers
-// exactly one.
+// The proof is a barrier: every element must be inside its handler before any
+// of them returns. Serial dispatch delivers one.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_BatchElementsRunConcurrently(t *testing.T) {
@@ -849,14 +801,9 @@ func TestWire_BatchElementsRunConcurrently(t *testing.T) {
 	assert.Equal(t, strconv.Itoa(len(want)), rec.Header().Get("Content-Length"))
 }
 
-// A batch borrows from the process-wide bound; it does not multiply it. Two
-// separate things are pinned, because they fail separately:
-//
-//  1. no more than the semaphore's weight of a batch's handlers run at once, and
-//  2. no more than that many GOROUTINES exist for them, which is only true
-//     because the permit is taken on the serving goroutine BEFORE the worker
-//     is started. Acquire inside the worker instead and this batch parks one
-//     goroutine per element — which the 512KB body cap bounds at ~260,000.
+// A batch borrows from the process-wide bound. The weight must bound concurrent
+// HANDLERS and GOROUTINES both — the latter only because the permit is taken
+// before the worker starts.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
@@ -894,7 +841,7 @@ func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
 			t.Fatalf("only %d of %d permits were taken", k, limit)
 		}
 	}
-	// Saturated: give an unbounded implementation ample room to overshoot.
+	// Give an unbounded implementation room to overshoot.
 	time.Sleep(250 * time.Millisecond)
 	observedPeak := peak.Load()
 	observedGoroutines := runtime.NumGoroutine()
@@ -903,16 +850,15 @@ func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
 
 	assert.Equal(t, int64(limit), observedPeak,
 		"a batch of %d elements ran %d handlers at once against a bound of %d", elements, observedPeak, limit)
-	// The serving goroutine, this test's goroutine and the runtime's own make
-	// up the slack; what must not appear is one goroutine per element.
+	// The slack is the serving, test and runtime goroutines.
 	assert.Less(t, observedGoroutines, before+limit+16,
 		"a batch of %d elements parked %d goroutines: the permit is being acquired inside the worker",
 		elements, observedGoroutines-before)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-// Input order (DELTA (e)) and notification compaction are properties of the
-// response, not of the completion order. This batch finishes back to front.
+// Input order (DELTA (e)) and compaction are properties of the response, not
+// the completion order. This batch finishes back to front.
 //
 //nolint:unparam // the handler literals must match the fixed jrpc2.Handler signature
 func TestWire_BatchOrderAndCompactionSurviveOutOfOrderCompletion(t *testing.T) {
@@ -953,12 +899,8 @@ func TestWire_BatchOrderAndCompactionSurviveOutOfOrderCompletion(t *testing.T) {
 	assert.Equal(t, int64(1), notified.Load(), "the notification must have run before the response was written")
 }
 
-// jrpc2 never recovered a handler panic: under the bridge it unwound on a
-// goroutine the server owned, and took the process with it. Here a panic
-// unwinds out of ServeHTTP into httpRequestDurationLimiter's recover, which
-// answers 500 — so a batch worker's panic must be RE-RAISED on the serving
-// goroutine rather than escaping its own, and the permit it held must be gone
-// either way.
+// A batch worker's panic must be RE-RAISED on the serving goroutine rather
+// than escaping its own, and its permit must be gone either way.
 //
 //nolint:unparam // the handler literals must match the fixed jrpc2.Handler signature
 func TestWire_APanicInABatchElementFailsTheRequestAndReleasesItsPermit(t *testing.T) {
@@ -1009,9 +951,8 @@ func TestWire_APanicInABatchElementFailsTheRequestAndReleasesItsPermit(t *testin
 	}
 }
 
-// A body that is valid JSON but is not a request object or an array of them.
-// jrpc2 parses it as a single element whose validation failed, so it answers
-// with one bare frame — never an array — which is what the bridge did too.
+// Valid JSON that is not a request object answers one bare frame, never an
+// array.
 func TestWire_ValidJSONThatIsNotARequest(t *testing.T) {
 	h, _ := newTestHandler(t)
 
@@ -1028,9 +969,8 @@ func TestWire_ValidJSONThatIsNotARequest(t *testing.T) {
 		body: `true`,
 		want: `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}`,
 	}, {
-		// null decodes into a nil map rather than failing, so it gets as far as
-		// the version check. Pinned because it is the one scalar that does not
-		// answer -32700.
+		// null decodes into a nil map, so it reaches the version check: the
+		// one scalar that does not answer -32700.
 		name: "a bare null",
 		body: `null`,
 		want: `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid version marker"}}`,
@@ -1044,25 +984,16 @@ func TestWire_ValidJSONThatIsNotARequest(t *testing.T) {
 	}
 }
 
-// Three jrpc2 accessors stopped working when the jrpc2.Server left the serving
-// path, and none of them is fabricated back (see the package doc):
-// jrpc2.InboundRequest returns nil, jrpc2.ServerFromContext PANICS, and
-// (*jrpc2.Request).IsNotification reports false for every request — the last
-// one silently, which is why it is banned here alongside the other two. That is
-// only safe while nothing calls them, so this test fails the moment production
-// code does.
+// Three jrpc2 accessors stopped working with the jrpc2.Server (see the package
+// doc), which is only safe while nothing calls them.
 func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
-	// Anchored on this file's own compiled-in path, not the working directory,
-	// so the walk is the same whether `go test` runs it from the package dir
-	// or something runs the built binary from elsewhere.
+	// Anchored on this file's compiled-in path, not the working directory.
 	_, thisFile, _, ok := runtime.Caller(0)
 	require.True(t, ok, "cannot locate this test's own source file")
 	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", "..", ".."))
 	require.Equal(t, "cmd", filepath.Base(root), "this test walks cmd/; the package moved")
 
-	// The accessor name, and the receiver that makes a hit a real call: the
-	// two context accessors are package functions of jrpc2, and
-	// IsNotification is a method on a *jrpc2.Request under any name.
+	// The accessor name, and the receiver that makes a hit a real call.
 	receiverOf := map[string]string{
 		"InboundRequest":    "jrpc2",
 		"ServerFromContext": "jrpc2",
@@ -1079,8 +1010,7 @@ func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
 		if perr != nil {
 			return perr
 		}
-		// Selector expressions only: the package doc names both accessors, and
-		// a comment is not a caller.
+		// Selector expressions only: a comment is not a caller.
 		ast.Inspect(file, func(n ast.Node) bool {
 			sel, ok := n.(*ast.SelectorExpr)
 			if !ok {
@@ -1107,13 +1037,8 @@ func TestNoJRPC2ContextValueCallersInProductionCode(t *testing.T) {
 		"Take the request from the handler's second argument, and its notification-ness from an empty ID()")
 }
 
-// Params reach the handler as the exact bytes the body carried, by position or
-// by name. DELTA (f): the bridge re-marshaled every params value through
-// json.Marshal of a json.RawMessage, which compacted it and HTML-escaped it.
-// Both forms decode to the same value and every handler here decodes, so the
-// delta is invisible in behavior — but rpcv2's getEventsV2 reads
-// r.ParamString() rather than UnmarshalParams, so the raw bytes are part of
-// the handler contract and are pinned rather than left to chance.
+// DELTA (f): params reach the handler as the exact bytes the body carried.
+// rpcv2's getEventsV2 reads ParamString, so those bytes are contract.
 //
 //nolint:nilnil,unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_ParamsReachTheHandlerVerbatim(t *testing.T) {
@@ -1142,8 +1067,8 @@ func TestWire_ParamsReachTheHandlerVerbatim(t *testing.T) {
 		body: `{"jsonrpc":"2.0","id":1,"method":"params"}`,
 		want: ``,
 	}, {
-		// jrpc2's parser reduces "null" params to nil, so a handler cannot
-		// tell an explicit null from an absent params.
+		// jrpc2 reduces "null" params to nil, so a handler cannot tell an
+		// explicit null from an absent one.
 		name: "an explicit null is reduced to absent",
 		body: `{"jsonrpc":"2.0","id":1,"method":"params","params":null}`,
 		want: ``,
@@ -1157,16 +1082,8 @@ func TestWire_ParamsReachTheHandlerVerbatim(t *testing.T) {
 	}
 }
 
-// DELTA (g), the half that stops: once the request is dead — the duration
-// limiter has written its 504, or the client is gone — the serving goroutine
-// stops feeding the bound. Before this it kept taking permits and starting
-// elements for ceil(elements/weight) x the per-element time AFTER the answer
-// had gone out, with the global backlog slot held inside that abandoned
-// goroutine; a 3,200-element batch measured 4.73s of it past a 300ms deadline.
-//
-// The half that does NOT stop — an element already inside its handler runs to
-// completion — is asserted here on the elements that held permits, and at the
-// mount in TestMount_AStartedElementSurvivesTheDeadline.
+// DELTA (g): once the request is dead the serving goroutine stops feeding the
+// bound. What HAD started still finishes.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
@@ -1198,8 +1115,7 @@ func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
 		h.ServeHTTP(rec, req)
 	}()
 
-	// Saturate the bound. Every permit is now held, so the dispatch loop is
-	// parked in Acquire with the great majority of the batch still to go.
+	// Saturate: the loop is now parked in Acquire, most of the batch to go.
 	for k := range weight {
 		select {
 		case <-entered:
@@ -1216,9 +1132,7 @@ func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
 	time.Sleep(250 * time.Millisecond) // ample room for the loop to notice
 	atCancel := started.Load()
 
-	// Release the in-flight elements and time the unwind from there: the
-	// serving goroutine joins the work it started, so it cannot return before
-	// that work does. What it must NOT do is start any more.
+	// The serving goroutine joins what it started, so time from the release.
 	close(release)
 	unwindStart := time.Now()
 	select {
@@ -1239,10 +1153,8 @@ func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
 		"a dead request is answered by the layer that killed it; the framing writes nothing")
 }
 
-// adversarialBatch fills the 512KB body cap with the cheapest element that
-// still demands an answer: a bare scalar, which is a -32700 "request is not a
-// JSON object" frame. It is the worst response amplification the cap allows —
-// ~260,000 elements in, ~22MB of frames out.
+// adversarialBatch fills the body cap with the cheapest element that still
+// demands an answer: the worst response amplification the cap allows.
 func adversarialBatch(t *testing.T) (string, int) {
 	t.Helper()
 	const bodyCap = 512 * 1024
@@ -1256,16 +1168,9 @@ func adversarialBatch(t *testing.T) (string, int) {
 	return body, n
 }
 
-// DELTA (g), the half the permit does not cover. Elements that answer without
-// a handler never reach acquirePermit, so a batch of nothing BUT those — the
-// adversarial `[5,5,5,...]` — used to keep building frames after the request
-// was already dead, 22MB of them for a reader that had gone.
-//
-// The signal is allocation, and specifically allocation ABOVE the parse: the
-// frames are discarded either way, so the only thing that changes is whether
-// they were built at all, and ParseRequests' own ~175MB for a quarter-million
-// elements would otherwise drown that out. Measuring the parse separately
-// leaves the framing cost by subtraction, and calibrates to the machine.
+// DELTA (g) for the elements that never reach acquirePermit. The signal is
+// allocation ABOVE the parse — the frames are discarded either way, so all
+// that changes is whether they were built.
 func TestWire_ADeadRequestStopsBuildingStaticErrorFrames(t *testing.T) {
 	h, _ := newTestHandler(t)
 	body, elements := adversarialBatch(t)
@@ -1315,18 +1220,13 @@ func TestWire_ADeadRequestStopsBuildingStaticErrorFrames(t *testing.T) {
 	require.Positive(t, liveLen, "the control run must actually answer, or this proves nothing")
 	require.Positive(t, liveFraming, "the control run framed nothing; the measurement is broken")
 	assert.Zero(t, deadLen, "a dead request must not be answered by the framing")
-	// The dead run's residual is the one allocation it makes before it can
-	// know: dispatchAll's slot slice, 24 bytes x the element count. The bound
-	// sits well above that and well below a run that framed anything.
+	// The residual is dispatchAll's slot slice, allocated before it can know.
 	assert.Less(t, deadFraming, liveFraming/5,
 		"a dead request spent %.1fMB framing against a %.1fMB control: it is still answering its elements",
 		mb(deadFraming), mb(liveFraming))
 }
 
-// Shutdown is the server-scoped lifetime jrpc2's Server used to own: its
-// stopLocked canceled every in-flight request's context at stop. Nothing
-// replaced that when the bridge retired, so a straggler could keep reading a
-// store its daemon had already closed.
+// Without Shutdown a straggler keeps reading a store its daemon has closed.
 //
 //nolint:unparam // the handler literals must match the fixed jrpc2.Handler signature
 func TestWire_Shutdown(t *testing.T) {
@@ -1388,9 +1288,8 @@ func TestWire_Shutdown(t *testing.T) {
 		<-done
 	})
 
-	// The two cancellation sources compose: Shutdown holds the bound, so a
-	// later request cannot start a handler, and unwinds at its own deadline
-	// instead of hanging (DELTA (g)).
+	// The two sources compose: Shutdown holds the bound, so a later request
+	// unwinds at its own deadline instead (DELTA (g)).
 	t.Run("nothing new starts after a completed drain", func(t *testing.T) {
 		var ran atomic.Int64
 		h := NewHandler(map[string]jrpc2.Handler{

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -95,7 +95,7 @@ func post(t *testing.T, h http.Handler, body string) (int, http.Header, string) 
 func newTestHandler(t *testing.T) (*Handler, *atomic.Int64) {
 	t.Helper()
 	var notified atomic.Int64
-	return NewHandler(testMethods(&notified)), &notified
+	return NewHandler(testMethods(&notified), nil), &notified
 }
 
 func TestWire_SingleRequests(t *testing.T) {
@@ -546,7 +546,7 @@ func TestWire_BigResponseIntegrity(t *testing.T) {
 
 	h := NewHandler(map[string]jrpc2.Handler{
 		"fat": func(context.Context, *jrpc2.Request) (any, error) { return value, nil },
-	})
+	}, nil)
 
 	status, header, got := post(t, h, `{"jsonrpc":"2.0","id":"big","method":"fat"}`)
 	require.Equal(t, http.StatusOK, status)
@@ -588,7 +588,7 @@ func TestWire_SemaphoreBoundsConcurrentDispatch(t *testing.T) {
 			inflight.Add(-1)
 			return held, nil
 		},
-	})
+	}, nil)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -644,7 +644,7 @@ func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
 			started <- struct{}{}
 			return "ok", nil
 		},
-	})
+	}, nil)
 
 	// Saturate with writers that never drain, then serve a fresh request.
 	blocked := make(chan struct{})
@@ -764,7 +764,7 @@ func TestWire_BatchElementsRunConcurrently(t *testing.T) {
 			<-release
 			return held, nil
 		},
-	})
+	}, nil)
 	rec, done := serveAsync(t, h, batchOf(n, "hold"))
 
 	for k := range n {
@@ -813,7 +813,7 @@ func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
 			inflight.Add(-1)
 			return held, nil
 		},
-	})
+	}, nil)
 
 	runtime.GC() // settle the goroutine count before sampling it
 	before := runtime.NumGoroutine()
@@ -865,7 +865,7 @@ func TestWire_BatchOrderAndCompactionSurviveOutOfOrderCompletion(t *testing.T) {
 			return "noted", nil
 		},
 		"fast": func(context.Context, *jrpc2.Request) (any, error) { return "fast", nil },
-	})
+	}, nil)
 
 	status, header, got := post(t, h, `[{"jsonrpc":"2.0","id":1,"method":"slowest"},`+
 		`{"jsonrpc":"2.0","method":"note"},`+
@@ -895,7 +895,7 @@ func TestWire_APanicInABatchElementFailsTheRequestAndReleasesItsPermit(t *testin
 		"echo": func(_ context.Context, r *jrpc2.Request) (any, error) {
 			return map[string]any{"method": r.Method()}, nil
 		},
-	})
+	}, nil)
 
 	serve := func(body string) any {
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
@@ -1031,7 +1031,7 @@ func TestWire_ParamsReachTheHandlerVerbatim(t *testing.T) {
 			seen = r.ParamString()
 			return nil, nil
 		},
-	})
+	}, nil)
 
 	for _, tc := range []struct{ name, body, want string }{{
 		name: "by position",
@@ -1083,7 +1083,7 @@ func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
 			completed.Add(1)
 			return held, nil
 		},
-	})
+	}, nil)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -1221,7 +1221,7 @@ func TestWire_Shutdown(t *testing.T) {
 				observed <- ctx.Err()
 				return held, nil
 			},
-		})
+		}, nil)
 		rec, done := serveAsync(t, h, `{"jsonrpc":"2.0","id":1,"method":"watch"}`)
 		<-entered
 
@@ -1253,7 +1253,7 @@ func TestWire_Shutdown(t *testing.T) {
 				<-release // ignores cancellation, as a scan loop between checks does
 				return held, nil
 			},
-		})
+		}, nil)
 		_, done := serveAsync(t, h, `{"jsonrpc":"2.0","id":1,"method":"stuck"}`)
 		<-entered
 
@@ -1278,7 +1278,7 @@ func TestWire_Shutdown(t *testing.T) {
 				ran.Add(1)
 				return held, nil
 			},
-		})
+		}, nil)
 		require.NoError(t, h.Shutdown(t.Context()))
 
 		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)

--- a/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
+++ b/cmd/stellar-rpc/internal/jsonrpc/wire/wire_test.go
@@ -28,9 +28,8 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/network"
 )
 
-// Every `want` is a byte string captured from jrpc2 v1.3.3's jhttp.Bridge,
-// except where annotated with a delta. Only an exact-byte pin notices a bump
-// moving one of wire.go's transcribed error strings.
+// Every `want` is a byte string captured from jhttp.Bridge, except where
+// annotated with a delta; only an exact-byte pin notices a library bump.
 
 // held is what the parked handlers return once released.
 const held = "done"
@@ -161,8 +160,8 @@ func TestWire_SingleRequests(t *testing.T) {
 	}
 }
 
-// If this fails because appendID was "simplified" to a plain append, the mount
-// is reflecting arbitrary client bytes into a response with no nosniff header.
+// If this fails, appendID was "simplified" and the mount now reflects client
+// bytes into a response with no nosniff header.
 func TestWire_IDIsHTMLEscapedExactlyAsTheBridgeEscapedIt(t *testing.T) {
 	h, _ := newTestHandler(t)
 
@@ -179,8 +178,7 @@ func TestWire_IDIsHTMLEscapedExactlyAsTheBridgeEscapedIt(t *testing.T) {
 		body: "{\"jsonrpc\":\"2.0\",\"id\":\"a\u2029b\",\"method\":\"echo\"}",
 		want: `{"jsonrpc":"2.0","id":"a\u2029b","result":{"method":"echo"}}`,
 	}, {
-		// Every byte but the five is spliced raw, invalid UTF-8 included:
-		// the boundary of the guarantee, not an oversight in it.
+		// Every byte but the five is spliced raw, invalid UTF-8 included.
 		name: "bytes that are not valid UTF-8 are spliced raw, as the bridge spliced them",
 		body: "{\"jsonrpc\":\"2.0\",\"id\":\"a\xffb\",\"method\":\"echo\"}",
 		want: "{\"jsonrpc\":\"2.0\",\"id\":\"a\xffb\",\"result\":{\"method\":\"echo\"}}",
@@ -199,8 +197,7 @@ func TestWire_IDIsHTMLEscapedExactlyAsTheBridgeEscapedIt(t *testing.T) {
 	}
 }
 
-// The frame's capacity must be its EXACT length: no assertion on the response
-// can see that, but cap > len means the payload was re-copied.
+// The capacity must be exact; cap > len means the payload was re-copied.
 func TestFrameIsExactlyOneAllocation(t *testing.T) {
 	payload := []byte(`{"a":[1,2,3]}`)
 	for _, id := range []string{
@@ -684,8 +681,8 @@ func TestWire_SemaphoreIsReleasedBeforeTheWrite(t *testing.T) {
 	wg.Wait()
 }
 
-// blockingWriter stands in for a client that stopped reading. Header must keep
-// the map it hands out, or the writer swallows every header set on it.
+// blockingWriter stands in for a client that stopped reading; Header must keep
+// the map it hands out or every header set on it is swallowed.
 type blockingWriter struct {
 	blocked chan struct{}
 	header  http.Header
@@ -790,9 +787,8 @@ func TestWire_BatchElementsRunConcurrently(t *testing.T) {
 	assert.Equal(t, strconv.Itoa(len(want)), rec.Header().Get("Content-Length"))
 }
 
-// A batch borrows from the process-wide bound. The weight must bound concurrent
-// HANDLERS and GOROUTINES both — the latter only because the permit is taken
-// before the worker starts.
+// The weight must bound concurrent handlers and goroutines both; the latter
+// only because the permit is taken before the worker starts.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
@@ -846,8 +842,7 @@ func TestWire_ABatchDoesNotMultiplyTheConcurrencyBound(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-// DELTA (e) and compaction hold however the batch completes; this one
-// finishes back to front.
+// Delta (e) and compaction hold however the batch completes.
 //
 //nolint:unparam // the handler literals must match the fixed jrpc2.Handler signature
 func TestWire_BatchOrderAndCompactionSurviveOutOfOrderCompletion(t *testing.T) {
@@ -956,8 +951,7 @@ func TestWire_ValidJSONThatIsNotARequest(t *testing.T) {
 		body: `true`,
 		want: `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"request is not a JSON object"}}`,
 	}, {
-		// null decodes into a nil map, so it reaches the version check: the
-		// one scalar that does not answer -32700.
+		// null decodes to a nil map, so it reaches the version check.
 		name: "a bare null",
 		body: `null`,
 		want: `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid version marker"}}`,
@@ -1136,8 +1130,7 @@ func TestWire_ADeadRequestStopsStartingElements(t *testing.T) {
 		"a dead request is answered by the layer that killed it; the framing writes nothing")
 }
 
-// adversarialBatch fills the body cap with the cheapest element that still
-// demands an answer.
+// adversarialBatch fills the body cap with the cheapest answerable element.
 func adversarialBatch(t *testing.T) (string, int) {
 	t.Helper()
 	const bodyCap = 512 * 1024
@@ -1151,9 +1144,8 @@ func adversarialBatch(t *testing.T) (string, int) {
 	return body, n
 }
 
-// DELTA (g) for the elements that never reach acquirePermit. Measured ABOVE
-// the parse: the frames are discarded either way, so all that changes is
-// whether they were built.
+// Delta (g) for elements that never reach acquirePermit, measured above the
+// parse: the frames are discarded either way, so only the building changes.
 func TestWire_ADeadRequestStopsBuildingStaticErrorFrames(t *testing.T) {
 	h, _ := newTestHandler(t)
 	body, elements := adversarialBatch(t)
@@ -1271,8 +1263,7 @@ func TestWire_Shutdown(t *testing.T) {
 		<-done
 	})
 
-	// Shutdown holds the bound, so a later request unwinds at its own
-	// deadline (DELTA (g)) rather than hanging.
+	// Shutdown holds the bound, so a later request unwinds at its own deadline.
 	t.Run("nothing new starts after a completed drain", func(t *testing.T) {
 		var ran atomic.Int64
 		h := NewHandler(map[string]jrpc2.Handler{
@@ -1296,11 +1287,8 @@ func TestWire_Shutdown(t *testing.T) {
 	})
 }
 
-// Static-error frames are the one answer that needs no handler, and a hostile
-// body carries ~260,000 of them at ~23MB. Building them outside the bound let
-// concurrent hostile bodies materialize that much each, so the deferred build
-// takes a permit — proved here by holding every permit and showing a
-// static-only batch cannot finish until one comes back.
+// Static-error frames need no handler, so the deferred build takes a permit;
+// held here to show a static-only batch cannot finish without one.
 //
 //nolint:unparam // the handler literal must match the fixed jrpc2.Handler signature
 func TestWire_StaticErrorFramesAreBuiltInsideTheBound(t *testing.T) {
@@ -1329,8 +1317,7 @@ func TestWire_StaticErrorFramesAreBuiltInsideTheBound(t *testing.T) {
 		<-entered
 	}
 
-	// Every permit is held. This batch runs no handler at all, so before the
-	// deferred build it answered immediately.
+	// Every permit held; this batch runs no handler at all.
 	rec, done := serveAsync(t, h, `[5,5,5]`)
 	select {
 	case <-done:
@@ -1353,10 +1340,8 @@ func TestWire_StaticErrorFramesAreBuiltInsideTheBound(t *testing.T) {
 	assert.Equal(t, "["+one+","+one+","+one+"]", rec.Body.String())
 }
 
-// Both ends of the drain must be wired to the SAME group. A nil one used to
-// default silently to a private group, producing a Shutdown that reports
-// success while abandoned handlers run into a closing store — no error, no log
-// line, nothing observable until a shutdown races a teardown in production.
+// Both ends of the drain must be the same group; a nil one silently defaulted
+// and produced a Shutdown that reported success with handlers still running.
 func TestWire_NewHandlerRefusesAMissingLiveHandlersGroup(t *testing.T) {
 	assert.PanicsWithValue(t,
 		"wire: NewHandler needs the mount's LiveHandlers; jsonrpc.NewHandler is the one place that builds it",

--- a/cmd/stellar-rpc/internal/network/requestdurationlimiter.go
+++ b/cmd/stellar-rpc/internal/network/requestdurationlimiter.go
@@ -198,6 +198,18 @@ func (q *httpRequestDurationLimiter) ServeHTTP(res http.ResponseWriter, req *htt
 	}
 }
 
+// LiveHandlers counts the handler executions one mount has in flight. It lives
+// here because both ends of the drain need it and neither imports the other:
+// the duration limiters count into it, and wire.Handler.Shutdown joins it.
+//
+// It is a named type so the two ends cannot be wired to different groups by
+// accident. There is exactly ONE legal producer, jsonrpc.NewHandler; anything
+// else building a mount gets a Shutdown that reports success while abandoned
+// handlers run into a closing store.
+type LiveHandlers struct {
+	sync.WaitGroup
+}
+
 type RPCRequestDurationLimiter struct {
 	requestDurationLimiter
 
@@ -214,7 +226,7 @@ type RPCRequestDurationLimiter struct {
 	// wire permit, so a drain that has taken every permit cannot race an Add.
 	// "Making the name true" by adding only on the timeout path is
 	// unimplementable: by then the parent has already abandoned the child.
-	liveHandlers *sync.WaitGroup
+	liveHandlers *LiveHandlers
 }
 
 func MakeJrpcRequestDurationLimiter(
@@ -224,14 +236,15 @@ func MakeJrpcRequestDurationLimiter(
 	warningCounter increasingCounter,
 	limitCounter increasingCounter,
 	logger *log.Entry,
-	liveHandlers *sync.WaitGroup,
+	liveHandlers *LiveHandlers,
 ) *RPCRequestDurationLimiter {
 	// make sure the warning threshold is less then the limit threshold; otherwise, just set it to the limit threshold.
 	if warningThreshold > limitThreshold {
 		warningThreshold = limitThreshold
 	}
 	if liveHandlers == nil {
-		liveHandlers = new(sync.WaitGroup)
+		panic("network: MakeJrpcRequestDurationLimiter needs the mount's LiveHandlers; " +
+			"jsonrpc.NewHandler is the one place that builds it")
 	}
 
 	return &RPCRequestDurationLimiter{

--- a/cmd/stellar-rpc/internal/network/requestdurationlimiter.go
+++ b/cmd/stellar-rpc/internal/network/requestdurationlimiter.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/creachadair/jrpc2"
@@ -201,6 +202,13 @@ type RPCRequestDurationLimiter struct {
 	requestDurationLimiter
 
 	jrpcDownstreamHandler jrpc2.Handler
+
+	// detached tracks the handler goroutines Handle abandons when its timer
+	// fires: it returns the timeout error to its caller and does NOT join
+	// them, which is the whole point of the decoupling and the reason
+	// rpcv2's graceMargin exists. Whoever owns the lifecycle needs them
+	// joinable at shutdown, so they are counted here.
+	detached *sync.WaitGroup
 }
 
 func MakeJrpcRequestDurationLimiter(
@@ -210,14 +218,19 @@ func MakeJrpcRequestDurationLimiter(
 	warningCounter increasingCounter,
 	limitCounter increasingCounter,
 	logger *log.Entry,
+	detached *sync.WaitGroup,
 ) *RPCRequestDurationLimiter {
 	// make sure the warning threshold is less then the limit threshold; otherwise, just set it to the limit threshold.
 	if warningThreshold > limitThreshold {
 		warningThreshold = limitThreshold
 	}
+	if detached == nil {
+		detached = new(sync.WaitGroup)
+	}
 
 	return &RPCRequestDurationLimiter{
 		jrpcDownstreamHandler: downstream,
+		detached:              detached,
 		requestDurationLimiter: requestDurationLimiter{
 			warningThreshold: warningThreshold,
 			limitThreshold:   limitThreshold,
@@ -253,7 +266,11 @@ func (q *RPCRequestDurationLimiter) Handle(ctx context.Context, req *jrpc2.Reque
 	requestCtx, requestCtxCancel := context.WithTimeout(ctx, q.limitThreshold)
 	defer requestCtxCancel()
 
+	// Counted before the launch and released after the handler returns, so a
+	// request abandoned below stays visible to whoever joins the group.
+	q.detached.Add(1)
 	go func() {
+		defer q.detached.Done()
 		defer func() {
 			if err := recover(); err != nil {
 				q.logger.Errorf("Request for method %s resulted in an error : %v", req.Method(), err)

--- a/cmd/stellar-rpc/internal/network/requestdurationlimiter.go
+++ b/cmd/stellar-rpc/internal/network/requestdurationlimiter.go
@@ -203,12 +203,18 @@ type RPCRequestDurationLimiter struct {
 
 	jrpcDownstreamHandler jrpc2.Handler
 
-	// detached tracks the handler goroutines Handle abandons when its timer
-	// fires: it returns the timeout error to its caller and does NOT join
-	// them, which is the whole point of the decoupling and the reason
-	// rpcv2's graceMargin exists. Whoever owns the lifecycle needs them
-	// joinable at shutdown, so they are counted here.
-	detached *sync.WaitGroup
+	// liveHandlers counts EVERY live child of a budgeted method, not only the
+	// abandoned ones — the Add below is unconditional and pre-launch. They
+	// need to be joinable at shutdown because Handle returns on its timer
+	// without waiting for them, which is the whole point of the decoupling
+	// and the reason rpcv2 carries a graceMargin.
+	//
+	// LOAD-BEARING: the Add happens on the WRAPPER goroutine, synchronously,
+	// before the launch — never inside the child. The wrapper always holds a
+	// wire permit, so a drain that has taken every permit cannot race an Add.
+	// "Making the name true" by adding only on the timeout path is
+	// unimplementable: by then the parent has already abandoned the child.
+	liveHandlers *sync.WaitGroup
 }
 
 func MakeJrpcRequestDurationLimiter(
@@ -218,19 +224,19 @@ func MakeJrpcRequestDurationLimiter(
 	warningCounter increasingCounter,
 	limitCounter increasingCounter,
 	logger *log.Entry,
-	detached *sync.WaitGroup,
+	liveHandlers *sync.WaitGroup,
 ) *RPCRequestDurationLimiter {
 	// make sure the warning threshold is less then the limit threshold; otherwise, just set it to the limit threshold.
 	if warningThreshold > limitThreshold {
 		warningThreshold = limitThreshold
 	}
-	if detached == nil {
-		detached = new(sync.WaitGroup)
+	if liveHandlers == nil {
+		liveHandlers = new(sync.WaitGroup)
 	}
 
 	return &RPCRequestDurationLimiter{
 		jrpcDownstreamHandler: downstream,
-		detached:              detached,
+		liveHandlers:          liveHandlers,
 		requestDurationLimiter: requestDurationLimiter{
 			warningThreshold: warningThreshold,
 			limitThreshold:   limitThreshold,
@@ -266,11 +272,10 @@ func (q *RPCRequestDurationLimiter) Handle(ctx context.Context, req *jrpc2.Reque
 	requestCtx, requestCtxCancel := context.WithTimeout(ctx, q.limitThreshold)
 	defer requestCtxCancel()
 
-	// Counted before the launch and released after the handler returns, so a
-	// request abandoned below stays visible to whoever joins the group.
-	q.detached.Add(1)
+	// Before the launch, on this goroutine, under this wrapper's wire permit.
+	q.liveHandlers.Add(1)
 	go func() {
-		defer q.detached.Done()
+		defer q.liveHandlers.Done()
 		defer func() {
 			if err := recover(); err != nil {
 				q.logger.Errorf("Request for method %s resulted in an error : %v", req.Method(), err)

--- a/cmd/stellar-rpc/internal/network/requestdurationlimiter_test.go
+++ b/cmd/stellar-rpc/internal/network/requestdurationlimiter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
 	"github.com/creachadair/jrpc2/jhttp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -207,7 +208,7 @@ func TestJRPCRequestDurationLimiter_Limiting(t *testing.T) {
 		&warningCounter,
 		&limitCounter,
 		logCounter.Entry(),
-		nil,
+		new(LiveHandlers),
 	).Handle
 
 	ch := jhttp.NewChannel("http://"+addr+"/", nil)
@@ -255,7 +256,7 @@ func TestJRPCRequestDurationLimiter_NoLimiting(t *testing.T) {
 		&warningCounter,
 		&limitCounter,
 		logCounter.Entry(),
-		nil,
+		new(LiveHandlers),
 	).Handle
 
 	ch := jhttp.NewChannel("http://"+addr+"/", nil)
@@ -300,7 +301,7 @@ func TestJRPCRequestDurationLimiter_NoLimiting_Warn(t *testing.T) {
 		&warningCounter,
 		&limitCounter,
 		logCounter.Entry(),
-		nil,
+		new(LiveHandlers),
 	).Handle
 
 	ch := jhttp.NewChannel("http://"+addr+"/", nil)
@@ -350,4 +351,18 @@ func TestHTTPRequestDurationLimiter_Panicing(t *testing.T) {
 	require.Equal(t, []byte{}, bytes)
 	require.Equal(t, [7]int{0, 0, 0, 7, 0, 0, 0}, logCounter.writtenLogEntries)
 	shutdown()
+}
+
+// The limiter counts its children into the mount's group; without one, a
+// Shutdown that joins that group proves nothing about them.
+func TestMakeJrpcRequestDurationLimiterRefusesAMissingGroup(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"network: MakeJrpcRequestDurationLimiter needs the mount's LiveHandlers; "+
+			"jsonrpc.NewHandler is the one place that builds it",
+		func() {
+			MakeJrpcRequestDurationLimiter(
+				//nolint:nilnil // the handler is never called; only the constructor is under test
+				func(context.Context, *jrpc2.Request) (any, error) { return nil, nil },
+				time.Second, time.Second, nil, nil, nil, nil)
+		})
 }

--- a/cmd/stellar-rpc/internal/network/requestdurationlimiter_test.go
+++ b/cmd/stellar-rpc/internal/network/requestdurationlimiter_test.go
@@ -206,7 +206,9 @@ func TestJRPCRequestDurationLimiter_Limiting(t *testing.T) {
 		time.Second/10,
 		&warningCounter,
 		&limitCounter,
-		logCounter.Entry()).Handle
+		logCounter.Entry(),
+		nil,
+	).Handle
 
 	ch := jhttp.NewChannel("http://"+addr+"/", nil)
 	client := jrpc2.NewClient(ch, nil)
@@ -252,7 +254,9 @@ func TestJRPCRequestDurationLimiter_NoLimiting(t *testing.T) {
 		time.Second*10,
 		&warningCounter,
 		&limitCounter,
-		logCounter.Entry()).Handle
+		logCounter.Entry(),
+		nil,
+	).Handle
 
 	ch := jhttp.NewChannel("http://"+addr+"/", nil)
 	client := jrpc2.NewClient(ch, nil)
@@ -295,7 +299,9 @@ func TestJRPCRequestDurationLimiter_NoLimiting_Warn(t *testing.T) {
 		time.Second*10,
 		&warningCounter,
 		&limitCounter,
-		logCounter.Entry()).Handle
+		logCounter.Entry(),
+		nil,
+	).Handle
 
 	ch := jhttp.NewChannel("http://"+addr+"/", nil)
 	client := jrpc2.NewClient(ch, nil)

--- a/cmd/stellar-rpc/internal/rpcv1/config/options.go
+++ b/cmd/stellar-rpc/internal/rpcv1/config/options.go
@@ -521,78 +521,91 @@ func (cfg *Config) options() Options {
 			Usage:        "The max request execution duration is the predefined maximum duration of time allowed for processing a request. When that time elapses, the server would return 504 and abort the request's execution",
 			ConfigKey:    &cfg.MaxRequestExecutionDuration,
 			DefaultValue: 25 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-get-health-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getHealth request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetHealthExecutionDuration,
 			DefaultValue: 5 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-get_events-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getEvents request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetEventsExecutionDuration,
 			DefaultValue: 10 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-get-network-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getNetwork request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetNetworkExecutionDuration,
 			DefaultValue: 5 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-get-version-info-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getVersionInfo request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetVersionInfoExecutionDuration,
 			DefaultValue: 5 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-get-latest-ledger-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getLatestLedger request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetLatestLedgerExecutionDuration,
 			DefaultValue: 5 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-get_ledger-entries-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getLedgerEntries request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetLedgerEntriesExecutionDuration,
 			DefaultValue: 5 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-get-transaction-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getTransaction request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetTransactionExecutionDuration,
 			DefaultValue: 5 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-get-transactions-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getTransactions request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetTransactionsExecutionDuration,
 			DefaultValue: 5 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-get-ledgers-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getLedgers request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetLedgersExecutionDuration,
 			DefaultValue: 10 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-send-transaction-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a sendTransaction request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxSendTransactionExecutionDuration,
 			DefaultValue: 15 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-simulate-transaction-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a simulateTransaction request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxSimulateTransactionExecutionDuration,
 			DefaultValue: 15 * time.Second,
+			Validate:     positive,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("max-get-fee-stats-execution-duration"),
 			Usage:        "The maximum duration of time allowed for processing a getFeeStats request. When that time elapses, the rpc server would return -32001 and abort the request's execution",
 			ConfigKey:    &cfg.MaxGetFeeStatsExecutionDuration,
 			DefaultValue: 5 * time.Second,
+			Validate:     positive,
 		},
 		{
 			Name:         "serve-ledgers-from-datastore",
@@ -753,6 +766,13 @@ func positive(option *Option) error {
 		}
 	case *uint, *uint8, *uint16, *uint32, *uint64:
 		if reflect.ValueOf(v).Elem().Uint() <= 0 {
+			return fmt.Errorf("%s must be positive", option.Name)
+		}
+	case *time.Duration:
+		// A named int64: the *int64 case above does NOT match it, so without
+		// this every duration option that asks for validation would be
+		// rejected as "not a positive integer".
+		if *v <= 0 {
 			return fmt.Errorf("%s must be positive", option.Name)
 		}
 	default:

--- a/cmd/stellar-rpc/internal/rpcv1/config/options_test.go
+++ b/cmd/stellar-rpc/internal/rpcv1/config/options_test.go
@@ -4,9 +4,11 @@ import (
 	"reflect"
 	"regexp"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllConfigKeysMustBePointers(t *testing.T) {
@@ -106,4 +108,28 @@ func TestAllOptionsMustHaveAUniqueValidTomlKey(t *testing.T) {
 		// Ensure the keys are simple valid toml keys
 		assert.True(t, keyRegex.MatchString(key), "Invalid toml key for Option %s: %s", option.Name, key)
 	}
+}
+
+// A zero execution budget is a footgun the limiter cannot report: it arms no
+// limit timer, hands the handler an already-expired context, and then waits on
+// the handler with no deadline at all. v2 rejects it; v1 accepted it until
+// these options gained a validator.
+func TestExecutionDurationOptionsRejectZero(t *testing.T) {
+	cfg := Config{}
+	var checked int
+	for _, option := range cfg.options() {
+		if option.Validate == nil {
+			continue
+		}
+		target, ok := option.ConfigKey.(*time.Duration)
+		if !ok {
+			continue
+		}
+		checked++
+		*target = 0
+		require.Error(t, option.Validate(option), "%s accepted a zero duration", option.Name)
+		*target = time.Second
+		require.NoError(t, option.Validate(option), "%s rejected a positive duration", option.Name)
+	}
+	assert.Equal(t, 13, checked, "the execution-duration options lost their validator")
 }

--- a/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
@@ -99,6 +99,18 @@ func (d *Daemon) close() {
 		}
 	}
 
+	// FIRST teardown step: handler contexts are server-scoped, so this is the
+	// only thing that ends a request still reading core, db or the datastore
+	// below. Its own budget, not shutdownCtx's remainder, because the drain
+	// matters most when the Shutdown above already spent that on the very
+	// stragglers this cancels. Logged, not collected: a drain that ran out of
+	// time is a degraded shutdown, not a failed one.
+	drainCtx, drainRelease := context.WithTimeout(context.Background(), defaultShutdownGracePeriod)
+	defer drainRelease()
+	if err := d.jsonRPCHandler.Shutdown(drainCtx); err != nil {
+		d.logger.WithError(err).Warn("JSON-RPC handlers did not drain before teardown")
+	}
+
 	if err := d.ingestService.Close(); err != nil {
 		d.logger.WithError(err).Error("error closing ingestion service")
 		closeErrors = append(closeErrors, err)
@@ -106,17 +118,6 @@ func (d *Daemon) close() {
 	if err := d.core.Close(); err != nil {
 		d.logger.WithError(err).Error("error closing captive core")
 		closeErrors = append(closeErrors, err)
-	}
-	// Handler contexts are server-scoped, so this is the only thing that ends
-	// a request still reading d.db below. Its own budget rather than
-	// shutdownCtx's remainder: the drain matters most when the Shutdown above
-	// has already spent that on the very stragglers this cancels. Logged, not
-	// collected — a drain that ran out of time is a degraded shutdown, not a
-	// failed one.
-	drainCtx, drainRelease := context.WithTimeout(context.Background(), defaultShutdownGracePeriod)
-	defer drainRelease()
-	if err := d.jsonRPCHandler.Shutdown(drainCtx); err != nil {
-		d.logger.WithError(err).Warn("JSON-RPC handlers did not drain before teardown")
 	}
 	if err := d.db.Close(); err != nil {
 		d.logger.WithError(err).Error("Error closing db")

--- a/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
@@ -99,11 +99,19 @@ func (d *Daemon) close() {
 		}
 	}
 
-	// FIRST teardown step: handler contexts are server-scoped, so this is the
-	// only thing that ends a request still reading core, db or the datastore
-	// below. Its own budget, not shutdownCtx's remainder, because the drain
-	// matters most when the Shutdown above already spent that on the very
-	// stragglers this cancels. Logged, not collected: a drain that ran out of
+	// Connections dead before the drain, or live requests keep starting
+	// elements. A no-op after a graceful Shutdown; when that exhausted its
+	// deadline this force-closes the survivors, killing their request
+	// contexts. Ignored like rpcv2's: re-closing listeners Shutdown already
+	// closed reports so, and there is nothing to do about it here. The admin
+	// server serves NewAdminMux, not this handler, so it is not in the path.
+	_ = d.server.Close()
+
+	// FIRST resource-teardown step: handler contexts are server-scoped, so
+	// this is the only thing that ends a request still reading core, db or the
+	// datastore below. Its own budget, not shutdownCtx's remainder, because
+	// the drain matters most when the Shutdown above already spent that on the
+	// very stragglers this cancels. Logged, not collected: a drain that ran out of
 	// time is a degraded shutdown, not a failed one.
 	drainCtx, drainRelease := context.WithTimeout(context.Background(), defaultShutdownGracePeriod)
 	defer drainRelease()

--- a/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
@@ -107,6 +107,17 @@ func (d *Daemon) close() {
 		d.logger.WithError(err).Error("error closing captive core")
 		closeErrors = append(closeErrors, err)
 	}
+	// Handler contexts are server-scoped, so this is the only thing that ends
+	// a request still reading d.db below. Its own budget rather than
+	// shutdownCtx's remainder: the drain matters most when the Shutdown above
+	// has already spent that on the very stragglers this cancels. Logged, not
+	// collected — a drain that ran out of time is a degraded shutdown, not a
+	// failed one.
+	drainCtx, drainRelease := context.WithTimeout(context.Background(), defaultShutdownGracePeriod)
+	defer drainRelease()
+	if err := d.jsonRPCHandler.Shutdown(drainCtx); err != nil {
+		d.logger.WithError(err).Warn("JSON-RPC handlers did not drain before teardown")
+	}
 	if err := d.db.Close(); err != nil {
 		d.logger.WithError(err).Error("Error closing db")
 		closeErrors = append(closeErrors, err)

--- a/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv1/daemon/daemon.go
@@ -107,7 +107,6 @@ func (d *Daemon) close() {
 		d.logger.WithError(err).Error("error closing captive core")
 		closeErrors = append(closeErrors, err)
 	}
-	d.jsonRPCHandler.Close()
 	if err := d.db.Close(); err != nil {
 		d.logger.WithError(err).Error("Error closing db")
 		closeErrors = append(closeErrors, err)

--- a/cmd/stellar-rpc/internal/rpcv1/integrationtest/builtin_methods_disabled_test.go
+++ b/cmd/stellar-rpc/internal/rpcv1/integrationtest/builtin_methods_disabled_test.go
@@ -14,7 +14,12 @@ import (
 
 // TestBuiltinRPCMethodsDisabled verifies that the jrpc2 library's built-in
 // rpc.* methods (e.g. rpc.serverInfo, which leaks node lifetime metrics and
-// process start time) are not reachable via the HTTP bridge.
+// process start time) are not reachable on the JSON-RPC mount.
+//
+// This used to depend on the bridge's DisableBuiltin server option. The mount
+// no longer runs a jrpc2.Server at all: internal/jsonrpc/wire dispatches from
+// the method table alone, so a reserved name is an ordinary unknown method and
+// the -32601 shape below is unchanged.
 func TestBuiltinRPCMethodsDisabled(t *testing.T) {
 	test := infrastructure.NewTest(t, nil)
 

--- a/cmd/stellar-rpc/internal/rpcv2/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/rpcv2/jsonrpc.go
@@ -180,7 +180,10 @@ func gateHealthOnFirstCommit(h jrpc2.Handler, registry *query.Registry) jrpc2.Ha
 // request timeout. It covers the gap between a request's deadline firing and
 // its handler goroutine actually stopping: the duration limiter answers the
 // client at the deadline but the handler keeps running until it observes its
-// canceled context, which scan loops only check between iterations.
+// canceled context, which scan loops only check between iterations. (Verified:
+// the loops in stores/event, stores/txhash, packfile and adapters do check
+// per iteration. The orchestration layers above them do not, which is why the
+// margin is 30s and not zero.)
 //
 // jsonrpc.Handler.Shutdown cancels handler contexts too, at teardown. That can
 // only shorten a handler's life, so this stays an upper bound.
@@ -189,12 +192,23 @@ const graceMargin = 30 * time.Second
 // deriveLifecycleGrace computes the deferred-deletion grace period from the
 // serving timeouts: the longest time any request can run, plus graceMargin.
 //
-// INVARIANT: the request timeouts and the grace period move together. There is
-// no reader refcount — after a lifecycle run demotes a resource, this grace is
-// the ONLY thing separating an in-flight request from os.Remove. Deriving it
-// here (instead of a constant) means an operator raising a method's
-// max_execution_duration automatically widens the grace; a constant would let
-// the two drift until a slow request reads deleted files.
+// INVARIANT: the request timeouts and the grace period move together.
+// Deriving it here (instead of a constant) means an operator raising a
+// method's max_execution_duration automatically widens the grace; a constant
+// would let the two drift until a slow request reads deleted files.
+//
+// What the grace buys is AVAILABILITY, not memory safety: it covers a view
+// that predates a demotion opening a cold artifact for the FIRST time
+// afterwards (query-routing-design.md, "Filesystem unlink semantics alone").
+// Memory safety comes from ownership and drain barriers — rocksdb's per-op
+// read lock, CloseIfIdle declining under an in-flight op — because the
+// deadline bounds the response, not the handler goroutine.
+//
+// The handler drain is best-effort (readShutdownTimeout here, rpcv1's
+// defaultShutdownGracePeriod there) and the daemon closes its stores when it
+// expires, so store ownership is the backstop and not this. Relaxing the
+// per-op read lock as an optimization would silently turn a drain timeout into
+// a use-after-free, and nothing in the lifecycle code would show why.
 func deriveLifecycleGrace(svc config.ServiceConfig) time.Duration {
 	// The global HTTP-layer limit bounds every request, including any future
 	// method only it covers, so it participates in the max alongside the

--- a/cmd/stellar-rpc/internal/rpcv2/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/rpcv2/jsonrpc.go
@@ -181,6 +181,9 @@ func gateHealthOnFirstCommit(h jrpc2.Handler, registry *query.Registry) jrpc2.Ha
 // its handler goroutine actually stopping: the duration limiter answers the
 // client at the deadline but the handler keeps running until it observes its
 // canceled context, which scan loops only check between iterations.
+//
+// jsonrpc.Handler.Shutdown cancels handler contexts too, at teardown. That can
+// only shorten a handler's life, so this stays an upper bound.
 const graceMargin = 30 * time.Second
 
 // deriveLifecycleGrace computes the deferred-deletion grace period from the

--- a/cmd/stellar-rpc/internal/rpcv2/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/rpcv2/jsonrpc.go
@@ -214,5 +214,13 @@ func deriveLifecycleGrace(svc config.ServiceConfig) time.Duration {
 	// method only it covers, so it participates in the max alongside the
 	// per-method budgets.
 	longest := max(deref(svc.MaxRequestExecutionDuration), limitsByMethod(svc.Methods).LongestDuration())
+	if longest > math.MaxInt64-graceMargin {
+		// Adding the margin would wrap to a NEGATIVE duration, which
+		// lifecycle.WithLifecycleDefaults reads as unset and silently replaces
+		// with its 5-minute default — the narrowest grace in the codebase,
+		// under the widest budget an operator can configure. Config validates
+		// only a minimum. Saturate instead.
+		return math.MaxInt64
+	}
 	return longest + graceMargin
 }

--- a/cmd/stellar-rpc/internal/rpcv2/jsonrpc_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/jsonrpc_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/channel"
+	"github.com/creachadair/jrpc2/handler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -65,10 +68,8 @@ func newTestRPCServer(t *testing.T, r *query.Registry) string {
 	t.Helper()
 	handler := newJSONRPCHandler(defaultsConfig(t), testHandlerParams(t, r))
 	srv := httptest.NewServer(handler)
-	t.Cleanup(func() {
-		srv.Close()
-		handler.Close()
-	})
+	// No handler teardown: the mount owns no goroutine and no connection.
+	t.Cleanup(srv.Close)
 	return srv.URL
 }
 
@@ -227,4 +228,85 @@ func TestDeriveLifecycleGrace_TracksARaisedMethodBudget(t *testing.T) {
 	long := 2 * time.Minute
 	cfg.Service.Methods.SimulateTransaction.MaxExecutionDuration = &long
 	assert.Equal(t, long+graceMargin, deriveLifecycleGrace(cfg.Service))
+}
+
+// The mount answers an unknown method with jrpc2's own method-not-found frame:
+// code, message and data are exactly what a client saw when jrpc2's server
+// resolved the method, so replacing that server changed no byte here.
+//
+// It also drives the trigger of the library leak documented below many times
+// over. Under the wire framing an unknown method never reaches a jrpc2.Server —
+// it never reaches a handler at all — so no in-flight entry can be stranded and
+// no attacker-chosen method name can reach the per-method metric labels.
+func TestJSONRPCHandler_UnknownMethodWireShapeUnchanged(t *testing.T) {
+	url := newTestRPCServer(t, seedServingRegistry(t))
+	before := runtime.NumGoroutine()
+
+	const unknownCalls = 500
+	for range unknownCalls {
+		out := rpcv2test.PostRPC(t, url, "noSuchMethod", `{"padding":"xxxxxxxxxxxxxxxx"}`)
+		require.NotNil(t, out.Error)
+		require.Nil(t, out.Result)
+		require.EqualValues(t, jrpc2.MethodNotFound, out.Error.Code)
+		require.Equal(t, "method not found", out.Error.Message)
+		require.JSONEq(t, `"noSuchMethod"`, string(out.Error.Data))
+	}
+
+	// Generous: the HTTP server's own per-connection goroutines come and go.
+	// A per-call goroutine leak over 500 calls would blow past this.
+	assert.Less(t, runtime.NumGoroutine(), before+50,
+		"unknown-method calls must not accumulate goroutines")
+}
+
+// The upstream jrpc2 defect, kept as a self-contained reproduction for the
+// planned filing against creachadair/jrpc2 v1.3.3.
+//
+// Server.checkAndAssignLocked calls setContext (server.go:365-375) BEFORE it
+// resolves a handler (348-351), so by the time Assign returns nil the server
+// has already recorded the request's CancelFunc in Server.used. Release happens
+// only in deliver() (295-299), and only for a response with no rsp.err — which
+// responses() sets precisely when the task was never assigned a handler
+// (800-802). So every unknown-method CALL carrying an id strands its map entry,
+// its CancelFunc, and through that context the *Request and its params, for the
+// life of the process. Remotely triggerable from garbage method names, and
+// unbounded.
+//
+// Server.used is unexported, but it has one exported consequence: a second
+// request reusing a still-registered id is rejected as a duplicate. That makes
+// id reuse a direct, deterministic probe — no reflection, no fork.
+//
+// Nothing in this repo's serving path constructs a jrpc2.Server any more, so
+// this is no longer a mitigation we carry; it is evidence. If this test ever
+// stops failing in the way it asserts, the library has fixed the leak and both
+// this test and the upstream ticket can go.
+func TestJRPC2ServerStrandsUnknownMethodInFlightEntries(t *testing.T) {
+	// Two calls, same id, unknown method: the second is refused as a duplicate
+	// id because the first one's entry was never released.
+	cli, srv := channel.Direct()
+	table := handler.Map{
+		"getHealth": func(context.Context, *jrpc2.Request) (any, error) { return "ok", nil },
+	}
+	server := jrpc2.NewServer(table, &jrpc2.ServerOptions{DisableBuiltin: true}).Start(srv)
+	t.Cleanup(func() {
+		require.NoError(t, cli.Close())
+		require.NoError(t, server.Wait())
+	})
+
+	errs := make([]*jrpc2.Error, 0, 2)
+	for range 2 {
+		require.NoError(t, cli.Send([]byte(`{"jsonrpc":"2.0","id":1,"method":"noSuchMethod"}`)))
+		raw, err := cli.Recv()
+		require.NoError(t, err)
+		var rsp struct {
+			Error *jrpc2.Error `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &rsp))
+		require.NotNil(t, rsp.Error, "an unknown method must answer an error")
+		errs = append(errs, rsp.Error)
+	}
+
+	assert.Equal(t, jrpc2.MethodNotFound, errs[0].Code)
+	assert.Equal(t, jrpc2.InvalidRequest, errs[1].Code,
+		"if this passes as MethodNotFound, jrpc2 fixed the leak: retire the upstream ticket")
+	assert.Equal(t, "duplicate request ID", errs[1].Message)
 }

--- a/cmd/stellar-rpc/internal/rpcv2/jsonrpc_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/jsonrpc_test.go
@@ -3,6 +3,7 @@ package rpcv2
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http/httptest"
 	"runtime"
 	"testing"
@@ -309,4 +310,18 @@ func TestJRPC2ServerStrandsUnknownMethodInFlightEntries(t *testing.T) {
 	assert.Equal(t, jrpc2.InvalidRequest, errs[1].Code,
 		"if this passes as MethodNotFound, jrpc2 fixed the leak: retire the upstream ticket")
 	assert.Equal(t, "duplicate request ID", errs[1].Message)
+}
+
+// A budget near the top of the range must not wrap the grace negative:
+// lifecycle.WithLifecycleDefaults reads a non-positive Grace as unset and
+// substitutes 5 minutes, which would pair the narrowest grace with the widest
+// budget. Config validates only a minimum, so nothing upstream stops this.
+func TestDeriveLifecycleGrace_SaturatesInsteadOfWrapping(t *testing.T) {
+	cfg := defaultsConfig(t)
+	huge := time.Duration(math.MaxInt64)
+	cfg.Service.MaxRequestExecutionDuration = &huge
+
+	grace := deriveLifecycleGrace(cfg.Service)
+	assert.Positive(t, grace, "the derived grace wrapped negative")
+	assert.Equal(t, time.Duration(math.MaxInt64), grace)
 }

--- a/cmd/stellar-rpc/internal/rpcv2/serve.go
+++ b/cmd/stellar-rpc/internal/rpcv2/serve.go
@@ -18,8 +18,10 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/query"
 )
 
-// readShutdownTimeout bounds the graceful drain at shutdown; whatever is
-// still in flight after it is cut off.
+// readShutdownTimeout bounds EACH phase of the read server's teardown: first
+// http.Server.Shutdown waiting for in-flight requests, then the handler drain
+// canceling and waiting for the handlers those requests left behind. The two
+// are sequential, so the endpoint's teardown is bounded by twice this.
 const readShutdownTimeout = 5 * time.Second
 
 // newServeReads returns the production ServeReads — the method table over the
@@ -43,8 +45,20 @@ func newServeReads(
 
 		// Both exits close the server: on death this reaps established
 		// keep-alive conns Serve abandoned; after the graceful path's
-		// Shutdown it is a no-op. The handler itself owns nothing to close.
+		// Shutdown it is a no-op.
 		defer func() { _ = server.Close() }()
+		// Runs first, defers being LIFO: handler contexts are server-scoped,
+		// so this is the only thing that ends a request still reading the
+		// registry. It must finish before startup.go's `defer registry.Close()`,
+		// which runs after g.Wait joins this goroutine.
+		//nolint:contextcheck // a fresh budget: ctx is already canceled
+		defer func() {
+			drainCtx, cancel := context.WithTimeout(context.Background(), readShutdownTimeout)
+			defer cancel()
+			if derr := handler.Shutdown(drainCtx); derr != nil {
+				p.logger.WithError(derr).Warn("read handlers did not drain before teardown")
+			}
+		}()
 		died := make(chan error, 1)
 		go func() { died <- server.Serve(listener) }()
 		select {

--- a/cmd/stellar-rpc/internal/rpcv2/serve.go
+++ b/cmd/stellar-rpc/internal/rpcv2/serve.go
@@ -43,16 +43,15 @@ func newServeReads(
 			IdleTimeout: jsonrpc.DefaultHTTPIdleTimeout,
 		}
 
-		// Both exits close the server: on death this reaps established
-		// keep-alive conns Serve abandoned; after the graceful path's
-		// Shutdown it is a no-op.
-		defer func() { _ = server.Close() }()
-		// Runs first, defers being LIFO: handler contexts are server-scoped,
-		// so this is the only thing that ends a request still reading the
-		// registry. It must finish before startup.go's `defer registry.Close()`,
-		// which runs after g.Wait joins this goroutine.
+		// Both steps on every exit, in ONE defer so the order is written down
+		// rather than inferred from LIFO. Connections dead before the drain,
+		// or live requests keep starting elements. Close reaps the keep-alives
+		// Serve abandoned on death and is a no-op after a graceful Shutdown;
+		// the drain must then finish before startup.go's `defer
+		// registry.Close()`, which runs once g.Wait joins this goroutine.
 		//nolint:contextcheck // a fresh budget: ctx is already canceled
 		defer func() {
+			_ = server.Close()
 			drainCtx, cancel := context.WithTimeout(context.Background(), readShutdownTimeout)
 			defer cancel()
 			if derr := handler.Shutdown(drainCtx); derr != nil {

--- a/cmd/stellar-rpc/internal/rpcv2/serve.go
+++ b/cmd/stellar-rpc/internal/rpcv2/serve.go
@@ -43,9 +43,8 @@ func newServeReads(
 
 		// Both exits close the server: on death this reaps established
 		// keep-alive conns Serve abandoned; after the graceful path's
-		// Shutdown it is a no-op.
+		// Shutdown it is a no-op. The handler itself owns nothing to close.
 		defer func() { _ = server.Close() }()
-		defer handler.Close()
 		died := make(chan error, 1)
 		go func() { died <- server.Serve(listener) }()
 		select {


### PR DESCRIPTION
### What

The JSON-RPC layer writes its own response envelope, on both mounts: one `json.Marshal` of the handler result, one hand-appended envelope, one `Write`. The jhttp bridge is deleted; jrpc2 remains as the request parser (`ParseRequests`) and the error vocabulary. The middleware chain (CORS, body cap, duration limiter + buffered writer, backlog limiters) is unchanged.

### Why

Every response previously passed through four framing stages: the result marshal, the bridge's envelope re-marshal (stdlib validates and re-compacts every embedded `json.RawMessage`), a second bridge marshal, and a re-parse on the internal client hop — 57% of CPU and 35% of allocations on fat responses, scaling with response size. Raw-wire measurement (full request-to-request wall time; the daemon's request log stops at handler return and cannot see framing):

| raw wire p50 / p99 | before | after |
|---|---|---|
| getLedgers limit=1 (16.9MB response) | 410.1 / 436.2 ms | **68.6 / 97.3 ms** |
| getTransactions limit=50 | 103.6 / 118.4 ms | 100.1 / 115.6 ms |

Responses byte-identical (same bytes out, integrity-checked per request, 0 errors). `appendCompact`, `checkValid`, and the framing re-parse are absent from the after-profile. getTransactions moves little because its framing share was ~10ms; its handler cost is a separate concern.

### Wire-visible changes

Seven deltas vs the bridge, each pinned byte-exactly: **(a)** malformed body → 200 + `-32700` frame (was 500 + plaintext); **(b)** empty batch `[]` → `-32600` frame (was 204); **(c)** a notification has finished before its 204 unless its method budget expired first, in which case the limiter answered and left it running; **(d)** empty-method notification → error frame (was an accidental 204); **(e)** batch responses in input order; **(f)** params reach handlers verbatim; **(g)** dispatch stops at the HTTP deadline — a 504'd request's unstarted batch elements never run; started elements finish. Batch elements dispatch concurrently under one shared `GOMAXPROCS` bound. Everything else is deliberate parity, pinned against frames captured from the bridge before its deletion: id escaping, duplicate ids, `id:null` as notification, one-element batches, the `-32601` shape, jhttp's HTTP shell.

Handler context: server-scoped. A client's disconnect does not cancel a handler; the method budget does, and at teardown `Shutdown` does. `jrpc2.InboundRequest`/`ServerFromContext`/`IsNotification` no longer work (no jrpc2 server exists); a guard test fails on any production caller. The unknown-method memory leak jrpc2's server carried is gone with the server.

### Shutdown

`Handler.Shutdown` cancels the server-scoped context and drains in two steps: acquire every permit (no wrapper running), then join the duration limiters' live handler children (`network.LiveHandlers`; miswiring the group is a construction-time panic). Teardown order is pinned on both daemons including failure paths: connections closed before the drain, drain before any resource handlers read. Abandoned over-budget handlers are joinable and cancelled; the per-method backlog limiter bounds them at QueueLimit. Six metric families built since 2023 but never registered — including `<method>_inflight_requests`, the live-handler count — are now registered.

### Testing

120+ wire/mount tests: byte-exact envelopes (ids incl. big-int/escaping/null, error mapping incl. wrapped and value-typed `jrpc2.Error`), the seven deltas, the parity set, a 4MB result equality check, semaphore bound + release-before-write, drain and teardown-order pins with negative checks, panic paths (a NoLimit handler panic was a process crash under the bridge; now a 500 with the mount still serving), and end-to-end through the real middleware chain. Full `internal/jsonrpc`, `internal/rpcv1`, `internal/rpcv2` suites green; changed-lines lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7opQUW9UZPKzE6B3tz9b5
