### PR TITLE
ci: share native-library caches across PRs and run integration tests on ubuntu-24.04

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -139,12 +139,16 @@ runs:
         echo SUDO='sudo' >> $GITHUB_OUTPUT
       id: variables
 
-    # Cache the Go Modules downloaded during the job.
+    # Cache the Go modules downloaded during the job. The module cache holds
+    # the same files for every workflow, job and matrix leg, so it is keyed by
+    # OS and go.sum only. Keying it by KEY_PREFIX stored one 560MB copy per
+    # leg and crowded the small, slow-to-rebuild native libraries out of the
+    # repository's 10GB cache budget.
     - uses: actions/cache@v4
       with:
         path: ${{ steps.variables.outputs.GOMODCACHE }}
-        key: ${{ steps.variables.outputs.KEY_PREFIX }}-go-mod-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ steps.variables.outputs.KEY_PREFIX  }}-go-mod-
+        key: go-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: go-mod-${{ runner.os }}-
 
     # Cache any build and test artifacts during the job, which will speed up
     # rebuilds and cause test runs to skip tests that have no reason to rerun.

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -145,10 +145,19 @@ runs:
     # leg and crowded the small, slow-to-rebuild native libraries out of the
     # repository's 10GB cache budget.
     - uses: actions/cache@v4
+      id: go-mod-cache
       with:
         path: ${{ steps.variables.outputs.GOMODCACHE }}
         key: go-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
         restore-keys: go-mod-${{ runner.os }}-
+
+    # The first job to finish saves the shared entry. Fill the module cache
+    # here so that job saves a complete one, even if it is a job that never
+    # builds Go code. Without this the dependency checker saved an empty
+    # folder and every other job found the key taken.
+    - if: steps.go-mod-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: go mod download
 
     # Cache any build and test artifacts during the job, which will speed up
     # rebuilds and cause test runs to skip tests that have no reason to rerun.

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -151,14 +151,6 @@ runs:
         key: go-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
         restore-keys: go-mod-${{ runner.os }}-
 
-    # The first job to finish saves the shared entry. Fill the module cache
-    # here so that job saves a complete one, even if it is a job that never
-    # builds Go code. Without this the dependency checker saved an empty
-    # folder and every other job found the key taken.
-    - if: steps.go-mod-cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: go mod download
-
     # Cache any build and test artifacts during the job, which will speed up
     # rebuilds and cause test runs to skip tests that have no reason to rerun.
     - uses: actions/cache@v4
@@ -174,3 +166,12 @@ runs:
     - if: github.ref_protected
       shell: bash
       run: ${{ steps.variables.outputs.SUDO }} rm -rf ${{ steps.variables.outputs.GOMODCACHE }} ${{ steps.variables.outputs.GOCACHE  }}
+
+    # The first job to finish saves the shared module cache. Fill it here, after
+    # the protected-branch reset above, so that job saves a complete one even
+    # when it never builds Go code. `go mod download` fetches every module in
+    # go.mod, test-only ones included. Without this the dependency checker
+    # saved an empty folder and every other job found the key taken.
+    - if: steps.go-mod-cache.outputs.cache-hit != 'true' || github.ref_protected
+      shell: bash
+      run: go mod download

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       core_deb_version:
-        description: 'Stellar Core debian package version (e.g. 25.2.0-3045.rc2.bb195c49d.jammy). Mutually exclusive with core_git_ref.'
+        description: 'Stellar Core debian package version from the noble repo (e.g. 28.0.0-3494.a9b861321.noble). Mutually exclusive with core_git_ref.'
         required: false
         type: string
       core_docker_img:
@@ -32,7 +32,7 @@ jobs:
   integration:
     name: Integration tests
     continue-on-error: true
-    runs-on: ${{ inputs.core_git_ref && 'ubuntu-24.04' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-24.04
     env:
       STELLAR_RPC_INTEGRATION_TESTS_ENABLED: true
       STELLAR_RPC_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ inputs.protocol_version }}
@@ -106,17 +106,12 @@ jobs:
         if: env.CORE_GIT_REF == ''
         shell: bash
         run: |
-          # Workaround for https://github.com/actions/virtual-environments/issues/5245,
-          # libc++1-8 won't be installed if another version is installed (but apt won't give you a helpful
-          # message about why the installation fails)
-          sudo apt-get remove -y libc++1-10 libc++abi1-10 || true
-
           sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
-          sudo bash -c 'echo "deb https://apt.stellar.org jammy unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
+          sudo bash -c 'echo "deb https://apt.stellar.org noble stable" > /etc/apt/sources.list.d/SDF.list'
 
+          # The noble package links libc++ 20, which comes from apt.llvm.org.
           sudo wget -O /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key
-          sudo bash -c 'echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm.list'
-          sudo bash -c 'echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" >> /etc/apt/sources.list.d/llvm.list'
+          sudo bash -c 'echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list'
 
           sudo apt-get update && sudo apt-get install -y stellar-core="$CORE_DEBIAN_PKG_VERSION"
           echo "Using stellar core version $(stellar-core version)"

--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -89,21 +89,21 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '27'
-      core_deb_version: '28.0.0-3494.a9b861321.noble'
-      core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3494.a9b861321.jammy'
+      core_deb_version: '28.0.1-3508.947aad841.noble'
+      core_docker_img: 'stellar/stellar-core:28.0.1-3508.947aad841.noble'
 
   integration-p28-pkg:
     name: Integration tests (P28)
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '28'
-      # Protocol 28 GA core release, the build published to the noble apt repo.
-      # Its src/rust/soroban/p28 submodule is
-      # rs-soroban-env v28.0.0 (ba37ea5f) — the same release soroban-env-host-curr
-      # pins from crates.io, keeping simulation cost models identical to
-      # apply-time metering.
-      core_deb_version: '28.0.0-3494.a9b861321.noble'
-      core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3494.a9b861321.jammy'
+      # Protocol 28 stable core release (28.0.1), the same pin as main. Its
+      # src/rust/soroban/p28 submodule is unchanged from 28.0.0: rs-soroban-env
+      # v28.0.0 (ba37ea5f) — the same release soroban-env-host-curr pins from
+      # crates.io, keeping simulation cost models identical to apply-time
+      # metering.
+      core_deb_version: '28.0.1-3508.947aad841.noble'
+      core_docker_img: 'stellar/stellar-core:28.0.1-3508.947aad841.noble'
 
   # integration-p25-src:
   #   name: Integration tests (p25, core from source)

--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -7,7 +7,10 @@ defaults:
 on:
   pull_request:
   push:
-    branches: [ main, release/** ]
+    # A pull request can restore caches saved on its base branch. Running on
+    # push to feature/full-history is what saves librocksdb, libzstd and the Go
+    # module cache there, so PRs against it do not rebuild them on every run.
+    branches: [ main, release/**, feature/full-history ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
@@ -86,20 +89,21 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '27'
-      core_deb_version: '28.0.0-3486.2332980a1.jammy'
-      core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3486.2332980a1.jammy'
+      core_deb_version: '28.0.0-3494.a9b861321.noble'
+      core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3494.a9b861321.jammy'
 
   integration-p28-pkg:
     name: Integration tests (P28)
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '28'
-      # Protocol 28 GA core release. Its src/rust/soroban/p28 submodule is
+      # Protocol 28 GA core release, the build published to the noble apt repo.
+      # Its src/rust/soroban/p28 submodule is
       # rs-soroban-env v28.0.0 (ba37ea5f) — the same release soroban-env-host-curr
       # pins from crates.io, keeping simulation cost models identical to
       # apply-time metering.
-      core_deb_version: '28.0.0-3486.2332980a1.jammy'
-      core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3486.2332980a1.jammy'
+      core_deb_version: '28.0.0-3494.a9b861321.noble'
+      core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3494.a9b861321.jammy'
 
   # integration-p25-src:
   #   name: Integration tests (p25, core from source)


### PR DESCRIPTION
## What this PR does

- CI stops building librocksdb and libzstd from source on every run. That saves about 10 minutes per job.
- The integration job moves to ubuntu-24.04, the same image as every other job.
- All jobs on one OS share one Go module cache.

## Why the cache never hit

| fact | detail |
|---|---|
| A pull request can read caches from its own ref, from `main`, and from its base branch. | The base branch here is `feature/full-history`. |
| Nothing ever saved a cache on `feature/full-history`. | The workflow ran on pushes to `main` only. |
| The 10GB cache storage was full of duplicates. | One pull request held 12.6GB. Eight jobs each saved the same 560MB Go module folder. GitHub deleted the 6MB librocksdb entries first. |

## The changes

| # | change | file |
|---|---|---|
| 1 | Run the workflow on push to `feature/full-history`. Each merge now saves the caches where every PR can read them. | `stellar-rpc.yml` |
| 2 | Key the Go module cache by OS and `go.sum` only. On a miss, run `go mod download` first, so the first job to save stores a full folder. | `setup-go/action.yml` |
| 3 | Run the integration job on ubuntu-24.04 with the Core package from the noble repo. | `integration-tests.yml`, `stellar-rpc.yml` |

## Core version

| | before | after |
|---|---|---|
| captive core package | 28.0.0, jammy | 28.0.1, noble, the release `main` pins |
| Core container image | `unsafe-stellar-core` 28.0.0 jammy | `stellar-core` 28.0.1 noble, the image `main` pins |

The soroban submodule is the same in both releases. Simulation cost models do not change.

## Results on this PR

| run | libraries | Go module cache | integration job |
|---|---|---|---|
| [1](https://github.com/stellar/stellar-rpc/actions/runs/33909693672) | built and saved | | 24m |
| [2](https://github.com/stellar/stellar-rpc/actions/runs/33911873930) | restored in all 7 jobs | | 13m 40s |
| [4](https://github.com/stellar/stellar-rpc/actions/runs/33914634433) | restored in all 7 jobs | one full 590MB folder saved | |

## After the merge

The push run on `feature/full-history` saves the entries on the base branch. Every later PR restores them on its first run. This command must then list `librocksdb`, `libzstd` and `go-mod` entries:

```bash
gh cache list --repo stellar/stellar-rpc --json key,ref \
  | jq -r '.[] | select(.ref=="refs/heads/feature/full-history") | .key[0:40]'
```
