### PR TITLE
fix(perf-eval): stop autolinking run numbers to issues in sticky comments

### DIFF
--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/perf-eval/coordinator-runner.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/perf-eval/coordinator-runner.go
@@ -139,7 +139,7 @@ func renderBody(hist []runRecord) string {
 	fmt.Fprintf(&b, "<!-- perf-eval-history: %s -->\n", encodeHistory(hist))
 	b.WriteString(renderRun(hist[0]))
 	for _, r := range hist[1:] {
-		fmt.Fprintf(&b, "\n<details>\n<summary>Performance Evaluation Test #%d</summary>\n\n", r.Num)
+		fmt.Fprintf(&b, "\n<details>\n<summary>Performance Evaluation Test #&#8203;%d</summary>\n\n", r.Num)
 		b.WriteString(strings.Trim(renderRun(r), "\n"))
 		b.WriteString("\n</details>\n")
 	}
@@ -148,7 +148,8 @@ func renderBody(hist []runRecord) string {
 
 func renderRun(r runRecord) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## 🧪 Performance Evaluation Test #%d\n\n", r.Num)
+	// The zero-width space entity keeps GitHub from autolinking "#N" to issue N.
+	fmt.Fprintf(&b, "## 🧪 Performance Evaluation Test #&#8203;%d\n\n", r.Num)
 	fmt.Fprintf(&b, "**Commit:** `%s` (`%s`)\n", r.TargetSHA[:min(12, len(r.TargetSHA))], r.TargetRef)
 	fmt.Fprintf(&b, "**Run:** %s\n", r.RunURL)
 	for _, l := range r.Legs {

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/perf-eval/coordinator-runner_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/perf-eval/coordinator-runner_test.go
@@ -33,7 +33,7 @@ func TestRenderComment_FirstRun(t *testing.T) {
 		Legs:      okLeg("throughput: 42 l/s"),
 	}, "")
 	require.True(t, strings.HasPrefix(out, marker+"\n"))
-	require.Contains(t, out, "## 🧪 Performance Evaluation Test #1")
+	require.Contains(t, out, "## 🧪 Performance Evaluation Test #&#8203;1")
 	require.Contains(t, out, "**Commit:** `abcdef123456` (`release/v1.2.3`)")
 	require.Contains(t, out, "### ✅ Apply-load ingestion — verdict: ok")
 	require.Contains(t, out, "throughput: 42 l/s")
@@ -52,13 +52,13 @@ func TestRenderComment_FoldsHistory(t *testing.T) {
 	out := renderN(4, okLeg("run body"))
 
 	require.Equal(t, 1, strings.Count(out, marker))
-	require.Contains(t, out, "## 🧪 Performance Evaluation Test #4")
+	require.Contains(t, out, "## 🧪 Performance Evaluation Test #&#8203;4")
 	require.Equal(t, 3, strings.Count(out, "<details>\n<summary>Performance Evaluation Test #"))
 
 	// Each prior run in descending order (#3, then #2, then #1)
-	i3 := strings.Index(out, "Performance Evaluation Test #3")
-	i2 := strings.Index(out, "Performance Evaluation Test #2")
-	i1 := strings.Index(out, "Performance Evaluation Test #1")
+	i3 := strings.Index(out, "Performance Evaluation Test #&#8203;3")
+	i2 := strings.Index(out, "Performance Evaluation Test #&#8203;2")
+	i1 := strings.Index(out, "Performance Evaluation Test #&#8203;1")
 	require.Positive(t, i3)
 	require.Less(t, i3, i2)
 	require.Less(t, i2, i1)
@@ -87,9 +87,9 @@ func TestRenderComment_CapsHistory(t *testing.T) {
 	hist := parseHistory(out)
 	require.Len(t, hist, maxHistory)
 	require.Equal(t, maxHistory+2, hist[0].Num)
-	require.Contains(t, out, fmt.Sprintf("## 🧪 Performance Evaluation Test #%d", maxHistory+2))
-	require.NotContains(t, out, "Performance Evaluation Test #2\n") // shed
-	require.NotContains(t, out, "Performance Evaluation Test #1\n") // shed
+	require.Contains(t, out, fmt.Sprintf("## 🧪 Performance Evaluation Test #&#8203;%d", maxHistory+2))
+	require.NotContains(t, out, "Performance Evaluation Test #&#8203;2\n") // shed
+	require.NotContains(t, out, "Performance Evaluation Test #&#8203;1\n") // shed
 }
 
 // Oversized histories shed old runs to stay under the comment-size cap.
@@ -117,5 +117,5 @@ func TestParseHistory_FreshOnAbsentOrCorrupt(t *testing.T) {
 		RunURL:    "https://example/run",
 		Legs:      okLeg("body"),
 	}, marker+"\n## some legacy comment\n")
-	require.Contains(t, out, "## 🧪 Performance Evaluation Test #1")
+	require.Contains(t, out, "## 🧪 Performance Evaluation Test #&#8203;1")
 }


### PR DESCRIPTION
The perf-eval coordinator posts sticky comments on release PRs with the
run number rendered as "Performance Evaluation Test #N", which GitHub
autolinks to issues with matching numbers. Since the counter is usually
low on those PRs, issues like #1 and #2 end up collecting references
from unrelated eval comments.

As suggested in the issue, I inserted a zero-width space between the "#"
and the number in both places the text is rendered (current run header
and the history dropdowns). Displays the same, but doesn't link anymore.
Renderer tests updated to match, nothing else in the repo parses that
text.

Closes #988
