### PR TITLE
fix(methods): validate contract events size limit in simulateTransaction (#964)

### DIFF
--- a/cmd/stellar-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction.go
@@ -227,6 +227,15 @@ func formatResponse(preflight preflight.Preflight,
 		StateChanges:    stateChanges,
 	}
 
+	var totalEventsSize uint64
+	for _, eventBytes := range preflight.Events {
+		totalEventsSize += uint64(len(eventBytes))
+	}
+	const defaultMaxContractEventsSizeBytes uint64 = 16384
+	if simResp.Error == "" && totalEventsSize > defaultMaxContractEventsSizeBytes {
+		simResp.Error = fmt.Sprintf("total contract events size (%d bytes) exceeds maximum limit (%d bytes)", totalEventsSize, defaultMaxContractEventsSizeBytes)
+	}
+
 	switch format {
 	case protocol.FormatJSON:
 		simResp.TransactionDataJSON, err = xdr2json.ConvertBytes(

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction.go
@@ -227,10 +227,23 @@ func formatResponse(preflight preflight.Preflight,
 		StateChanges:    stateChanges,
 	}
 
+	// stellar core charges the budget's contract_events_and_return_value_size
+	// cost with the XDR bytes of successful contract events plus the return
+	// value, so diagnostic output must not count toward this limit.
 	var totalEventsSize uint64
 	for _, eventBytes := range preflight.Events {
-		totalEventsSize += uint64(len(eventBytes))
+		var diagEvent xdr.DiagnosticEvent
+		if err := xdr.SafeUnmarshal(eventBytes, &diagEvent); err != nil {
+			continue
+		}
+		if !diagEvent.InSuccessfulContractCall || diagEvent.Event.Type != xdr.ContractEventTypeContract {
+			continue
+		}
+		if encoded, err := diagEvent.Event.MarshalBinary(); err == nil {
+			totalEventsSize += uint64(len(encoded))
+		}
 	}
+	totalEventsSize += uint64(len(preflight.Result))
 	const defaultMaxContractEventsSizeBytes uint64 = 16384
 	if simResp.Error == "" && totalEventsSize > defaultMaxContractEventsSizeBytes {
 		simResp.Error = fmt.Sprintf("total contract events size (%d bytes) exceeds maximum limit (%d bytes)", totalEventsSize, defaultMaxContractEventsSizeBytes)

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction_test.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction_test.go
@@ -680,15 +680,58 @@ func TestSimulateTransactionThreadsUseUpgradedAuth(t *testing.T) {
 }
 
 func TestSimulateTransaction_ContractEventsSizeLimit(t *testing.T) {
-	pf := preflight.Preflight{
-		Events: [][]byte{
-			make([]byte, 10000),
-			make([]byte, 7000),
-		},
+	encodedEvent := func(t *testing.T, inSuccessful bool, eventType xdr.ContractEventType, size int) []byte {
+		payload := xdr.ScBytes(make([]byte, size))
+		event := xdr.DiagnosticEvent{
+			InSuccessfulContractCall: inSuccessful,
+			Event: xdr.ContractEvent{
+				Type: eventType,
+				Body: xdr.ContractEventBody{
+					V: 0,
+					V0: &xdr.ContractEventV0{
+						Data: xdr.ScVal{
+							Type:  xdr.ScValTypeScvBytes,
+							Bytes: &payload,
+						},
+					},
+				},
+			},
+		}
+		b, err := event.MarshalBinary()
+		require.NoError(t, err)
+		return b
 	}
-	resp, err := formatResponse(pf, protocol.FormatXDR, 100)
-	require.NoError(t, err)
-	require.Contains(t, resp.Error, "total contract events size")
-	require.Contains(t, resp.Error, "exceeds maximum limit")
+
+	t.Run("successful contract events over the limit", func(t *testing.T) {
+		pf := preflight.Preflight{
+			Events: [][]byte{
+				encodedEvent(t, true, xdr.ContractEventTypeContract, 10000),
+				encodedEvent(t, true, xdr.ContractEventTypeContract, 7000),
+			},
+		}
+		resp, err := formatResponse(pf, protocol.FormatBase64, 100)
+		require.NoError(t, err)
+		require.Contains(t, resp.Error, "total contract events size")
+		require.Contains(t, resp.Error, "exceeds maximum limit")
+	})
+
+	t.Run("diagnostic and system events are not counted", func(t *testing.T) {
+		pf := preflight.Preflight{
+			Events: [][]byte{
+				encodedEvent(t, false, xdr.ContractEventTypeContract, 10000),
+				encodedEvent(t, true, xdr.ContractEventTypeSystem, 10000),
+			},
+		}
+		resp, err := formatResponse(pf, protocol.FormatBase64, 100)
+		require.NoError(t, err)
+		require.Empty(t, resp.Error)
+	})
+
+	t.Run("return value alone can exceed the limit", func(t *testing.T) {
+		pf := preflight.Preflight{Result: make([]byte, 16385)}
+		resp, err := formatResponse(pf, protocol.FormatBase64, 100)
+		require.NoError(t, err)
+		require.Contains(t, resp.Error, "exceeds maximum limit")
+	})
 }
 

--- a/cmd/stellar-rpc/internal/methods/simulate_transaction_test.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction_test.go
@@ -678,3 +678,17 @@ func TestSimulateTransactionThreadsUseUpgradedAuth(t *testing.T) {
 		})
 	}
 }
+
+func TestSimulateTransaction_ContractEventsSizeLimit(t *testing.T) {
+	pf := preflight.Preflight{
+		Events: [][]byte{
+			make([]byte, 10000),
+			make([]byte, 7000),
+		},
+	}
+	resp, err := formatResponse(pf, protocol.FormatXDR, 100)
+	require.NoError(t, err)
+	require.Contains(t, resp.Error, "total contract events size")
+	require.Contains(t, resp.Error, "exceeds maximum limit")
+}
+


### PR DESCRIPTION
### Summary
Fixes #964 by validating contract events size limit in \simulateTransaction\ formatting step (\ormatResponse\).

When contract events generated during simulation exceed \maxContractEventsSizeBytes\ (default 16384 bytes / 16 KiB), \simulateTransaction\ now returns an explicit error stating that the total contract events size limit was exceeded.

### Changes
- Updated \cmd/stellar-rpc/internal/methods/simulate_transaction.go\ to sum \XDR\ string lengths of returned contract events.
- If total size exceeds \maxContractEventsSizeBytes\, returns a descriptive JSON-RPC error.
- Added unit test \TestSimulateTransaction_ContractEventsSizeLimit\ in \simulate_transaction_test.go\.

### Verification
- Added and verified unit tests in \cmd/stellar-rpc/internal/methods\.