### PR TITLE
Merge main into feature/full-history

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,11 +16,11 @@ on:
         required: true
         type: string
       core_deb_version:
-        description: 'Stellar Core debian package version (e.g. 25.2.0-3045.rc2.bb195c49d.jammy). Mutually exclusive with core_git_ref.'
+        description: 'Stellar Core debian package version from the noble repo (e.g. 28.0.1-3508.947aad841.noble). Mutually exclusive with core_git_ref.'
         required: false
         type: string
       core_docker_img:
-        description: 'Full docker image reference for Stellar Core (e.g. stellar/unsafe-stellar-core:25.2.0-3045.rc2.bb195c49d.jammy). Mutually exclusive with core_git_ref.'
+        description: 'Full docker image reference for Stellar Core (e.g. stellar/stellar-core:28.0.1-3508.947aad841.noble). Mutually exclusive with core_git_ref.'
         required: false
         type: string
       core_git_ref:
@@ -32,7 +32,7 @@ jobs:
   integration:
     name: Integration tests
     continue-on-error: true
-    runs-on: ${{ inputs.core_git_ref && 'ubuntu-24.04' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-24.04
     env:
       STELLAR_RPC_INTEGRATION_TESTS_ENABLED: true
       STELLAR_RPC_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ inputs.protocol_version }}
@@ -106,17 +106,12 @@ jobs:
         if: env.CORE_GIT_REF == ''
         shell: bash
         run: |
-          # Workaround for https://github.com/actions/virtual-environments/issues/5245,
-          # libc++1-8 won't be installed if another version is installed (but apt won't give you a helpful
-          # message about why the installation fails)
-          sudo apt-get remove -y libc++1-10 libc++abi1-10 || true
-
           sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
-          sudo bash -c 'echo "deb https://apt.stellar.org jammy unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
+          sudo bash -c 'echo "deb https://apt.stellar.org noble stable" > /etc/apt/sources.list.d/SDF.list'
 
+          # The noble package links libc++ 20, which comes from apt.llvm.org.
           sudo wget -O /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key
-          sudo bash -c 'echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm.list'
-          sudo bash -c 'echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" >> /etc/apt/sources.list.d/llvm.list'
+          sudo bash -c 'echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list'
 
           sudo apt-get update && sudo apt-get install -y stellar-core="$CORE_DEBIAN_PKG_VERSION"
           echo "Using stellar core version $(stellar-core version)"

--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -18,7 +18,7 @@ jobs:
     name: Unit tests
     strategy:
       matrix:
-        os: [ ubuntu-22.04 ]
+        os: [ ubuntu-24.04 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -89,8 +89,8 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '27'
-      core_deb_version: '28.0.1-3508.947aad841.jammy'
-      core_docker_img: 'stellar/stellar-core:28.0.1-3508.947aad841.jammy'
+      core_deb_version: '28.0.1-3508.947aad841.noble'
+      core_docker_img: 'stellar/stellar-core:28.0.1-3508.947aad841.noble'
 
   integration-p28-pkg:
     name: Integration tests (P28)
@@ -101,8 +101,8 @@ jobs:
       # submodule is unchanged from 28.0.0: rs-soroban-env v28.0.0 (ba37ea5f)
       # — the same release soroban-env-host-curr pins from crates.io, keeping
       # simulation cost models identical to apply-time metering.
-      core_deb_version: '28.0.1-3508.947aad841.jammy'
-      core_docker_img: 'stellar/stellar-core:28.0.1-3508.947aad841.jammy'
+      core_deb_version: '28.0.1-3508.947aad841.noble'
+      core_docker_img: 'stellar/stellar-core:28.0.1-3508.947aad841.noble'
 
   # integration-p25-src:
   #   name: Integration tests (p25, core from source)

--- a/cmd/stellar-rpc/docker/Makefile
+++ b/cmd/stellar-rpc/docker/Makefile
@@ -9,7 +9,7 @@ STELLAR_RPC_LATEST_RELEASE := $(shell curl -sS https://api.github.com/repos/stel
 # If deb version was provided via the STELLAR_RPC_VERSION variable use it.
 # If not get latest deb build matching release from GitHub
 ifndef STELLAR_RPC_VERSION
-        STELLAR_RPC_VERSION_PACKAGE_VERSION := $(shell curl -sS https://apt.stellar.org/dists/jammy/unstable/binary-amd64/Packages|grep -A 18 stellar-stellar-rpc|grep Version|grep $(STELLAR_RPC_LATEST_RELEASE)|head -1|cut -d' ' -f2 )
+        STELLAR_RPC_VERSION_PACKAGE_VERSION := $(shell curl -sS https://apt.stellar.org/dists/noble/unstable/binary-amd64/Packages|grep -A 18 "^Package: stellar-rpc$$"|grep Version|grep $(STELLAR_RPC_LATEST_RELEASE)|head -1|cut -d' ' -f2 )
 else
         STELLAR_RPC_VERSION_PACKAGE_VERSION := $(STELLAR_RPC_VERSION)
 endif
@@ -19,7 +19,7 @@ ifndef STELLAR_RPC_VERSION_PACKAGE_VERSION
 endif
 
 ifndef STELLAR_CORE_VERSION
-        $(error STELLAR_CORE_VERSION environment variable must be set. For example 19.10.1-1310.6649f5173.jammy)
+        $(error STELLAR_CORE_VERSION environment variable must be set. For example 28.0.1-3508.947aad841.noble)
 endif
 
 docker-build:

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/docker/docker-compose.yml
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoids implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-stellar/stellar-core:25.0.0-2911.e9748b05a.jammy}
+    image: ${CORE_IMAGE:-stellar/stellar-core:28.0.1-3508.947aad841.noble}
     depends_on:
       - core-postgres
     environment:


### PR DESCRIPTION
## Summary

- Syncs `feature/full-history` with latest `main`.
- Resolves the CI workflow conflict blocking PR #999 (`feature/full-history` → `main`):
  - `.github/workflows/integration-tests.yml`
  - `.github/workflows/stellar-rpc.yml`
  - Conflict cause: main's #980 (jammy → noble) and full-history's #977 (ubuntu-24.04 runners) edited the same lines independently.

## Test plan

- CI on this PR.
- Resolve the two workflow-file conflicts, keeping both the noble and ubuntu-24.04 changes where compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)