### PR TITLE
rpcv2: wait for the hot DB destroys before the lifecycle e2e shuts down

### DIFF
--- a/cmd/stellar-rpc/internal/rpcv2/e2e_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/e2e_test.go
@@ -348,6 +348,23 @@ func TestE2E_DaemonLifecycle_FirstStartIngestFreezeLookupRestartPrune(t *testing
 		return metrics.discardedCount() >= 2
 	}, 60*time.Second, 50*time.Millisecond, "the boundary ticks must freeze+fold+discard chunks 0 and 1")
 
+	// discardedCount rises when the stage DEMOTES a chunk; the destroy that removes
+	// its hot DB and key is deferred to end-of-run (after the grace wait), and a
+	// shutdown mid-grace skips it (the demoted keys would then persist for the
+	// next run). Wait for both hot DB directories to be gone — proof the destroys
+	// ran — BEFORE shutting the daemon down, as the prune step does with the
+	// index file.
+	hotLayout := config.NewLayoutFromPaths(
+		config.Config{Storage: config.StorageConfig{DefaultDataDir: dataDir}}.WithDefaults().ResolvePaths())
+	require.Eventually(t, func() bool {
+		for _, c := range []chunk.ID{c0, c1} {
+			if _, statErr := os.Stat(hotLayout.HotChunkPath(c)); !os.IsNotExist(statErr) {
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second, 50*time.Millisecond, "chunks 0 and 1 hot DBs are destroyed while the daemon runs")
+
 	require.GreaterOrEqual(t, served.Load(), int32(1), "reads were served")
 	require.Equal(t, c0First, core.fromSeen.Load(),
 		"first start resumes the ingestion stream at genesis (last committed ledger + 1)")


### PR DESCRIPTION
`TestE2E_DaemonLifecycle_FirstStartIngestFreezeLookupRestartPrune` fails now and then under `-race` on `e2e_test.go:374`, "chunk 00000001 hot key is discarded". It passed on rerun on #968 and fails about one run in four locally on the base branch with the race detector, so it is a timing race in the test, not a regression.

**The race.** The test waits for the discard counter to reach two and then cancels the daemon. That counter rises when the lifecycle *demotes* a hot chunk. The hot key it then asserts on is removed by the deferred *destroy* at the end of the same tick, after the grace wait, and a cancellation during that wait skips the destroy by design and leaves the demoted key for the next run. The test's cancel lands at a random point up to 50 ms after the counter moved, so when it falls inside the prune scan or the grace wait, the assertion sees the key still there.

**The fix.** Before shutting down, the test also waits for both chunks' hot DB directories to be removed, which is what the destroy does. This is the same proof the test's prune step already uses for its index file. No production code changes.

**Checked.** Six consecutive `-race` runs of the test pass on this branch; on the base branch the same loop fails about one run in four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
